### PR TITLE
Request tests

### DIFF
--- a/test/plugins.json.js
+++ b/test/plugins.json.js
@@ -1,0 +1,61 @@
+var subject = require('../plugins/json');
+var request = require('superagent');
+var assert = require('assert');
+var nock = require('nock');
+
+describe('plugins/json', function () {
+
+	function createMockResponse() {
+		return nock('https://api.flickr.com')
+		.get('/services/rest')
+		.query({
+			format: 'json',
+			nojsoncallback: 1
+		});
+	}
+
+	it('parses a json response', function () {
+		var api = createMockResponse().reply(200, '{"stat":"ok"}');
+
+		return request('GET', 'https://api.flickr.com/services/rest')
+		.use(subject)
+		.then(function (res) {
+			assert(api.isDone(), 'Expected mock to have been called');
+			assert.deepEqual(res.body, { stat: 'ok' });
+		});
+	});
+
+	it('yields a SyntaxError if JSON parsing fails', function () {
+		var api = createMockResponse().reply(200, '{');
+
+		return request('GET', 'https://api.flickr.com/services/rest')
+		.use(subject)
+		.then(function () {
+			throw new Error('Expected errback');
+		}, function (err) {
+			assert(api.isDone(), 'Expected mock to have been called');
+			assert.equal(err.name, 'SyntaxError');
+		});
+
+	});
+
+	it('yields an error if stat=fail is returned', function () {
+		var api = createMockResponse().reply(200, {
+			stat: 'fail',
+			code: 100,
+			message: 'Invalid API Key (Key has invalid format)'
+		});
+
+		return request('GET', 'https://api.flickr.com/services/rest')
+		.use(subject)
+		.then(function () {
+			throw new Error('Expected errback');
+		}, function (err) {
+			assert(api.isDone(), 'Expected mock to have been called');
+			assert.equal(err.message, 'Invalid API Key (Key has invalid format)');
+			assert.equal(err.code, 100);
+		});
+
+	});
+
+});

--- a/test/request.js
+++ b/test/request.js
@@ -1,133 +1,62 @@
 var subject = require('../request')(function auth() { /* noop */ });
+var Request = require('superagent').Request;
 var assert = require('assert');
-var nock = require('nock');
+var parse = require('url').parse;
 
 describe('request', function () {
 
-	it('adds default request headers', function () {
-		var api = nock('https://api.flickr.com', {
-			reqheaders: {
-				'X-Flickr-API-Method': 'flickr.test.echo'
-			}
-		})
-		.get('/services/rest')
-		.query({
-			method: 'flickr.test.echo',
-			format: 'json',
-			nojsoncallback: 1
-		})
-		.reply(200, {stat: 'ok'});
-
-		return subject('GET', 'flickr.test.echo').then(function (res) {
-			assert(api.isDone(), 'Expected mock to have been called');
-			assert.equal(res.statusCode, 200);
-			assert.equal(res.body.stat, 'ok');
-		});
+	it('returns a superagent Request', function () {
+		assert(subject('GET', 'flickr.test.echo') instanceof Request);
 	});
 
+	it('adds default request headers', function () {
+		var req = subject('GET', 'flickr.test.echo').request();
+
+		/*
+			TODO user-agent
+		*/
+
+		assert.equal(req.getHeader('x-flickr-api-method'), 'flickr.test.echo');
+	});
+
+	it('uses the correct path');
+	it('uses the correct host');
+	it('can provide the host as an option');
+
 	it('adds default query string arguments', function () {
-		var api = nock('https://api.flickr.com')
-		.get('/services/rest')
-		.query({
-			method: 'flickr.test.echo',
-			format: 'json',
-			nojsoncallback: 1
-		})
-		.reply(200, {stat: 'ok'});
+		var req = subject('GET', 'flickr.test.echo').request();
+		var url = parse(req.path, true);
 
-		return subject('GET', 'flickr.test.echo').then(function (res) {
-			assert(api.isDone(), 'Expected mock to have been called');
-			assert.equal(res.statusCode, 200);
-			assert.equal(res.body.stat, 'ok');
-		});
-
+		assert.equal(url.query.method, 'flickr.test.echo');
+		assert.equal(url.query.format, 'json');
+		assert.equal(url.query.nojsoncallback, '1');
 	});
 
 	it('adds additional query string arguments', function () {
-		var api = nock('https://api.flickr.com')
-		.get('/services/rest')
-		.query({
-			method: 'flickr.test.echo',
-			format: 'json',
-			nojsoncallback: 1,
-			foo: 'bar'
-		})
-		.reply(200, {stat: 'ok'});
+		var req = subject('GET', 'flickr.test.echo', { foo: 'bar' }).request();
+		var url = parse(req.path, true);
 
-		return subject('GET', 'flickr.test.echo', {foo: 'bar'}).then(function (res) {
-			assert(api.isDone(), 'Expected mock to have been called');
-			assert.equal(res.statusCode, 200);
-			assert.equal(res.body.stat, 'ok');
-		});
-
+		assert.equal(url.query.method, 'flickr.test.echo');
+		assert.equal(url.query.format, 'json');
+		assert.equal(url.query.nojsoncallback, '1');
+		assert.equal(url.query.foo, 'bar');
 	});
 
 	it('joins "extras" if passed as an array', function () {
-		var api = nock('https://api.flickr.com')
-		.get('/services/rest')
-		.query({
-			method: 'flickr.test.echo',
-			format: 'json',
-			nojsoncallback: 1,
-			extras: 'foo,bar,baz'
-		})
-		.reply(200, {stat: 'ok'});
-
-		return subject('GET', 'flickr.test.echo', {
+		var req = subject('GET', 'flickr.test.echo', {
 			extras: [
 				'foo',
 				'bar',
 				'baz'
 			]
-		}).then(function (res) {
-			assert(api.isDone(), 'Expected mock to have been called');
-			assert.equal(res.statusCode, 200);
-			assert.equal(res.body.stat, 'ok');
-		});
+		}).request();
 
-	});
+		var url = parse(req.path, true);
 
-	it('yields an error if stat=fail is returned', function () {
-		var api = nock('https://api.flickr.com')
-		.get('/services/rest')
-		.query({
-			method: 'flickr.test.echo',
-			format: 'json',
-			nojsoncallback: 1
-		})
-		.reply(200, {
-			stat: 'fail',
-			code: 100,
-			message: 'Invalid API Key (Key has invalid format)'
-		});
-
-		return subject('GET', 'flickr.test.echo').then(function () {
-			throw new Error('Expected errback');
-		}, function (err) {
-			assert(api.isDone(), 'Expected mock to have been called');
-			assert.equal(err.message, 'Invalid API Key (Key has invalid format)');
-			assert.equal(err.code, 100);
-		});
-
-	});
-
-	it('yields a SyntaxError if JSON parsing fails', function () {
-		var api = nock('https://api.flickr.com')
-		.get('/services/rest')
-		.query({
-			method: 'flickr.test.echo',
-			format: 'json',
-			nojsoncallback: 1
-		})
-		.reply(200, '{');
-
-		return subject('GET', 'flickr.test.echo').then(function () {
-			throw new Error('Expected errback');
-		}, function (err) {
-			assert(api.isDone(), 'Expected mock to have been called');
-			assert.equal(err.name, 'SyntaxError');
-		});
-
+		assert.equal(url.query.method, 'flickr.test.echo');
+		assert.equal(url.query.format, 'json');
+		assert.equal(url.query.nojsoncallback, '1');
+		assert.equal(url.query.extras, 'foo,bar,baz');
 	});
 
 });

--- a/test/request.js
+++ b/test/request.js
@@ -1,16 +1,29 @@
-var subject = require('../request')(function auth() { /* noop */ });
+var subject = require('../request');
 var Request = require('superagent').Request;
 var assert = require('assert');
 var parse = require('url').parse;
 
+describe('request factory', function () {
+
+	it('requires an auth function to be passed', function () {
+		assert.throws(function () {
+			subject();
+		}, function (err) {
+			return err.message === 'Missing auth superagent plugin';
+		});
+	});
+
+});
+
 describe('request', function () {
+	var request = subject(function auth() { /* noop for tests */ });
 
 	it('returns a superagent Request', function () {
-		assert(subject('GET', 'flickr.test.echo') instanceof Request);
+		assert(request('GET', 'flickr.test.echo') instanceof Request);
 	});
 
 	it('adds default request headers', function () {
-		var req = subject('GET', 'flickr.test.echo').request();
+		var req = request('GET', 'flickr.test.echo').request();
 
 		/*
 			TODO user-agent
@@ -19,12 +32,24 @@ describe('request', function () {
 		assert.equal(req.getHeader('x-flickr-api-method'), 'flickr.test.echo');
 	});
 
-	it('uses the correct path');
-	it('uses the correct host');
+	it('uses the correct path', function () {
+		var req = request('GET', 'flickr.test.echo');
+		var url = parse(req.url);
+
+		assert.equal(url.pathname, '/services/rest');
+	});
+
+	it('uses the correct host', function () {
+		var req = request('GET', 'flickr.test.echo');
+		var url = parse(req.url);
+
+		assert.equal(url.host, 'api.flickr.com');
+	});
+
 	it('can provide the host as an option');
 
 	it('adds default query string arguments', function () {
-		var req = subject('GET', 'flickr.test.echo').request();
+		var req = request('GET', 'flickr.test.echo').request();
 		var url = parse(req.path, true);
 
 		assert.equal(url.query.method, 'flickr.test.echo');
@@ -33,7 +58,7 @@ describe('request', function () {
 	});
 
 	it('adds additional query string arguments', function () {
-		var req = subject('GET', 'flickr.test.echo', { foo: 'bar' }).request();
+		var req = request('GET', 'flickr.test.echo', { foo: 'bar' }).request();
 		var url = parse(req.path, true);
 
 		assert.equal(url.query.method, 'flickr.test.echo');
@@ -43,7 +68,7 @@ describe('request', function () {
 	});
 
 	it('joins "extras" if passed as an array', function () {
-		var req = subject('GET', 'flickr.test.echo', {
+		var req = request('GET', 'flickr.test.echo', {
 			extras: [
 				'foo',
 				'bar',


### PR DESCRIPTION
Previously, our request.js tests also covered the JSON plugin functionality, which made them unnecessarily complicated and unclear. This patch separates the tests into two files.