### PR TITLE
Set X-Flickr-API-Method header for all requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flickr-sdk",
-  "version": "3.0.0-alpha.3",
+  "version": "3.0.0-alpha.4",
   "description": "Almost certainly the best Flickr API client in the world for node and the browser",
   "keywords": [
     "flickr",

--- a/request.js
+++ b/request.js
@@ -31,6 +31,7 @@ module.exports = function createClient(auth) {
 		return request(verb, 'https://api.flickr.com/services/rest')
 		.query('method=' + method)
 		.query(args)
+		.set('X-Flickr-API-Method', method)
 		.use(json)
 		.use(auth);
 	};

--- a/test/request.js
+++ b/test/request.js
@@ -4,6 +4,27 @@ var nock = require('nock');
 
 describe('request', function () {
 
+	it('adds default request headers', function () {
+		var api = nock('https://api.flickr.com', {
+			reqheaders: {
+				'X-Flickr-API-Method': 'flickr.test.echo'
+			}
+		})
+		.get('/services/rest')
+		.query({
+			method: 'flickr.test.echo',
+			format: 'json',
+			nojsoncallback: 1
+		})
+		.reply(200, {stat: 'ok'});
+
+		return subject('GET', 'flickr.test.echo').then(function (res) {
+			assert(api.isDone(), 'Expected mock to have been called');
+			assert.equal(res.statusCode, 200);
+			assert.equal(res.body.stat, 'ok');
+		});
+	});
+
 	it('adds default query string arguments', function () {
 		var api = nock('https://api.flickr.com')
 		.get('/services/rest')


### PR DESCRIPTION
This sets up a pattern for us to add additional request headers that could help out the API. This also provides a semi-standard way to retrieve the API method in question from the request later on like `req.get('X-Flickr-API-Method')`.