### PR TITLE
Refactor OAuth timestamp into a method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ node_js:
 - '4.0'
 - '0.12'
 - '0.10'
-before_install:
-- export TZ=America/Los_Angeles
 before_script:
 - npm run build
 - npm run lint

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mocha": "~3.0.2",
     "nock": "~8.0.0",
     "require-dir": "~0.3.1",
-    "timemachine": "~0.2.6"
+    "sinon": "~1.17.6"
   },
   "dependencies": {
     "deepmerge": "^1.1.1",

--- a/services/oauth.js
+++ b/services/oauth.js
@@ -133,15 +133,27 @@ OAuth.prototype.verify = function (oauthToken, oauthVerifier, tokenSecret) {
 OAuth.prototype.parse = request.parse['application/x-www-form-urlencoded'];
 
 /**
+ * Returns the number of seconds since January 1, 1970 00:00:00 GMT.
+ * @returns {Number}
+ * @see https://oauth.net/core/1.0a/#nonce
+ */
+
+OAuth.prototype.timestamp = function () {
+	return Math.floor(Date.now() / 1000);
+};
+
+/**
  * Creates an object with the standard OAuth 1.0 query params
  * for this instance.
  * @returns {Object}
  */
 
 OAuth.prototype.params = function () {
+	var timestamp = this.timestamp();
+
 	return {
-		oauth_nonce: nonce(Date.now()),
-		oauth_timestamp: Math.floor(Date.now() / 1000),
+		oauth_nonce: nonce(timestamp),
+		oauth_timestamp: timestamp,
 		oauth_consumer_key: this.consumerKey,
 		oauth_signature_method: 'HMAC-SHA1',
 		oauth_version: '1.0'

--- a/test/plugins.oauth.js
+++ b/test/plugins.oauth.js
@@ -1,5 +1,5 @@
 var subject = require('../plugins/oauth');
-var request = require('../request');
+var flickr = require('..')();
 var assert = require('assert');
 var time = require('timemachine');
 var nock = require('nock');
@@ -20,25 +20,21 @@ describe('plugins/oauth', function () {
 		var api = nock('https://api.flickr.com')
 		.get('/services/rest')
 		.query({
-			api_key: '653e7a6ecc1d528c516cc8f92cf98611',
-			foo: 'bar',
 			oauth_nonce: '84145a28b1e2bfec42932a97e7cd658093cc0301',
 			oauth_consumer_key: 'consumer key',
 			oauth_token: 'oauth token',
 			oauth_version: '1.0',
 			oauth_timestamp: 499166400,
 			oauth_signature_method: 'HMAC-SHA1',
-			oauth_signature: 'SgZUlgoJYgxc4+LNXD7aBVrKZnc=',
+			oauth_signature: '24FqVjB0tvdn3AQDjfXYQI8WyRI=',
 			method: 'flickr.test.echo',
+			foo: 'bar',
 			format: 'json',
 			nojsoncallback: '1'
 		})
 		.reply(200, {stat: 'ok'});
 
-		return request({
-			api_key: '653e7a6ecc1d528c516cc8f92cf98611',
-			foo: 'bar'
-		})('GET', 'flickr.test.echo')
+		return flickr.test.echo({ foo: 'bar' })
 		.use(subject('consumer key', 'consumer secret', 'oauth token', 'oauth token secret'))
 		.then(function (res) {
 			assert(api.isDone(), 'Expected mock to have been called');

--- a/test/plugins.oauth.js
+++ b/test/plugins.oauth.js
@@ -1,32 +1,33 @@
 var subject = require('../plugins/oauth');
+var OAuth = require('../services/oauth');
 var flickr = require('..')();
 var assert = require('assert');
-var time = require('timemachine');
+var sinon = require('sinon');
 var nock = require('nock');
 
 describe('plugins/oauth', function () {
+	var sandbox;
 
 	beforeEach(function () {
-		time.config({
-			dateString: 'October 26, 1985 01:20:00 PST'
-		});
+		sandbox = sinon.sandbox.create();
+		sandbox.stub(OAuth.prototype, 'timestamp').returns(499166400);
 	});
 
 	afterEach(function () {
-		time.reset();
+		sandbox.restore();
 	});
 
 	it('signs an api call', function () {
 		var api = nock('https://api.flickr.com')
 		.get('/services/rest')
 		.query({
-			oauth_nonce: '84145a28b1e2bfec42932a97e7cd658093cc0301',
+			oauth_nonce: '2114a105bc84fafbd4a05333b0b7f836c5dba8db',
 			oauth_consumer_key: 'consumer key',
 			oauth_token: 'oauth token',
 			oauth_version: '1.0',
 			oauth_timestamp: 499166400,
 			oauth_signature_method: 'HMAC-SHA1',
-			oauth_signature: '24FqVjB0tvdn3AQDjfXYQI8WyRI=',
+			oauth_signature: 'a8DFIqDyb0o1tnB2XeqM85RFz6o=',
 			method: 'flickr.test.echo',
 			foo: 'bar',
 			format: 'json',

--- a/test/services.oauth.js
+++ b/test/services.oauth.js
@@ -1,7 +1,7 @@
 var OAuth = require('../services/oauth');
 var request = require('superagent');
 var assert = require('assert');
-var time = require('timemachine');
+var sinon = require('sinon');
 var nock = require('nock');
 
 describe('services/oauth', function () {
@@ -9,16 +9,7 @@ describe('services/oauth', function () {
 
 	beforeEach(function () {
 		subject = new OAuth('consumer key', 'consumer secret');
-	});
-
-	beforeEach(function () {
-		time.config({
-			dateString: 'October 26, 1985 01:20:00 PST'
-		});
-	});
-
-	afterEach(function () {
-		time.reset();
+		sinon.stub(subject, 'timestamp').returns(499166400);
 	});
 
 	describe('#request', function () {
@@ -27,13 +18,13 @@ describe('services/oauth', function () {
 			var api = nock('https://www.flickr.com')
 			.get('/services/oauth/request_token')
 			.query({
-				oauth_nonce: '84145a28b1e2bfec42932a97e7cd658093cc0301',
+				oauth_nonce: '2114a105bc84fafbd4a05333b0b7f836c5dba8db',
 				oauth_timestamp: 499166400,
 				oauth_consumer_key: subject.consumerKey,
 				oauth_signature_method: 'HMAC-SHA1',
 				oauth_version: '1.0',
 				oauth_callback: 'https://www.example.com/callback',
-				oauth_signature: 'gml5sU1tVCjqEVWufq4a7eHpAZI='
+				oauth_signature: 'n9Lnt7f7j9LrDJ0U6X30SSHSmW4='
 			})
 			.reply(200, 'oauth_callback_confirmed=true&oauth_token=foo&oauth_token_secret=bar');
 
@@ -57,12 +48,12 @@ describe('services/oauth', function () {
 			.query({
 				oauth_token: 'token',
 				oauth_verifier: 'verfier',
-				oauth_nonce: '84145a28b1e2bfec42932a97e7cd658093cc0301',
+				oauth_nonce: '2114a105bc84fafbd4a05333b0b7f836c5dba8db',
 				oauth_timestamp: 499166400,
 				oauth_consumer_key: subject.consumerKey,
 				oauth_signature_method: 'HMAC-SHA1',
 				oauth_version: '1.0',
-				oauth_signature: 'bOpTpeJsYL38EWmISx8BGbgVgSs='
+				oauth_signature: 'kdVh2jMIk5AGoN/63AGQ4kexpSg='
 			})
 			.reply(200, 'fullname=Jamal%20Fanaian&oauth_token=foo&oauth_token_secret=bar&user_nsid=21207597%40N07&username=jamalfanaian');
 
@@ -79,12 +70,24 @@ describe('services/oauth', function () {
 
 	});
 
+	describe('#timestamp', function () {
+
+		beforeEach(function () {
+			sinon.restore(subject.timestamp);
+		});
+
+		it('returns the current system time in seconds', function () {
+			assert.equal(subject.timestamp(), Math.floor(Date.now() / 1000));
+		});
+
+	});
+
 	describe('#params', function () {
 
 		it('returns OAuth 1.0 params', function () {
 			var params = subject.params();
 
-			assert.equal(params.oauth_nonce, '84145a28b1e2bfec42932a97e7cd658093cc0301');
+			assert.equal(params.oauth_nonce, '2114a105bc84fafbd4a05333b0b7f836c5dba8db');
 			assert.equal(params.oauth_timestamp, 499166400);
 			assert.equal(params.oauth_consumer_key, subject.consumerKey);
 			assert.equal(params.oauth_signature_method, 'HMAC-SHA1');


### PR DESCRIPTION
This way, we can stub it out instead of relying on freezing time during tests