### PR TITLE
Allow overriding the host for rest service

### DIFF
--- a/request.js
+++ b/request.js
@@ -11,10 +11,16 @@ var json = require('./plugins/json');
  * @see https://github.com/visionmedia/superagent
  */
 
-module.exports = function createClient(auth) {
+module.exports = function createClient(auth, opts) {
+	var host;
+
 	if (typeof auth !== 'function') {
 		throw new Error('Missing auth superagent plugin');
 	}
+
+	// options
+	opts = opts || {};
+	host = opts.host || 'api.flickr.com';
 
 	return function (verb, method, args) {
 		if (typeof args === 'undefined') {
@@ -28,7 +34,7 @@ module.exports = function createClient(auth) {
 			args.extras = args.extras.join(',');
 		}
 
-		return request(verb, 'https://api.flickr.com/services/rest')
+		return request(verb, 'https://' + host + '/services/rest')
 		.query('method=' + method)
 		.query(args)
 		.set('X-Flickr-API-Method', method)

--- a/test/request.js
+++ b/test/request.js
@@ -13,6 +13,16 @@ describe('request factory', function () {
 		});
 	});
 
+	it('can provide the host as an option', function () {
+		var request = subject(function auth() { /* noop for tests */ }, {
+			host: 'www.flickr.com'
+		});
+		var req = request('GET', 'flickr.test.echo');
+		var url = parse(req.url);
+
+		assert.equal(url.host, 'www.flickr.com');
+	});
+
 });
 
 describe('request', function () {
@@ -45,8 +55,6 @@ describe('request', function () {
 
 		assert.equal(url.host, 'api.flickr.com');
 	});
-
-	it('can provide the host as an option');
 
 	it('adds default query string arguments', function () {
 		var req = request('GET', 'flickr.test.echo').request();


### PR DESCRIPTION
This patch provides an options hash for the REST service, particularly to enable overriding the default `api.flickr.com` host.