### PR TITLE
Feeds fix and example

### DIFF
--- a/examples/.eslintrc.js
+++ b/examples/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+
+	rules: {
+		'no-console': 'off'
+	}
+
+};

--- a/examples/feeds.js
+++ b/examples/feeds.js
@@ -1,0 +1,11 @@
+var Flickr = require('..');
+
+// create a new feeds instance
+var feeds = new Flickr.Feeds();
+
+// get the most recent public photos
+feeds.publicPhotos().then(function (res) {
+	console.log(res.body);
+}, function (err) {
+	console.log('got error', err.message);
+});

--- a/services/feeds.js
+++ b/services/feeds.js
@@ -7,11 +7,8 @@ var validate = require('../validate');
  */
 
 function Feeds(args) {
-
 	// default arguments
-	this._args = args || {
-		format: 'json'
-	};
+	this._args = Object.assign({ format: 'json', nojsoncallback: 1 }, args);
 }
 
 /**

--- a/test/services.feeds.js
+++ b/test/services.feeds.js
@@ -39,21 +39,20 @@ describe('services/feeds', function () {
 		var url = parse(req.path, true);
 
 		assert.equal(url.query.format, 'json');
+		assert.equal(url.query.nojsoncallback, '1');
 	});
 
 	it('overrides default query string arguments', function () {
 		var req, url;
 
 		subject = new Subject({
-			lang: 'fr-fr',
-			format: 'atom'
+			lang: 'fr-fr'
 		});
 
 		req = subject._('photos_public').request();
 		url = parse(req.path, true);
 
 		assert.equal(url.query.lang, 'fr-fr');
-		assert.equal(url.query.format, 'atom');
 	});
 
 	it('adds additional query string arguments', function () {
@@ -72,6 +71,7 @@ describe('services/feeds', function () {
 			assert.equal(req.method, 'GET');
 			assert.equal(req.url, 'https://www.flickr.com/services/feeds/photos_public.gne');
 			assert.equal(req.qs.format, 'json');
+			assert.equal(req.qs.nojsoncallback, '1');
 			assert.equal(req.qs.lang, 'fr-fr');
 		});
 
@@ -95,6 +95,7 @@ describe('services/feeds', function () {
 			assert.equal(req.method, 'GET');
 			assert.equal(req.url, 'https://www.flickr.com/services/feeds/photos_friends.gne');
 			assert.equal(req.qs.format, 'json');
+			assert.equal(req.qs.nojsoncallback, '1');
 			assert.equal(req.qs.user_id, '1234');
 		});
 
@@ -117,6 +118,7 @@ describe('services/feeds', function () {
 			assert.equal(req.method, 'GET');
 			assert.equal(req.url, 'https://www.flickr.com/services/feeds/photos_faves.gne');
 			assert.equal(req.qs.format, 'json');
+			assert.equal(req.qs.nojsoncallback, '1');
 			assert.equal(req.qs.id, '1234');
 		});
 
@@ -139,6 +141,7 @@ describe('services/feeds', function () {
 			assert.equal(req.method, 'GET');
 			assert.equal(req.url, 'https://www.flickr.com/services/feeds/groups_discuss.gne');
 			assert.equal(req.qs.format, 'json');
+			assert.equal(req.qs.nojsoncallback, '1');
 			assert.equal(req.qs.id, '1234');
 		});
 
@@ -161,6 +164,7 @@ describe('services/feeds', function () {
 			assert.equal(req.method, 'GET');
 			assert.equal(req.url, 'https://www.flickr.com/services/feeds/groups_pool.gne');
 			assert.equal(req.qs.format, 'json');
+			assert.equal(req.qs.nojsoncallback, '1');
 			assert.equal(req.qs.id, '1234');
 		});
 
@@ -175,6 +179,7 @@ describe('services/feeds', function () {
 			assert.equal(req.method, 'GET');
 			assert.equal(req.url, 'https://www.flickr.com/services/feeds/forums.gne');
 			assert.equal(req.qs.format, 'json');
+			assert.equal(req.qs.nojsoncallback, '1');
 		});
 
 	});
@@ -196,6 +201,7 @@ describe('services/feeds', function () {
 			assert.equal(req.method, 'GET');
 			assert.equal(req.url, 'https://www.flickr.com/services/feeds/activity.gne');
 			assert.equal(req.qs.format, 'json');
+			assert.equal(req.qs.nojsoncallback, '1');
 			assert.equal(req.qs.user_id, '1234');
 		});
 
@@ -218,6 +224,7 @@ describe('services/feeds', function () {
 			assert.equal(req.method, 'GET');
 			assert.equal(req.url, 'https://www.flickr.com/services/feeds/photos_comments.gne');
 			assert.equal(req.qs.format, 'json');
+			assert.equal(req.qs.nojsoncallback, '1');
 			assert.equal(req.qs.user_id, '1234');
 		});
 


### PR DESCRIPTION
Feeds respond as jsonp by default, so this adds the `nojsoncallback=1` param by default as well. I also created a very simple example of how to use the feeds API.