### PR TITLE
Make OAuth 1.0 a no-op in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flickr-sdk",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "description": "Almost certainly the best Flickr API client in the world for node and the browser",
   "keywords": [
     "flickr",
@@ -17,6 +17,10 @@
     "services",
     "validate.js"
   ],
+  "browser": {
+    "./plugins/oauth.js": "./plugins/oauth-browser.js",
+    "./services/oauth.js": "./services/oauth-browser.js"
+  },
   "scripts": {
     "reflect": "node script/reflect",
     "build": "node script/build > services/rest.js",

--- a/plugins/oauth-browser.js
+++ b/plugins/oauth-browser.js
@@ -1,0 +1,9 @@
+/**
+ * OAuth 1.0 requires your consumer secret to sign calls,
+ * and you should never expose secrets to the browser.
+ * @throws {Error}
+ */
+
+module.exports = function () {
+	throw new Error('OAuth 1.0 is not supported in the browser');
+};

--- a/services/oauth-browser.js
+++ b/services/oauth-browser.js
@@ -1,0 +1,16 @@
+/**
+ * OAuth 1.0 requires your consumer secret to sign calls,
+ * and you should never expose secrets to the browser.
+ * @constructor
+ * @throws {Error}
+ */
+
+function OAuth() {
+	throw new Error('OAuth 1.0 is not supported in the browser');
+}
+
+/**
+ * @module services/oauth-browser
+ */
+
+module.exports = OAuth;

--- a/test/plugins.oauth-browser.js
+++ b/test/plugins.oauth-browser.js
@@ -1,0 +1,15 @@
+var subject = require('../plugins/oauth-browser');
+var assert = require('assert');
+
+describe('plugins/oauth-browser', function () {
+
+	it('throws an appropriate error', function () {
+		assert.throws(function () {
+			subject();
+		}, function (err) {
+			assert.equal(err.message, 'OAuth 1.0 is not supported in the browser');
+			return true;
+		});
+	});
+
+});

--- a/test/services.oauth-browser.js
+++ b/test/services.oauth-browser.js
@@ -1,0 +1,15 @@
+var OAuth = require('../services/oauth-browser');
+var assert = require('assert');
+
+describe('services/oauth-browser', function () {
+
+	it('throws an appropriate error', function () {
+		assert.throws(function () {
+			new OAuth(); // eslint-disable-line no-new
+		}, function (err) {
+			assert.equal(err.message, 'OAuth 1.0 is not supported in the browser');
+			return true;
+		});
+	});
+
+});


### PR DESCRIPTION
OAuth 1.0 needs your client secret to sign calls, so we should not support that in the browser.