### PR TITLE
Move client secret leaking logic lower

### DIFF
--- a/lib/flickr-transport.js
+++ b/lib/flickr-transport.js
@@ -40,11 +40,6 @@ var FlickrTransport = function (config, options) {
 		config.onProgress = function () { /*noop*/ };
 	}
 
-	/* istanbul ignore next */
-	if (process.browser && config.apiSecret) {
-		throw new Error('Embedding your API secret in the browser could allow a malicious third-party to make API calls using your key.  Making authenticated API calls is disabled in the browser using this SDK at the moment.');
-	}
-
 	this.config = config;
 	this.retries = 3;
 	this.plugins = [];
@@ -222,6 +217,11 @@ FlickrTransport.prototype.oAuth = function (params, auth, isUpload) {
  * @returns {Promise}
  */
 FlickrTransport.prototype.call = function (definition, params, auth, additionalParams, transportConfig) {
+
+	/* istanbul ignore next */
+	if (process.browser && flickrTransport.config && flickrTransport.config.apiSecret) {
+		throw new Error('Embedding your API secret in the browser could allow a malicious third-party to make API calls using your key.  Making authenticated API calls is disabled in the browser using this SDK at the moment.');
+	}
 
 	var flickrTransport = this;
 	var schema = definition.schema;


### PR DESCRIPTION
The transport is used by other things too, but calls are allowed in the client there because it supports oauth2, so this needs to be changed.

Moving it to `call` still gives us that protection, but without interfering with other libs that override our transport (i.e. success-pod).