### PR TITLE
OAuth refactor

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,0 +1,167 @@
+var crypto = require('crypto');
+var parse = require('url').parse;
+var stringify = require('querystring').stringify;
+
+/**
+ * Returns the HMAC-SHA1 digest of `text` and `key` in baset64 encoding.
+ * @param {String} text
+ * @param {String} key
+ * @returns {String}
+ * @see https://oauth.net/core/1.0a/#rfc.section.9.2
+ * @private
+ */
+
+function hmac(text, key) {
+	return crypto.createHmac('sha1', key).update(text).digest('base64');
+}
+
+/**
+ * Encodes each of the strings in `arr` and joins them with the '&'
+ * character (ASCII code 38).
+ * @param {String[]} arr
+ * @returns {String}
+ * @see https://oauth.net/core/1.0a/#rfc.section.9.1.3
+ * @see https://oauth.net/core/1.0a/#encoding_parameters
+ * @private
+ */
+
+function join(arr) {
+	return arr.map(encodeURIComponent).join('&');
+}
+
+/**
+ * Returns `url` with the query string part removed.
+ * @param {String} url
+ * @returns {String}
+ */
+
+function parseUrl(url) {
+	var query = url.indexOf('?');
+
+	if (query > -1) {
+		return url.slice(0, query);
+	} else {
+		return url;
+	}
+}
+
+/**
+ * Returns the query string part of `url`, sorted lexicographically.
+ * @param {String} url
+ * @returns {String}
+ */
+
+function parseQuery(url) {
+	var parts = parse(url, true);
+	var query = {};
+
+	Object.keys(parts.query).sort().forEach(function (key) {
+		query[key] = parts.query[key];
+	});
+
+	return stringify(query);
+}
+
+/**
+ * @constructor
+ * @param {String} consumerKey The application's API key
+ * @param {String} consumerSecret The application's API secret
+ * @see https://www.flickr.com/services/api/auth.oauth.html
+ */
+
+function OAuth(consumerKey, consumerSecret) {
+	if (!consumerKey) {
+		throw new Error('Missing required argument "consumerKey"');
+	}
+	if (!consumerSecret) {
+		throw new Error('Missing required argument "consumerSecret"');
+	}
+	this.consumerKey = consumerKey;
+	this.consumerSecret = consumerSecret;
+}
+
+/**
+ * Returns the number of seconds since January 1, 1970 00:00:00 GMT.
+ * @returns {Number}
+ * @see https://oauth.net/core/1.0a/#nonce
+ */
+
+OAuth.prototype.timestamp = function () {
+	return Math.floor(Date.now() / 1000);
+};
+
+/**
+ * Generates a pseudo-random string. OAuth 1.0 defines a
+ * nonce as a value unique within a given timestamp in seconds.
+ * @returns {String}
+ * @see https://oauth.net/core/1.0a/#nonce
+ */
+
+OAuth.prototype.nonce = function () {
+	return crypto.pseudoRandomBytes(32).toString('base64');
+};
+
+/**
+ * The signature method is always HMAC-SHA1.
+ * @type {String}
+ * @see https://oauth.net/core/1.0a/#rfc.section.9.2
+ */
+
+OAuth.prototype.signatureMethod = 'HMAC-SHA1';
+
+/**
+ * The version is always 1.0.
+ * @type {String}
+ */
+
+OAuth.prototype.version = '1.0';
+
+/**
+ * Creates an object with the standard OAuth 1.0 query params
+ * for this instance.
+ * @returns {Object}
+ */
+
+OAuth.prototype.params = function () {
+	return {
+		oauth_nonce: this.nonce(),
+		oauth_timestamp: this.timestamp(),
+		oauth_consumer_key: this.consumerKey,
+		oauth_signature_method: this.signatureMethod,
+		oauth_version: this.version
+	};
+};
+
+/**
+ * Calculates the OAuth 1.0 signature for `method` and `url`,
+ * optionally including `tokenSecret`.
+ * @param {String} method
+ * @param {String} url
+ * @param {String} tokenSecret
+ * @returns {String}
+ */
+
+OAuth.prototype.signature = function (method, url, tokenSecret) {
+	var signingKey = join([ this.consumerSecret, tokenSecret || '' ]);
+	var baseString = join([ method, parseUrl(url), parseQuery(url) ]);
+
+	return hmac(baseString, signingKey);
+};
+
+/**
+ * Adds the `oauth_signature` query parameter to `url` and returns it.
+ * @param {String} method
+ * @param {String} url
+ * @param {String} tokenSecret
+ * @returns {String}
+ */
+
+OAuth.prototype.sign = function (method, url, tokenSecret) {
+	return url + (url.includes('?') ? '&' : '?') + 'oauth_signature=' + encodeURIComponent(this.signature(method, url, tokenSecret));
+};
+
+/**
+ * @module lib/oauth
+ */
+
+module.exports = OAuth;

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "sinon": "~1.17.6"
   },
   "dependencies": {
-    "superagent": "^3.5.2"
+    "superagent": "^3.5.3-beta.2"
   },
   "bugs": {
     "url": "https://github.com/flickr/flickr-sdk/issues"

--- a/plugins/oauth.js
+++ b/plugins/oauth.js
@@ -1,11 +1,15 @@
-var OAuth = require('../services/oauth');
+var OAuth = require('../lib/oauth');
 
 /**
  * Creates a superagent plugin to sign API calls using OAuth 1.0.
+ * You must provide `oauthToken` and `oauthTokenSecret` when signing
+ * calls to the Flickr API, or you may pass `false` to explicitly
+ * omit one or both of these parameters, as is the case for the
+ * OAuth 1.0 flow in /services/oauth.
  * @param {String} consumerKey
  * @param {String} consumerSecret
- * @param {String} oauthToken
- * @param {String} oauthTokenSecret
+ * @param {String|false} oauthToken
+ * @param {String|false} oauthTokenSecret
  * @returns {Function}
  * @see https://github.com/visionmedia/superagent
  * @see https://www.flickr.com/services/api/auth.oauth.html#call_api
@@ -14,24 +18,39 @@ var OAuth = require('../services/oauth');
 module.exports = function (consumerKey, consumerSecret, oauthToken, oauthTokenSecret) {
 	var oauth = new OAuth(consumerKey, consumerSecret);
 
-	if (!oauthToken) {
+	if (!oauthToken && oauthToken !== false) {
 		throw new Error('Missing required argument "oauthToken"');
 	}
-	if (!oauthTokenSecret) {
+	if (!oauthTokenSecret && oauthTokenSecret !== false) {
 		throw new Error('Missing required argument "oauthTokenSecret"');
 	}
 
 	return function (req) {
-		// we need to overwrite .end to make sure we
+		// we need to overwrite _finalizeQueryString to make sure we
 		// sign the request at the last possible moment
-		var _end = req.end;
+		var _finalizeQueryString = req._finalizeQueryString;
 
-		req.end = function (fn) {
-			this.use(oauth.sign(oauthTokenSecret));
-			_end.call(this, fn);
+		req._finalizeQueryString = function () {
+			// call the original, this.url now has all of the query
+			// string parameters appended
+			_finalizeQueryString.call(this);
+
+			// sign the url with token secret unless it was
+			// explicitly omitted
+			if (oauthTokenSecret !== false) {
+				this.url = oauth.sign(this.method, this.url, oauthTokenSecret);
+			} else {
+				this.url = oauth.sign(this.method, this.url);
+			}
 		};
 
+		// always add our oauth params
 		req.query(oauth.params());
-		req.query({ oauth_token: oauthToken });
+
+		// add the oauth token unless explicitly omitted
+		if (oauthToken !== false) {
+			req.query({ oauth_token: oauthToken });
+		}
+
 	};
 };

--- a/services/oauth.js
+++ b/services/oauth.js
@@ -1,51 +1,5 @@
 var request = require('superagent');
-var crypto = require('crypto');
-
-/**
- * Returns the HMAC-SHA1 digest of `text` and `key` in baset64 encoding.
- * @param {String} text
- * @param {String} key
- * @returns {String}
- * @see https://oauth.net/core/1.0a/#rfc.section.9.2
- * @private
- */
-
-function hmac(text, key) {
-	return crypto.createHmac('sha1', key).update(text).digest('base64');
-}
-
-/**
- * Encodes each of the strings in `arr` and joins them with the '&'
- * character (ASCII code 38).
- * @param {String[]} arr
- * @returns {String}
- * @see https://oauth.net/core/1.0a/#rfc.section.9.1.3
- * @see https://oauth.net/core/1.0a/#encoding_parameters
- * @private
- */
-
-function join(arr) {
-	return arr.map(encodeURIComponent).join('&');
-}
-
-/**
- * Normalizes and sorts all of the query string params in `req`,
- * then joins them with the '&' character (ASCII code 38).
- * @param {Request}
- * @returns String.
- * @see https://oauth.net/core/1.0a/#sig_norm_param
- * @private
- */
-
-function query(req) {
-	var pairs = req.qsRaw.slice();
-
-	Object.keys(req.qs).forEach(function (key) {
-		pairs.push(key + '=' + encodeURIComponent(req.qs[key]));
-	});
-
-	return pairs.sort().join('&');
-}
+var oauth = require('../plugins/oauth');
 
 /**
  * @constructor
@@ -65,12 +19,6 @@ function OAuth(consumerKey, consumerSecret) {
 }
 
 /**
- * @module services/oauth
- */
-
-module.exports = OAuth;
-
-/**
  * Get a Request Token using the consumer key.
  * @param {String} oauthCallback
  * @returns {Request}
@@ -81,9 +29,8 @@ module.exports = OAuth;
 OAuth.prototype.request = function (oauthCallback) {
 	return request('GET', 'https://www.flickr.com/services/oauth/request_token')
 	.query({ oauth_callback: oauthCallback })
-	.query(this.params())
 	.parse(this.parse)
-	.use(this.sign());
+	.use(oauth(this.consumerKey, this.consumerSecret, false, false));
 
 	/*
 		TODO 'https://www.flickr.com/services/oauth/authorize?oauth_token=' + res.body.oauth_token
@@ -103,10 +50,13 @@ OAuth.prototype.request = function (oauthCallback) {
 
 OAuth.prototype.verify = function (oauthToken, oauthVerifier, tokenSecret) {
 	return request('GET', 'https://www.flickr.com/services/oauth/access_token')
-	.query({ oauth_token: oauthToken, oauth_verifier: oauthVerifier })
-	.query(this.params())
+	.query({ oauth_verifier: oauthVerifier })
 	.parse(this.parse)
-	.use(this.sign(tokenSecret));
+	.use(oauth(this.consumerKey, this.consumerSecret, oauthToken, tokenSecret));
+
+	/*
+		TODO hand back a new Flickr instance with the oauth plugin set up?
+	*/
 };
 
 /**
@@ -120,55 +70,7 @@ OAuth.prototype.verify = function (oauthToken, oauthVerifier, tokenSecret) {
 OAuth.prototype.parse = request.parse['application/x-www-form-urlencoded'];
 
 /**
- * Returns the number of seconds since January 1, 1970 00:00:00 GMT.
- * @returns {Number}
- * @see https://oauth.net/core/1.0a/#nonce
+ * @module services/oauth
  */
 
-OAuth.prototype.timestamp = function () {
-	return Math.floor(Date.now() / 1000);
-};
-
-/**
- * Generates a pseudo-random string. OAuth 1.0 defines a
- * nonce as a value unique within a given timestamp in seconds.
- * @returns {String}
- * @see https://oauth.net/core/1.0a/#nonce
- */
-
-OAuth.prototype.nonce = function () {
-	return crypto.pseudoRandomBytes(32).toString('base64');
-};
-
-/**
- * Creates an object with the standard OAuth 1.0 query params
- * for this instance.
- * @returns {Object}
- */
-
-OAuth.prototype.params = function () {
-	return {
-		oauth_nonce: this.nonce(),
-		oauth_timestamp: this.timestamp(),
-		oauth_consumer_key: this.consumerKey,
-		oauth_signature_method: 'HMAC-SHA1',
-		oauth_version: '1.0'
-	};
-};
-
-/**
- * TODO docs
- */
-
-OAuth.prototype.sign = function (tokenSecret) {
-	var consumerSecret = this.consumerSecret;
-
-	return function (req) {
-		var signingKey = join([ consumerSecret, tokenSecret || '' ]);
-		var baseString = join([ req.method, req.url, query(req) ]);
-
-		req.query({
-			oauth_signature: hmac(baseString, signingKey)
-		});
-	};
-};
+module.exports = OAuth;

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -1,0 +1,114 @@
+var Subject = require('../lib/oauth');
+var assert = require('assert');
+var sinon = require('sinon');
+
+describe('oauth', function () {
+	var subject;
+
+	beforeEach(function () {
+		subject = new Subject('consumer key', 'consumer secret');
+		sinon.stub(subject, 'timestamp').returns(499166400);
+		sinon.stub(subject, 'nonce').returns('p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k=');
+	});
+
+	it('requires "consumerKey" and "consumerSecret"', function () {
+
+		assert.throws(function () {
+			subject = new Subject();
+		}, function (err) {
+			return err.message === 'Missing required argument "consumerKey"';
+		});
+
+		assert.throws(function () {
+			subject = new Subject('abc');
+		}, function (err) {
+			return err.message === 'Missing required argument "consumerSecret"';
+		});
+
+		assert.doesNotThrow(function () {
+			subject = new Subject('abc', 'def');
+		});
+
+	});
+
+	describe('#timestamp', function () {
+
+		beforeEach(function () {
+			sinon.restore(subject.timestamp);
+		});
+
+		it('returns the current system time in seconds', function () {
+			assert.equal(subject.timestamp(), Math.floor(Date.now() / 1000));
+		});
+
+	});
+
+	describe('#nonce', function () {
+
+		beforeEach(function () {
+			sinon.restore(subject.nonce);
+		});
+
+		it('returns a string', function () {
+			assert.equal(typeof subject.nonce(), 'string');
+		});
+
+		it('returns 32 bytes of data', function () {
+			assert.equal(Buffer.byteLength(subject.nonce(), 'base64'), 32);
+		});
+
+		it('does not return the same nonce twice', function () {
+			assert.notEqual(subject.nonce(), subject.nonce());
+		});
+
+	});
+
+	describe('#signatureMethod', function () {
+
+		it('is HMAC-SHA1', function () {
+			assert.equal(subject.signatureMethod, 'HMAC-SHA1');
+		});
+
+	});
+
+	describe('#version', function () {
+
+		it('is 1.0', function () {
+			assert.equal(subject.version, '1.0');
+		});
+
+	});
+
+	describe('#signature', function () {
+
+		it('returns the signature without a token secret', function () {
+			var signature = subject.signature('GET', 'http://www.example.com?foo=123&bar=456');
+
+			assert.equal(signature, 'lNBTzyWRRHBuoXmgK13Nht5oiKs=');
+		});
+
+		it('returns the signature with a token secret', function () {
+			var signature = subject.signature('GET', 'http://www.example.com?foo=123&bar=456', 'keyboard cat');
+
+			assert.equal(signature, 'pytjoWTzMmvq13/Bai9YVX1tV9c=');
+		});
+
+	});
+
+	describe('#sign', function () {
+
+		it('signs the url without a token secret', function () {
+			var url = subject.sign('GET', 'http://www.example.com?foo=123&bar=456');
+
+			assert.equal(url, 'http://www.example.com?foo=123&bar=456&oauth_signature=lNBTzyWRRHBuoXmgK13Nht5oiKs%3D');
+		});
+
+		it('signs the url with a token secret', function () {
+			var url = subject.sign('GET', 'http://www.example.com?foo=123&bar=456', 'keyboard cat');
+
+			assert.equal(url, 'http://www.example.com?foo=123&bar=456&oauth_signature=pytjoWTzMmvq13%2FBai9YVX1tV9c%3D');
+		});
+
+	});
+
+});

--- a/test/plugins.oauth.js
+++ b/test/plugins.oauth.js
@@ -1,5 +1,5 @@
 var subject = require('../plugins/oauth');
-var OAuth = require('../services/oauth');
+var OAuth = require('../lib/oauth');
 var Flickr = require('..');
 var assert = require('assert');
 var sinon = require('sinon');

--- a/test/services.oauth.js
+++ b/test/services.oauth.js
@@ -1,16 +1,22 @@
-var OAuth = require('../services/oauth');
-var request = require('superagent');
+var Subject = require('../services/oauth');
+var OAuth = require('../lib/oauth');
 var assert = require('assert');
 var sinon = require('sinon');
 var nock = require('nock');
 
 describe('services/oauth', function () {
 	var subject;
+	var sandbox;
 
 	beforeEach(function () {
-		subject = new OAuth('consumer key', 'consumer secret');
-		sinon.stub(subject, 'timestamp').returns(499166400);
-		sinon.stub(subject, 'nonce').returns('p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k=');
+		subject = new Subject('consumer key', 'consumer secret');
+		sandbox = sinon.sandbox.create();
+		sandbox.stub(OAuth.prototype, 'timestamp').returns(499166400);
+		sandbox.stub(OAuth.prototype, 'nonce').returns('p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k=');
+	});
+
+	afterEach(function () {
+		sandbox.restore();
 	});
 
 	describe('#request', function () {
@@ -67,82 +73,6 @@ describe('services/oauth', function () {
 				assert.equal(res.body.user_nsid, '21207597@N07');
 				assert.equal(res.body.username, 'jamalfanaian');
 			});
-		});
-
-	});
-
-	describe('#timestamp', function () {
-
-		beforeEach(function () {
-			sinon.restore(subject.timestamp);
-		});
-
-		it('returns the current system time in seconds', function () {
-			assert.equal(subject.timestamp(), Math.floor(Date.now() / 1000));
-		});
-
-	});
-
-	describe('#nonce', function () {
-
-		beforeEach(function () {
-			sinon.restore(subject.nonce);
-		});
-
-		it('returns a string', function () {
-			assert.equal(typeof subject.nonce(), 'string');
-		});
-
-		it('returns 32 bytes of data', function () {
-			assert.equal(Buffer.byteLength(subject.nonce(), 'base64'), 32);
-		});
-
-		it('does not return the same nonce twice', function () {
-			assert.notEqual(subject.nonce(), subject.nonce());
-		});
-
-	});
-
-	describe('#params', function () {
-
-		it('returns OAuth 1.0 params', function () {
-			var params = subject.params();
-
-			assert.equal(params.oauth_nonce, 'p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k=');
-			assert.equal(params.oauth_timestamp, 499166400);
-			assert.equal(params.oauth_consumer_key, subject.consumerKey);
-			assert.equal(params.oauth_signature_method, 'HMAC-SHA1');
-			assert.equal(params.oauth_version, '1.0');
-		});
-
-	});
-
-	describe('#sign', function () {
-
-		it('returns a superagent plugin', function () {
-			assert.equal(typeof subject.sign(), 'function');
-		});
-
-		it('signs a request without a token secret', function () {
-			var req = request('GET', 'http://www.example.com');
-
-			req.query({ foo: '123' });
-			req.query('bar=456');
-
-			subject.sign()(req);
-
-			assert.equal(req.qs.oauth_signature, 'lNBTzyWRRHBuoXmgK13Nht5oiKs=');
-		});
-
-		it('signs a request with a token secret', function () {
-			var req = request('GET', 'http://www.example.com');
-
-			req.query({ foo: '123' });
-			req.query('bar=456');
-
-			subject.sign('keyboard cat')(req);
-
-			assert.equal(req.qs.oauth_signature, 'pytjoWTzMmvq13/Bai9YVX1tV9c=');
 		});
 
 	});


### PR DESCRIPTION
This patch separates our OAuth concerns in a way that makes a lot more sense. Before, all of the OAuth signing logic was in the OAuth service (also used to request/verify tokens) and our OAuth superagent plugin would create a new OAuth service to sign requests. This patch makes it so we have one OAuth class with all of the signing logic, the superagent plugin uses that to sign requests, and the OAuth service signs its requests with the superagent plugin. 