### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,7 @@
     "deepmerge": "^0.2.10",
     "except": "^0.1.3",
     "flickr-api-swagger": "2.3.0",
-    "indexof": "^0.0.1",
     "native-promise-only": "^0.8.1",
-    "superagent": "1.8.3",
-    "url": "^0.11.0"
+    "superagent": "1.8.3"
   }
 }


### PR DESCRIPTION
We're not using `url` or `indexof` anywhere in the codebase. Let's get rid of some deps!