### PR TITLE
Transport hoisting bug

### DIFF
--- a/lib/flickr-transport.js
+++ b/lib/flickr-transport.js
@@ -217,13 +217,13 @@ FlickrTransport.prototype.oAuth = function (params, auth, isUpload) {
  * @returns {Promise}
  */
 FlickrTransport.prototype.call = function (definition, params, auth, additionalParams, transportConfig) {
+	var flickrTransport = this;
 
 	/* istanbul ignore next */
 	if (process.browser && flickrTransport.config && flickrTransport.config.apiSecret) {
 		throw new Error('Embedding your API secret in the browser could allow a malicious third-party to make API calls using your key.  Making authenticated API calls is disabled in the browser using this SDK at the moment.');
 	}
 
-	var flickrTransport = this;
 	var schema = definition.schema;
 	var path = definition.path;
 	var verb = definition.verb;


### PR DESCRIPTION
`flickrTransport` is always undefined because of hoisting
when checking for apiSecret. So accessing `flickrTransport.config`
always throws when called in the browser.