### PR TITLE
Require api_key for every request

### DIFF
--- a/request.js
+++ b/request.js
@@ -41,15 +41,21 @@ function parseFlickr(res, fn) {
  */
 
 module.exports = function createClient(defaults) {
-
 	if (typeof defaults === 'undefined') {
 		defaults = {};
 	}
 	if (typeof defaults === 'string') {
-		defaults = {api_key: defaults};
+		defaults = { api_key: defaults };
 	}
 
 	return function (method, args) {
+		if (typeof args === 'undefined') {
+			args = {};
+		}
+		if (!defaults.api_key && !args.api_key) {
+			throw new Error('Missing required argument "api_key"');
+		}
+
 		return request('GET', 'https://api.flickr.com/services/rest')
 		.query(defaults)
 		.query('method=' + method)

--- a/script/build.js
+++ b/script/build.js
@@ -65,7 +65,7 @@ function inNamespace(ns) {
  */
 
 function required(arg) {
-	return !parseInt(arg.optional, 10);
+	return !parseInt(arg.optional, 10) && arg.name !== 'api_key';
 }
 
 /**


### PR DESCRIPTION
Previously each method was asserting that the `api_key` arg was passed in. This moves it into the baremetal request module so we can use this pattern as intended:

``` js
var flickr = require('flickr-sdk')('my api key');

flickr.photos.getInfo({ photo_id: '12345' }); // previously, this would throw
```