### PR TITLE
Fix tests for JSON parse errors in node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+- '6.0'
 - '5.0'
 - '4.0'
 - '0.12'

--- a/test/request.js
+++ b/test/request.js
@@ -65,7 +65,7 @@ describe('request', function () {
 
 	});
 
-	it('yields an error if json parsing fails', function () {
+	it('yields a SyntaxError if JSON parsing fails', function () {
 		var api = nock('https://api.flickr.com')
 		.get('/services/rest')
 		.query({
@@ -79,7 +79,7 @@ describe('request', function () {
 			throw new Error('Expected errback');
 		}, function (err) {
 			assert(api.isDone(), 'Expected mock to have been called');
-			assert.equal(err.message, 'Unexpected end of input');
+			assert.equal(err.name, 'SyntaxError');
 		});
 
 	});


### PR DESCRIPTION
The error message has changed from `Unexpected end of input` to `Unexpected end of JSON input`, so let's just test that it's a SyntaxError instead.