### PR TITLE
DRY feeds service up and match style

### DIFF
--- a/services/feeds.js
+++ b/services/feeds.js
@@ -3,112 +3,131 @@ var validate = require('../validate');
 
 /**
  * @constructor
+ * @param {Object} args
  */
 
-function Feeds(defaults) {
+function Feeds(args) {
 
-	this.defaults = defaults || {
+	// default arguments
+	this._args = args || {
 		format: 'json'
 	};
 }
 
 /**
- * Public Photos & Videos
- * @see https://www.flickr.com/services/feeds/docs/photos_public/
+ * Factory method to create a new request for a feed.
+ * @param {String} feed
+ * @param {Object} args
+ * @returns {Request}
  */
 
-Feeds.prototype.publicPhotos = function (args) {
-	return request('GET', 'https://www.flickr.com/services/feeds/photos_public.gne')
-	.query(this.defaults)
+Feeds.prototype._ = function (feed, args) {
+	return request('GET', 'https://www.flickr.com/services/feeds/' + feed + '.gne')
+	.query(this._args)
 	.query(args);
 };
 
 /**
+ * Public Photos & Videos
+ * @param {Object} args
+ * @returns {Request}
+ * @see https://www.flickr.com/services/feeds/docs/photos_public/
+ */
+
+Feeds.prototype.publicPhotos = function (args) {
+	return this._('photos_public', args);
+};
+
+/**
  * Friends' Feed
+ * @param {Object} args
+ * @returns {Request}
  * @see https://www.flickr.com/services/feeds/docs/photos_friends/
  */
 
 Feeds.prototype.friendsPhotos = function (args) {
 	validate(args, 'user_id');
-	return request('GET', 'https://www.flickr.com/services/feeds/photos_friends.gne')
-	.query(this.defaults)
-	.query(args);
+
+	return this._('photos_friends', args);
 };
 
 /**
  * Favorite Photos Feed
+ * @param {Object} args
+ * @returns {Request}
  * @see https://www.flickr.com/services/feeds/docs/photos_faves/
  */
 
 Feeds.prototype.favePhotos = function (args) {
-	/**
-	 * This feed launched with support for id, but was
-	 * later changed to support `nsid`
-	 * This allows us to check both, and fail if neither is specified
-	 */
+	// This feed launched with support for id, but was
+	// later changed to support `nsid`. This allows us to
+	// check both, and fail if neither is specified
 	validate(args, ['id', 'nsid']);
-	return request('GET', 'https://www.flickr.com/services/feeds/photos_faves.gne')
-	.query(this.defaults)
-	.query(args);
+
+	return this._('photos_faves', args);
 };
 
 /**
  * Group Discussion Feed
+ * @param {Object} args
+ * @returns {Request}
  * @see https://www.flickr.com/services/feeds/docs/groups_discuss/
  */
 
 Feeds.prototype.groupDiscussions = function (args) {
 	validate(args, 'id');
-	return request('GET', 'https://www.flickr.com/services/feeds/groups_discuss.gne')
-	.query(this.defaults)
-	.query(args);
+
+	return this._('groups_discuss', args);
 };
 
 /**
  * Group Pool Feed
+ * @param {Object} args
+ * @returns {Request}
  * @see https://www.flickr.com/services/feeds/docs/groups_pool/
  */
 
 Feeds.prototype.groupPool = function (args) {
 	validate(args, 'id');
-	return request('GET', 'https://www.flickr.com/services/feeds/groups_pool.gne')
-	.query(this.defaults)
-	.query(args);
+
+	return this._('groups_pool', args);
 };
 
 /**
  * Forum Discussion Feed
+ * @param {Object} args
+ * @returns {Request}
  * @see https://www.flickr.com/services/feeds/docs/forums/
  */
 
 Feeds.prototype.forum = function (args) {
-	return request('GET', 'https://www.flickr.com/services/feeds/forums.gne')
-	.query(this.defaults)
-	.query(args);
+	return this._('forums', args);
 };
 
 /**
  * Recent Activity on Your Photostream (erroneously named, includes sets)
+ * @param {Object} args
+ * @returns {Request}
  * @see https://www.flickr.com/services/feeds/docs/activity/
  */
 
 Feeds.prototype.recentActivity = function (args) {
 	validate(args, 'user_id');
-	return request('GET', 'https://www.flickr.com/services/feeds/activity.gne')
-	.query(this.defaults)
-	.query(args);
+
+	return this._('activity', args);
 };
 
 /**
  * Recent Comments Feed
+ * @param {Object} args
+ * @returns {Request}
  * @see https://www.flickr.com/services/feeds/docs/photos_comments/
  */
 
 Feeds.prototype.recentComments = function (args) {
 	validate(args, 'user_id');
-	return request('GET', 'https://www.flickr.com/services/feeds/photos_comments.gne')
-	.query(this.defaults)
-	.query(args);
+
+	return this._('photos_comments', args);
 };
 
 /**


### PR DESCRIPTION
- DRY up the request creation in the feeds service
- Stop using nock for feed service tests
- Match the style and idioms we're using elsewhere in the project