### PR TITLE
Make auth mandatory for REST service

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "scripts": {
     "build": "node script/build > services/rest.js",
+    "build-tests": "node script/build-tests",
     "lint": "eslint .",
     "test": "istanbul cover _mocha"
   },

--- a/plugins/api-key.js
+++ b/plugins/api-key.js
@@ -1,0 +1,24 @@
+/**
+ * Creates a superagent plugin that adds your Flickr API key
+ * to a request. You may pass your API key as a string, or
+ * in an object with an "api_key" field.
+ * @param {(String|Object)} params
+ * @returns {Function}
+ * @see https://github.com/visionmedia/superagent
+ */
+
+module.exports = function (params) {
+	if (typeof params === 'undefined') {
+		params = {};
+	} else if (typeof params === 'string') {
+		params = { api_key: params };
+	}
+	if (typeof params.api_key !== 'string') {
+		throw new Error('Missing required argument "api_key"');
+	}
+
+	return function (req) {
+		req.query(params);
+	};
+
+};

--- a/request.js
+++ b/request.js
@@ -4,20 +4,16 @@ var json = require('./plugins/json');
 /**
  * Creates a new Flickr API client. This "client" is a factory
  * method that creates a new superagent request pre-configured
- * for talking to the Flickr API. You must pass your `api_key`
- * either as a string or as a field on a hash of default query
- * string params.
- * @param {(String|Object)} defaults
+ * for talking to the Flickr API. You must pass an "auth"
+ * supergent plugin.
+ * @param {Function} auth
  * @returns {Function}
  * @see https://github.com/visionmedia/superagent
  */
 
-module.exports = function createClient(defaults) {
-	if (typeof defaults === 'undefined') {
-		defaults = {};
-	}
-	if (typeof defaults === 'string') {
-		defaults = { api_key: defaults };
+module.exports = function createClient(auth) {
+	if (typeof auth !== 'function') {
+		throw new Error('Missing auth superagent plugin');
 	}
 
 	return function (verb, method, args) {
@@ -27,9 +23,9 @@ module.exports = function createClient(defaults) {
 
 		return request(verb, 'https://api.flickr.com/services/rest')
 		.query('method=' + method)
+		.query(args)
 		.use(json)
-		.query(defaults)
-		.query(args);
+		.use(auth);
 	};
 
 };

--- a/script/rest.ejs
+++ b/script/rest.ejs
@@ -3,20 +3,21 @@ var validate = require('../validate');
 
 /**
  * @constructor
+ * @param {Function} auth
  */
 
-function Flickr(defaults) {
+function Flickr(auth) {
 
 	// allow creating a client without `new`
 	if (!(this instanceof Flickr)) {
-		return new Flickr(defaults);
+		return new Flickr(auth);
 	}
 
 	// create a new client and assign it to all of our namespaces
 	<%_ namespaces.forEach(function (ns) { _%>
 	this.<%= ns %>._ =
 	<%_ }); _%>
-	createClient(defaults);
+	createClient(auth);
 }
 
 <% namespaces.forEach(function (ns) { %>

--- a/script/test.ejs
+++ b/script/test.ejs
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('<%= method %>', function () {

--- a/test/flickr.activity.userComments.js
+++ b/test/flickr.activity.userComments.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.activity.userComments', function () {

--- a/test/flickr.activity.userPhotos.js
+++ b/test/flickr.activity.userPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.activity.userPhotos', function () {

--- a/test/flickr.auth.checkToken.js
+++ b/test/flickr.auth.checkToken.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.auth.checkToken', function () {

--- a/test/flickr.auth.getFrob.js
+++ b/test/flickr.auth.getFrob.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.auth.getFrob', function () {

--- a/test/flickr.auth.getFullToken.js
+++ b/test/flickr.auth.getFullToken.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.auth.getFullToken', function () {

--- a/test/flickr.auth.getToken.js
+++ b/test/flickr.auth.getToken.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.auth.getToken', function () {

--- a/test/flickr.auth.oauth.checkToken.js
+++ b/test/flickr.auth.oauth.checkToken.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.auth.oauth.checkToken', function () {

--- a/test/flickr.auth.oauth.getAccessToken.js
+++ b/test/flickr.auth.oauth.getAccessToken.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.auth.oauth.getAccessToken', function () {

--- a/test/flickr.blogs.getList.js
+++ b/test/flickr.blogs.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.blogs.getList', function () {

--- a/test/flickr.blogs.getServices.js
+++ b/test/flickr.blogs.getServices.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.blogs.getServices', function () {

--- a/test/flickr.blogs.postPhoto.js
+++ b/test/flickr.blogs.postPhoto.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.blogs.postPhoto', function () {

--- a/test/flickr.cameras.getBrandModels.js
+++ b/test/flickr.cameras.getBrandModels.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.cameras.getBrandModels', function () {

--- a/test/flickr.cameras.getBrands.js
+++ b/test/flickr.cameras.getBrands.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.cameras.getBrands', function () {

--- a/test/flickr.collections.getInfo.js
+++ b/test/flickr.collections.getInfo.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.collections.getInfo', function () {

--- a/test/flickr.collections.getTree.js
+++ b/test/flickr.collections.getTree.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.collections.getTree', function () {

--- a/test/flickr.commons.getInstitutions.js
+++ b/test/flickr.commons.getInstitutions.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.commons.getInstitutions', function () {

--- a/test/flickr.contacts.getList.js
+++ b/test/flickr.contacts.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.contacts.getList', function () {

--- a/test/flickr.contacts.getListRecentlyUploaded.js
+++ b/test/flickr.contacts.getListRecentlyUploaded.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.contacts.getListRecentlyUploaded', function () {

--- a/test/flickr.contacts.getPublicList.js
+++ b/test/flickr.contacts.getPublicList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.contacts.getPublicList', function () {

--- a/test/flickr.contacts.getTaggingSuggestions.js
+++ b/test/flickr.contacts.getTaggingSuggestions.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.contacts.getTaggingSuggestions', function () {

--- a/test/flickr.favorites.add.js
+++ b/test/flickr.favorites.add.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.favorites.add', function () {

--- a/test/flickr.favorites.getContext.js
+++ b/test/flickr.favorites.getContext.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.favorites.getContext', function () {

--- a/test/flickr.favorites.getList.js
+++ b/test/flickr.favorites.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.favorites.getList', function () {

--- a/test/flickr.favorites.getPublicList.js
+++ b/test/flickr.favorites.getPublicList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.favorites.getPublicList', function () {

--- a/test/flickr.favorites.remove.js
+++ b/test/flickr.favorites.remove.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.favorites.remove', function () {

--- a/test/flickr.galleries.addPhoto.js
+++ b/test/flickr.galleries.addPhoto.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.galleries.addPhoto', function () {

--- a/test/flickr.galleries.create.js
+++ b/test/flickr.galleries.create.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.galleries.create', function () {

--- a/test/flickr.galleries.editMeta.js
+++ b/test/flickr.galleries.editMeta.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.galleries.editMeta', function () {

--- a/test/flickr.galleries.editPhoto.js
+++ b/test/flickr.galleries.editPhoto.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.galleries.editPhoto', function () {

--- a/test/flickr.galleries.editPhotos.js
+++ b/test/flickr.galleries.editPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.galleries.editPhotos', function () {

--- a/test/flickr.galleries.getInfo.js
+++ b/test/flickr.galleries.getInfo.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.galleries.getInfo', function () {

--- a/test/flickr.galleries.getList.js
+++ b/test/flickr.galleries.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.galleries.getList', function () {

--- a/test/flickr.galleries.getListForPhoto.js
+++ b/test/flickr.galleries.getListForPhoto.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.galleries.getListForPhoto', function () {

--- a/test/flickr.galleries.getPhotos.js
+++ b/test/flickr.galleries.getPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.galleries.getPhotos', function () {

--- a/test/flickr.groups.browse.js
+++ b/test/flickr.groups.browse.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.browse', function () {

--- a/test/flickr.groups.discuss.replies.add.js
+++ b/test/flickr.groups.discuss.replies.add.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.discuss.replies.add', function () {

--- a/test/flickr.groups.discuss.replies.delete.js
+++ b/test/flickr.groups.discuss.replies.delete.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.discuss.replies.delete', function () {

--- a/test/flickr.groups.discuss.replies.edit.js
+++ b/test/flickr.groups.discuss.replies.edit.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.discuss.replies.edit', function () {

--- a/test/flickr.groups.discuss.replies.getInfo.js
+++ b/test/flickr.groups.discuss.replies.getInfo.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.discuss.replies.getInfo', function () {

--- a/test/flickr.groups.discuss.replies.getList.js
+++ b/test/flickr.groups.discuss.replies.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.discuss.replies.getList', function () {

--- a/test/flickr.groups.discuss.topics.add.js
+++ b/test/flickr.groups.discuss.topics.add.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.discuss.topics.add', function () {

--- a/test/flickr.groups.discuss.topics.getInfo.js
+++ b/test/flickr.groups.discuss.topics.getInfo.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.discuss.topics.getInfo', function () {

--- a/test/flickr.groups.discuss.topics.getList.js
+++ b/test/flickr.groups.discuss.topics.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.discuss.topics.getList', function () {

--- a/test/flickr.groups.getInfo.js
+++ b/test/flickr.groups.getInfo.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.getInfo', function () {

--- a/test/flickr.groups.join.js
+++ b/test/flickr.groups.join.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.join', function () {

--- a/test/flickr.groups.joinRequest.js
+++ b/test/flickr.groups.joinRequest.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.joinRequest', function () {

--- a/test/flickr.groups.leave.js
+++ b/test/flickr.groups.leave.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.leave', function () {

--- a/test/flickr.groups.members.getList.js
+++ b/test/flickr.groups.members.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.members.getList', function () {

--- a/test/flickr.groups.pools.add.js
+++ b/test/flickr.groups.pools.add.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.pools.add', function () {

--- a/test/flickr.groups.pools.getContext.js
+++ b/test/flickr.groups.pools.getContext.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.pools.getContext', function () {

--- a/test/flickr.groups.pools.getGroups.js
+++ b/test/flickr.groups.pools.getGroups.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.pools.getGroups', function () {

--- a/test/flickr.groups.pools.getPhotos.js
+++ b/test/flickr.groups.pools.getPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.pools.getPhotos', function () {

--- a/test/flickr.groups.pools.remove.js
+++ b/test/flickr.groups.pools.remove.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.pools.remove', function () {

--- a/test/flickr.groups.search.js
+++ b/test/flickr.groups.search.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.groups.search', function () {

--- a/test/flickr.interestingness.getList.js
+++ b/test/flickr.interestingness.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.interestingness.getList', function () {

--- a/test/flickr.machinetags.getNamespaces.js
+++ b/test/flickr.machinetags.getNamespaces.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.machinetags.getNamespaces', function () {

--- a/test/flickr.machinetags.getPairs.js
+++ b/test/flickr.machinetags.getPairs.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.machinetags.getPairs', function () {

--- a/test/flickr.machinetags.getPredicates.js
+++ b/test/flickr.machinetags.getPredicates.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.machinetags.getPredicates', function () {

--- a/test/flickr.machinetags.getRecentValues.js
+++ b/test/flickr.machinetags.getRecentValues.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.machinetags.getRecentValues', function () {

--- a/test/flickr.machinetags.getValues.js
+++ b/test/flickr.machinetags.getValues.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.machinetags.getValues', function () {

--- a/test/flickr.panda.getList.js
+++ b/test/flickr.panda.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.panda.getList', function () {

--- a/test/flickr.panda.getPhotos.js
+++ b/test/flickr.panda.getPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.panda.getPhotos', function () {

--- a/test/flickr.people.findByEmail.js
+++ b/test/flickr.people.findByEmail.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.people.findByEmail', function () {

--- a/test/flickr.people.findByUsername.js
+++ b/test/flickr.people.findByUsername.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.people.findByUsername', function () {

--- a/test/flickr.people.getGroups.js
+++ b/test/flickr.people.getGroups.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.people.getGroups', function () {

--- a/test/flickr.people.getInfo.js
+++ b/test/flickr.people.getInfo.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.people.getInfo', function () {

--- a/test/flickr.people.getLimits.js
+++ b/test/flickr.people.getLimits.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.people.getLimits', function () {

--- a/test/flickr.people.getPhotos.js
+++ b/test/flickr.people.getPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.people.getPhotos', function () {

--- a/test/flickr.people.getPhotosOf.js
+++ b/test/flickr.people.getPhotosOf.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.people.getPhotosOf', function () {

--- a/test/flickr.people.getPublicGroups.js
+++ b/test/flickr.people.getPublicGroups.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.people.getPublicGroups', function () {

--- a/test/flickr.people.getPublicPhotos.js
+++ b/test/flickr.people.getPublicPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.people.getPublicPhotos', function () {

--- a/test/flickr.people.getUploadStatus.js
+++ b/test/flickr.people.getUploadStatus.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.people.getUploadStatus', function () {

--- a/test/flickr.photos.addTags.js
+++ b/test/flickr.photos.addTags.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.addTags', function () {

--- a/test/flickr.photos.comments.addComment.js
+++ b/test/flickr.photos.comments.addComment.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.comments.addComment', function () {

--- a/test/flickr.photos.comments.deleteComment.js
+++ b/test/flickr.photos.comments.deleteComment.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.comments.deleteComment', function () {

--- a/test/flickr.photos.comments.editComment.js
+++ b/test/flickr.photos.comments.editComment.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.comments.editComment', function () {

--- a/test/flickr.photos.comments.getList.js
+++ b/test/flickr.photos.comments.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.comments.getList', function () {

--- a/test/flickr.photos.comments.getRecentForContacts.js
+++ b/test/flickr.photos.comments.getRecentForContacts.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.comments.getRecentForContacts', function () {

--- a/test/flickr.photos.delete.js
+++ b/test/flickr.photos.delete.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.delete', function () {

--- a/test/flickr.photos.geo.batchCorrectLocation.js
+++ b/test/flickr.photos.geo.batchCorrectLocation.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.geo.batchCorrectLocation', function () {

--- a/test/flickr.photos.geo.correctLocation.js
+++ b/test/flickr.photos.geo.correctLocation.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.geo.correctLocation', function () {

--- a/test/flickr.photos.geo.getLocation.js
+++ b/test/flickr.photos.geo.getLocation.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.geo.getLocation', function () {

--- a/test/flickr.photos.geo.getPerms.js
+++ b/test/flickr.photos.geo.getPerms.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.geo.getPerms', function () {

--- a/test/flickr.photos.geo.photosForLocation.js
+++ b/test/flickr.photos.geo.photosForLocation.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.geo.photosForLocation', function () {

--- a/test/flickr.photos.geo.removeLocation.js
+++ b/test/flickr.photos.geo.removeLocation.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.geo.removeLocation', function () {

--- a/test/flickr.photos.geo.setContext.js
+++ b/test/flickr.photos.geo.setContext.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.geo.setContext', function () {

--- a/test/flickr.photos.geo.setLocation.js
+++ b/test/flickr.photos.geo.setLocation.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.geo.setLocation', function () {

--- a/test/flickr.photos.geo.setPerms.js
+++ b/test/flickr.photos.geo.setPerms.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.geo.setPerms', function () {

--- a/test/flickr.photos.getAllContexts.js
+++ b/test/flickr.photos.getAllContexts.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getAllContexts', function () {

--- a/test/flickr.photos.getContactsPhotos.js
+++ b/test/flickr.photos.getContactsPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getContactsPhotos', function () {

--- a/test/flickr.photos.getContactsPublicPhotos.js
+++ b/test/flickr.photos.getContactsPublicPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getContactsPublicPhotos', function () {

--- a/test/flickr.photos.getContext.js
+++ b/test/flickr.photos.getContext.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getContext', function () {

--- a/test/flickr.photos.getCounts.js
+++ b/test/flickr.photos.getCounts.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getCounts', function () {

--- a/test/flickr.photos.getExif.js
+++ b/test/flickr.photos.getExif.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getExif', function () {

--- a/test/flickr.photos.getFavorites.js
+++ b/test/flickr.photos.getFavorites.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getFavorites', function () {

--- a/test/flickr.photos.getInfo.js
+++ b/test/flickr.photos.getInfo.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getInfo', function () {

--- a/test/flickr.photos.getNotInSet.js
+++ b/test/flickr.photos.getNotInSet.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getNotInSet', function () {

--- a/test/flickr.photos.getPerms.js
+++ b/test/flickr.photos.getPerms.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getPerms', function () {

--- a/test/flickr.photos.getRecent.js
+++ b/test/flickr.photos.getRecent.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getRecent', function () {

--- a/test/flickr.photos.getSizes.js
+++ b/test/flickr.photos.getSizes.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getSizes', function () {

--- a/test/flickr.photos.getUntagged.js
+++ b/test/flickr.photos.getUntagged.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getUntagged', function () {

--- a/test/flickr.photos.getWithGeoData.js
+++ b/test/flickr.photos.getWithGeoData.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getWithGeoData', function () {

--- a/test/flickr.photos.getWithoutGeoData.js
+++ b/test/flickr.photos.getWithoutGeoData.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.getWithoutGeoData', function () {

--- a/test/flickr.photos.licenses.getInfo.js
+++ b/test/flickr.photos.licenses.getInfo.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.licenses.getInfo', function () {

--- a/test/flickr.photos.licenses.setLicense.js
+++ b/test/flickr.photos.licenses.setLicense.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.licenses.setLicense', function () {

--- a/test/flickr.photos.notes.add.js
+++ b/test/flickr.photos.notes.add.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.notes.add', function () {

--- a/test/flickr.photos.notes.delete.js
+++ b/test/flickr.photos.notes.delete.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.notes.delete', function () {

--- a/test/flickr.photos.notes.edit.js
+++ b/test/flickr.photos.notes.edit.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.notes.edit', function () {

--- a/test/flickr.photos.people.add.js
+++ b/test/flickr.photos.people.add.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.people.add', function () {

--- a/test/flickr.photos.people.delete.js
+++ b/test/flickr.photos.people.delete.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.people.delete', function () {

--- a/test/flickr.photos.people.deleteCoords.js
+++ b/test/flickr.photos.people.deleteCoords.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.people.deleteCoords', function () {

--- a/test/flickr.photos.people.editCoords.js
+++ b/test/flickr.photos.people.editCoords.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.people.editCoords', function () {

--- a/test/flickr.photos.people.getList.js
+++ b/test/flickr.photos.people.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.people.getList', function () {

--- a/test/flickr.photos.recentlyUpdated.js
+++ b/test/flickr.photos.recentlyUpdated.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.recentlyUpdated', function () {

--- a/test/flickr.photos.removeTag.js
+++ b/test/flickr.photos.removeTag.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.removeTag', function () {

--- a/test/flickr.photos.search.js
+++ b/test/flickr.photos.search.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.search', function () {

--- a/test/flickr.photos.setContentType.js
+++ b/test/flickr.photos.setContentType.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.setContentType', function () {

--- a/test/flickr.photos.setDates.js
+++ b/test/flickr.photos.setDates.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.setDates', function () {

--- a/test/flickr.photos.setMeta.js
+++ b/test/flickr.photos.setMeta.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.setMeta', function () {

--- a/test/flickr.photos.setPerms.js
+++ b/test/flickr.photos.setPerms.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.setPerms', function () {

--- a/test/flickr.photos.setSafetyLevel.js
+++ b/test/flickr.photos.setSafetyLevel.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.setSafetyLevel', function () {

--- a/test/flickr.photos.setTags.js
+++ b/test/flickr.photos.setTags.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.setTags', function () {

--- a/test/flickr.photos.suggestions.approveSuggestion.js
+++ b/test/flickr.photos.suggestions.approveSuggestion.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.suggestions.approveSuggestion', function () {

--- a/test/flickr.photos.suggestions.getList.js
+++ b/test/flickr.photos.suggestions.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.suggestions.getList', function () {

--- a/test/flickr.photos.suggestions.rejectSuggestion.js
+++ b/test/flickr.photos.suggestions.rejectSuggestion.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.suggestions.rejectSuggestion', function () {

--- a/test/flickr.photos.suggestions.removeSuggestion.js
+++ b/test/flickr.photos.suggestions.removeSuggestion.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.suggestions.removeSuggestion', function () {

--- a/test/flickr.photos.suggestions.suggestLocation.js
+++ b/test/flickr.photos.suggestions.suggestLocation.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.suggestions.suggestLocation', function () {

--- a/test/flickr.photos.transform.rotate.js
+++ b/test/flickr.photos.transform.rotate.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.transform.rotate', function () {

--- a/test/flickr.photos.upload.checkTickets.js
+++ b/test/flickr.photos.upload.checkTickets.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photos.upload.checkTickets', function () {

--- a/test/flickr.photosets.addPhoto.js
+++ b/test/flickr.photosets.addPhoto.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.addPhoto', function () {

--- a/test/flickr.photosets.comments.addComment.js
+++ b/test/flickr.photosets.comments.addComment.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.comments.addComment', function () {

--- a/test/flickr.photosets.comments.deleteComment.js
+++ b/test/flickr.photosets.comments.deleteComment.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.comments.deleteComment', function () {

--- a/test/flickr.photosets.comments.editComment.js
+++ b/test/flickr.photosets.comments.editComment.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.comments.editComment', function () {

--- a/test/flickr.photosets.comments.getList.js
+++ b/test/flickr.photosets.comments.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.comments.getList', function () {

--- a/test/flickr.photosets.create.js
+++ b/test/flickr.photosets.create.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.create', function () {

--- a/test/flickr.photosets.delete.js
+++ b/test/flickr.photosets.delete.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.delete', function () {

--- a/test/flickr.photosets.editMeta.js
+++ b/test/flickr.photosets.editMeta.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.editMeta', function () {

--- a/test/flickr.photosets.editPhotos.js
+++ b/test/flickr.photosets.editPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.editPhotos', function () {

--- a/test/flickr.photosets.getContext.js
+++ b/test/flickr.photosets.getContext.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.getContext', function () {

--- a/test/flickr.photosets.getInfo.js
+++ b/test/flickr.photosets.getInfo.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.getInfo', function () {

--- a/test/flickr.photosets.getList.js
+++ b/test/flickr.photosets.getList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.getList', function () {

--- a/test/flickr.photosets.getPhotos.js
+++ b/test/flickr.photosets.getPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.getPhotos', function () {

--- a/test/flickr.photosets.orderSets.js
+++ b/test/flickr.photosets.orderSets.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.orderSets', function () {

--- a/test/flickr.photosets.removePhoto.js
+++ b/test/flickr.photosets.removePhoto.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.removePhoto', function () {

--- a/test/flickr.photosets.removePhotos.js
+++ b/test/flickr.photosets.removePhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.removePhotos', function () {

--- a/test/flickr.photosets.reorderPhotos.js
+++ b/test/flickr.photosets.reorderPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.reorderPhotos', function () {

--- a/test/flickr.photosets.setPrimaryPhoto.js
+++ b/test/flickr.photosets.setPrimaryPhoto.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.photosets.setPrimaryPhoto', function () {

--- a/test/flickr.places.find.js
+++ b/test/flickr.places.find.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.find', function () {

--- a/test/flickr.places.findByLatLon.js
+++ b/test/flickr.places.findByLatLon.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.findByLatLon', function () {

--- a/test/flickr.places.getChildrenWithPhotosPublic.js
+++ b/test/flickr.places.getChildrenWithPhotosPublic.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.getChildrenWithPhotosPublic', function () {

--- a/test/flickr.places.getInfo.js
+++ b/test/flickr.places.getInfo.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.getInfo', function () {

--- a/test/flickr.places.getInfoByUrl.js
+++ b/test/flickr.places.getInfoByUrl.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.getInfoByUrl', function () {

--- a/test/flickr.places.getPlaceTypes.js
+++ b/test/flickr.places.getPlaceTypes.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.getPlaceTypes', function () {

--- a/test/flickr.places.getShapeHistory.js
+++ b/test/flickr.places.getShapeHistory.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.getShapeHistory', function () {

--- a/test/flickr.places.getTopPlacesList.js
+++ b/test/flickr.places.getTopPlacesList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.getTopPlacesList', function () {

--- a/test/flickr.places.placesForBoundingBox.js
+++ b/test/flickr.places.placesForBoundingBox.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.placesForBoundingBox', function () {

--- a/test/flickr.places.placesForContacts.js
+++ b/test/flickr.places.placesForContacts.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.placesForContacts', function () {

--- a/test/flickr.places.placesForTags.js
+++ b/test/flickr.places.placesForTags.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.placesForTags', function () {

--- a/test/flickr.places.placesForUser.js
+++ b/test/flickr.places.placesForUser.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.placesForUser', function () {

--- a/test/flickr.places.resolvePlaceId.js
+++ b/test/flickr.places.resolvePlaceId.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.resolvePlaceId', function () {

--- a/test/flickr.places.resolvePlaceURL.js
+++ b/test/flickr.places.resolvePlaceURL.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.resolvePlaceURL', function () {

--- a/test/flickr.places.tagsForPlace.js
+++ b/test/flickr.places.tagsForPlace.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.places.tagsForPlace', function () {

--- a/test/flickr.prefs.getContentType.js
+++ b/test/flickr.prefs.getContentType.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.prefs.getContentType', function () {

--- a/test/flickr.prefs.getGeoPerms.js
+++ b/test/flickr.prefs.getGeoPerms.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.prefs.getGeoPerms', function () {

--- a/test/flickr.prefs.getHidden.js
+++ b/test/flickr.prefs.getHidden.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.prefs.getHidden', function () {

--- a/test/flickr.prefs.getPrivacy.js
+++ b/test/flickr.prefs.getPrivacy.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.prefs.getPrivacy', function () {

--- a/test/flickr.prefs.getSafetyLevel.js
+++ b/test/flickr.prefs.getSafetyLevel.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.prefs.getSafetyLevel', function () {

--- a/test/flickr.push.getSubscriptions.js
+++ b/test/flickr.push.getSubscriptions.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.push.getSubscriptions', function () {

--- a/test/flickr.push.getTopics.js
+++ b/test/flickr.push.getTopics.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.push.getTopics', function () {

--- a/test/flickr.push.subscribe.js
+++ b/test/flickr.push.subscribe.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.push.subscribe', function () {

--- a/test/flickr.push.unsubscribe.js
+++ b/test/flickr.push.unsubscribe.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.push.unsubscribe', function () {

--- a/test/flickr.reflection.getMethodInfo.js
+++ b/test/flickr.reflection.getMethodInfo.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.reflection.getMethodInfo', function () {

--- a/test/flickr.reflection.getMethods.js
+++ b/test/flickr.reflection.getMethods.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.reflection.getMethods', function () {

--- a/test/flickr.stats.getCSVFiles.js
+++ b/test/flickr.stats.getCSVFiles.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getCSVFiles', function () {

--- a/test/flickr.stats.getCollectionDomains.js
+++ b/test/flickr.stats.getCollectionDomains.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getCollectionDomains', function () {

--- a/test/flickr.stats.getCollectionReferrers.js
+++ b/test/flickr.stats.getCollectionReferrers.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getCollectionReferrers', function () {

--- a/test/flickr.stats.getCollectionStats.js
+++ b/test/flickr.stats.getCollectionStats.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getCollectionStats', function () {

--- a/test/flickr.stats.getPhotoDomains.js
+++ b/test/flickr.stats.getPhotoDomains.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getPhotoDomains', function () {

--- a/test/flickr.stats.getPhotoReferrers.js
+++ b/test/flickr.stats.getPhotoReferrers.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getPhotoReferrers', function () {

--- a/test/flickr.stats.getPhotoStats.js
+++ b/test/flickr.stats.getPhotoStats.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getPhotoStats', function () {

--- a/test/flickr.stats.getPhotosetDomains.js
+++ b/test/flickr.stats.getPhotosetDomains.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getPhotosetDomains', function () {

--- a/test/flickr.stats.getPhotosetReferrers.js
+++ b/test/flickr.stats.getPhotosetReferrers.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getPhotosetReferrers', function () {

--- a/test/flickr.stats.getPhotosetStats.js
+++ b/test/flickr.stats.getPhotosetStats.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getPhotosetStats', function () {

--- a/test/flickr.stats.getPhotostreamDomains.js
+++ b/test/flickr.stats.getPhotostreamDomains.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getPhotostreamDomains', function () {

--- a/test/flickr.stats.getPhotostreamReferrers.js
+++ b/test/flickr.stats.getPhotostreamReferrers.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getPhotostreamReferrers', function () {

--- a/test/flickr.stats.getPhotostreamStats.js
+++ b/test/flickr.stats.getPhotostreamStats.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getPhotostreamStats', function () {

--- a/test/flickr.stats.getPopularPhotos.js
+++ b/test/flickr.stats.getPopularPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getPopularPhotos', function () {

--- a/test/flickr.stats.getTotalViews.js
+++ b/test/flickr.stats.getTotalViews.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.stats.getTotalViews', function () {

--- a/test/flickr.tags.getClusterPhotos.js
+++ b/test/flickr.tags.getClusterPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.tags.getClusterPhotos', function () {

--- a/test/flickr.tags.getClusters.js
+++ b/test/flickr.tags.getClusters.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.tags.getClusters', function () {

--- a/test/flickr.tags.getHotList.js
+++ b/test/flickr.tags.getHotList.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.tags.getHotList', function () {

--- a/test/flickr.tags.getListPhoto.js
+++ b/test/flickr.tags.getListPhoto.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.tags.getListPhoto', function () {

--- a/test/flickr.tags.getListUser.js
+++ b/test/flickr.tags.getListUser.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.tags.getListUser', function () {

--- a/test/flickr.tags.getListUserPopular.js
+++ b/test/flickr.tags.getListUserPopular.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.tags.getListUserPopular', function () {

--- a/test/flickr.tags.getListUserRaw.js
+++ b/test/flickr.tags.getListUserRaw.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.tags.getListUserRaw', function () {

--- a/test/flickr.tags.getMostFrequentlyUsed.js
+++ b/test/flickr.tags.getMostFrequentlyUsed.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.tags.getMostFrequentlyUsed', function () {

--- a/test/flickr.tags.getRelated.js
+++ b/test/flickr.tags.getRelated.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.tags.getRelated', function () {

--- a/test/flickr.test.echo.js
+++ b/test/flickr.test.echo.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.test.echo', function () {

--- a/test/flickr.test.login.js
+++ b/test/flickr.test.login.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.test.login', function () {

--- a/test/flickr.test.null.js
+++ b/test/flickr.test.null.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.test.null', function () {

--- a/test/flickr.urls.getGroup.js
+++ b/test/flickr.urls.getGroup.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.urls.getGroup', function () {

--- a/test/flickr.urls.getUserPhotos.js
+++ b/test/flickr.urls.getUserPhotos.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.urls.getUserPhotos', function () {

--- a/test/flickr.urls.getUserProfile.js
+++ b/test/flickr.urls.getUserProfile.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.urls.getUserProfile', function () {

--- a/test/flickr.urls.lookupGallery.js
+++ b/test/flickr.urls.lookupGallery.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.urls.lookupGallery', function () {

--- a/test/flickr.urls.lookupGroup.js
+++ b/test/flickr.urls.lookupGroup.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.urls.lookupGroup', function () {

--- a/test/flickr.urls.lookupUser.js
+++ b/test/flickr.urls.lookupUser.js
@@ -1,4 +1,4 @@
-var flickr = require('..')();
+var flickr = require('..')(function auth() { /* noop */ });
 var assert = require('assert');
 
 describe('flickr.urls.lookupUser', function () {

--- a/test/plugins.api-key.js
+++ b/test/plugins.api-key.js
@@ -1,5 +1,5 @@
 var subject = require('../plugins/api-key');
-var request = require('superagent');
+var Flickr = require('..');
 var assert = require('assert');
 var nock = require('nock');
 
@@ -25,14 +25,19 @@ describe('plugins/api-key', function () {
 		var api = nock('https://api.flickr.com')
 		.get('/services/rest')
 		.query({
-			api_key: 'api key'
+			api_key: 'api key',
+			method: 'flickr.test.echo',
+			foo: 'bar',
+			format: 'json',
+			nojsoncallback: '1'
 		})
 		.reply(200, {
 			stat: 'ok'
 		});
 
-		return request('GET', 'https://api.flickr.com/services/rest')
-		.use(subject('api key'))
+		var flickr = new Flickr(subject('api key'));
+
+		return flickr.test.echo({ foo: 'bar' })
 		.then(function (res) {
 			assert(api.isDone(), 'Expected mock to have been called');
 			assert.equal(res.statusCode, 200);

--- a/test/plugins.api-key.js
+++ b/test/plugins.api-key.js
@@ -1,0 +1,44 @@
+var subject = require('../plugins/api-key');
+var request = require('superagent');
+var assert = require('assert');
+var nock = require('nock');
+
+describe('plugins/api-key', function () {
+
+	it('throws if required parameters are not provided', function () {
+
+		assert.throws(function () {
+			subject();
+		}, function (err) {
+			return err.message === 'Missing required argument "api_key"';
+		});
+
+		assert.throws(function () {
+			subject({});
+		}, function (err) {
+			return err.message === 'Missing required argument "api_key"';
+		});
+
+	});
+
+	it('signs an api call', function () {
+		var api = nock('https://api.flickr.com')
+		.get('/services/rest')
+		.query({
+			api_key: 'api key'
+		})
+		.reply(200, {
+			stat: 'ok'
+		});
+
+		return request('GET', 'https://api.flickr.com/services/rest')
+		.use(subject('api key'))
+		.then(function (res) {
+			assert(api.isDone(), 'Expected mock to have been called');
+			assert.equal(res.statusCode, 200);
+			assert.equal(res.body.stat, 'ok');
+		});
+
+	});
+
+});

--- a/test/plugins.oauth.js
+++ b/test/plugins.oauth.js
@@ -1,6 +1,6 @@
 var subject = require('../plugins/oauth');
 var OAuth = require('../services/oauth');
-var flickr = require('..')();
+var Flickr = require('..');
 var assert = require('assert');
 var sinon = require('sinon');
 var nock = require('nock');
@@ -36,8 +36,9 @@ describe('plugins/oauth', function () {
 		})
 		.reply(200, {stat: 'ok'});
 
+		var flickr = new Flickr(subject('consumer key', 'consumer secret', 'oauth token', 'oauth token secret'));
+
 		return flickr.test.echo({ foo: 'bar' })
-		.use(subject('consumer key', 'consumer secret', 'oauth token', 'oauth token secret'))
 		.then(function (res) {
 			assert(api.isDone(), 'Expected mock to have been called');
 			assert.equal(res.statusCode, 200);

--- a/test/request.js
+++ b/test/request.js
@@ -1,4 +1,4 @@
-var subject = require('../request');
+var subject = require('../request')(function auth() { /* noop */ });
 var assert = require('assert');
 var nock = require('nock');
 
@@ -8,14 +8,13 @@ describe('request', function () {
 		var api = nock('https://api.flickr.com')
 		.get('/services/rest')
 		.query({
-			api_key: 'abcd1234',
 			method: 'flickr.test.echo',
 			format: 'json',
 			nojsoncallback: 1
 		})
 		.reply(200, {stat: 'ok'});
 
-		return subject('abcd1234')('GET', 'flickr.test.echo').then(function (res) {
+		return subject('GET', 'flickr.test.echo').then(function (res) {
 			assert(api.isDone(), 'Expected mock to have been called');
 			assert.equal(res.statusCode, 200);
 			assert.equal(res.body.stat, 'ok');
@@ -23,11 +22,10 @@ describe('request', function () {
 
 	});
 
-	it('accepts default params as an object', function () {
+	it('adds additional query string arguments', function () {
 		var api = nock('https://api.flickr.com')
 		.get('/services/rest')
 		.query({
-			api_key: 'abcd1234',
 			method: 'flickr.test.echo',
 			format: 'json',
 			nojsoncallback: 1,
@@ -35,7 +33,7 @@ describe('request', function () {
 		})
 		.reply(200, {stat: 'ok'});
 
-		return subject({api_key: 'abcd1234', foo: 'bar'})('GET', 'flickr.test.echo').then(function (res) {
+		return subject('GET', 'flickr.test.echo', {foo: 'bar'}).then(function (res) {
 			assert(api.isDone(), 'Expected mock to have been called');
 			assert.equal(res.statusCode, 200);
 			assert.equal(res.body.stat, 'ok');
@@ -47,7 +45,6 @@ describe('request', function () {
 		var api = nock('https://api.flickr.com')
 		.get('/services/rest')
 		.query({
-			api_key: 'abcd1234',
 			method: 'flickr.test.echo',
 			format: 'json',
 			nojsoncallback: 1
@@ -58,7 +55,7 @@ describe('request', function () {
 			message: 'Invalid API Key (Key has invalid format)'
 		});
 
-		return subject('abcd1234')('GET', 'flickr.test.echo').then(function () {
+		return subject('GET', 'flickr.test.echo').then(function () {
 			throw new Error('Expected errback');
 		}, function (err) {
 			assert(api.isDone(), 'Expected mock to have been called');
@@ -68,38 +65,17 @@ describe('request', function () {
 
 	});
 
-	it('adds additional query string arguments', function () {
+	it('yields an error if json parsing fails', function () {
 		var api = nock('https://api.flickr.com')
 		.get('/services/rest')
 		.query({
-			api_key: 'abcd1234',
-			method: 'flickr.test.echo',
-			format: 'json',
-			nojsoncallback: 1,
-			foo: 'bar'
-		})
-		.reply(200, {stat: 'ok'});
-
-		return subject('abcd1234')('GET', 'flickr.test.echo', {foo: 'bar'}).then(function (res) {
-			assert(api.isDone(), 'Expected mock to have been called');
-			assert.equal(res.statusCode, 200);
-			assert.equal(res.body.stat, 'ok');
-		});
-
-	});
-
-	it('throws if json parsing fails', function () {
-		var api = nock('https://api.flickr.com')
-		.get('/services/rest')
-		.query({
-			api_key: 'abcd1234',
 			method: 'flickr.test.echo',
 			format: 'json',
 			nojsoncallback: 1
 		})
 		.reply(200, '{');
 
-		return subject('abcd1234')('GET', 'flickr.test.echo').then(function () {
+		return subject('GET', 'flickr.test.echo').then(function () {
 			throw new Error('Expected errback');
 		}, function (err) {
 			assert(api.isDone(), 'Expected mock to have been called');


### PR DESCRIPTION
This patch makes it so that instead of the REST service accepting an `api_key` param and then expecting you to use the oauth plugin later on, the REST service now makes you provide an auth plugin to the constructor, which can either be the existing oauth plugin or a new api-key plugin.

For example:

``` js
var oauth = require('flickr-sdk/plugins/oauth');
var flickr = require('flickr-sdk')(oauth('consumer key', 'consumer secret', 'oauth token', 'oauth token secret'));

flickr.photos.getInfo({ photo_id: 1234 }).then(/* ... */) // <= this call is authenticated
```