### PR TITLE
Support POST oauth signatures

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,5 +1,4 @@
 var crypto = require('crypto');
-var parse = require('url').parse;
 var stringify = require('querystring').stringify;
 
 /**
@@ -30,36 +29,19 @@ function join(arr) {
 }
 
 /**
- * Returns `url` with the query string part removed.
- * @param {String} url
+ * Returns `obj` sorted lexicographically by its keys and stringified.
+ * @param {Object} obj
  * @returns {String}
  */
 
-function parseUrl(url) {
-	var query = url.indexOf('?');
+function sortParams(obj) {
+	var tmp = {};
 
-	if (query > -1) {
-		return url.slice(0, query);
-	} else {
-		return url;
-	}
-}
-
-/**
- * Returns the query string part of `url`, sorted lexicographically.
- * @param {String} url
- * @returns {String}
- */
-
-function parseQuery(url) {
-	var parts = parse(url, true);
-	var query = {};
-
-	Object.keys(parts.query).sort().forEach(function (key) {
-		query[key] = parts.query[key];
+	Object.keys(obj).sort().forEach(function (key) {
+		tmp[key] = obj[key];
 	});
 
-	return stringify(query);
+	return stringify(tmp);
 }
 
 /**
@@ -137,27 +119,16 @@ OAuth.prototype.params = function () {
  * optionally including `tokenSecret`.
  * @param {String} method
  * @param {String} url
+ * @param {Object} params
  * @param {String} tokenSecret
  * @returns {String}
  */
 
-OAuth.prototype.signature = function (method, url, tokenSecret) {
+OAuth.prototype.signature = function (method, url, params, tokenSecret) {
 	var signingKey = join([ this.consumerSecret, tokenSecret || '' ]);
-	var baseString = join([ method, parseUrl(url), parseQuery(url) ]);
+	var baseString = join([ method, url, sortParams(params) ]);
 
 	return hmac(baseString, signingKey);
-};
-
-/**
- * Adds the `oauth_signature` query parameter to `url` and returns it.
- * @param {String} method
- * @param {String} url
- * @param {String} tokenSecret
- * @returns {String}
- */
-
-OAuth.prototype.sign = function (method, url, tokenSecret) {
-	return url + (url.includes('?') ? '&' : '?') + 'oauth_signature=' + encodeURIComponent(this.signature(method, url, tokenSecret));
 };
 
 /**

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,4 +1,5 @@
 var request = require('superagent');
+var parse = require('querystring').parse;
 
 /**
  * Subclass superagent's Request class so that we can add
@@ -10,9 +11,63 @@ var request = require('superagent');
 
 function Request(method, url) {
 	request.Request.call(this, method, url);
+
+	// keep track of all request params for oauth signing
+	this.params = {};
 }
 
 Request.prototype = Object.create(request.Request.prototype);
+
+/**
+ * Override .query() to also add query string params to our params hash.
+ * @param {String|Object} val
+ * @returns {this}
+ */
+
+Request.prototype.query = function (val) {
+	if (typeof val === 'string') {
+		Object.assign(this.params, parse(val));
+	} else {
+		Object.assign(this.params, val);
+	}
+
+	// super
+	return request.Request.prototype.query.call(this, val);
+};
+
+/**
+ * Override .field() to also add fields to our params hash.
+ * @param {String|Object} key
+ * @param {String} val
+ * @returns {this}
+ */
+
+Request.prototype.field = function (key, val) {
+	if (typeof key === 'string') {
+		this.params[key] = val;
+	} else {
+		Object.assign(this.params, key);
+	}
+
+	// super
+	return request.Request.prototype.field.call(this, key, val);
+};
+
+/**
+ * Convenience method to either call .query() or .field()
+ * based on this request's method.
+ * @param {Object} obj
+ * @returns {this}
+ */
+
+Request.prototype.param = function (obj) {
+	switch (this.method) {
+	case 'POST':
+		return this.field.call(this, obj);
+	default:
+		return this.query.call(this, obj);
+	}
+};
 
 /**
  * Mimic the request factory method that superagent exports.

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -82,31 +82,15 @@ describe('oauth', function () {
 	describe('#signature', function () {
 
 		it('returns the signature without a token secret', function () {
-			var signature = subject.signature('GET', 'http://www.example.com?foo=123&bar=456');
+			var signature = subject.signature('GET', 'http://www.example.com', { foo: '123', bar: '456' });
 
 			assert.equal(signature, 'lNBTzyWRRHBuoXmgK13Nht5oiKs=');
 		});
 
 		it('returns the signature with a token secret', function () {
-			var signature = subject.signature('GET', 'http://www.example.com?foo=123&bar=456', 'keyboard cat');
+			var signature = subject.signature('GET', 'http://www.example.com', { foo: '123', bar: '456' }, 'keyboard cat');
 
 			assert.equal(signature, 'pytjoWTzMmvq13/Bai9YVX1tV9c=');
-		});
-
-	});
-
-	describe('#sign', function () {
-
-		it('signs the url without a token secret', function () {
-			var url = subject.sign('GET', 'http://www.example.com?foo=123&bar=456');
-
-			assert.equal(url, 'http://www.example.com?foo=123&bar=456&oauth_signature=lNBTzyWRRHBuoXmgK13Nht5oiKs%3D');
-		});
-
-		it('signs the url with a token secret', function () {
-			var url = subject.sign('GET', 'http://www.example.com?foo=123&bar=456', 'keyboard cat');
-
-			assert.equal(url, 'http://www.example.com?foo=123&bar=456&oauth_signature=pytjoWTzMmvq13%2FBai9YVX1tV9c%3D');
 		});
 
 	});

--- a/test/request.js
+++ b/test/request.js
@@ -44,4 +44,126 @@ describe('lib/request', function () {
 		assert.equal(req.method, 'POST');
 	});
 
+	describe('#params', function () {
+
+		it('is an empty hash', function () {
+			var req = subject('GET', 'http://www.example.com');
+
+			assert.deepEqual(req.params, {});
+		});
+
+	});
+
+	describe('#query', function () {
+
+		beforeEach(function () {
+			sinon.stub(Request.prototype, 'query').returnsThis();
+		});
+
+		afterEach(function () {
+			sinon.restore(Request.prototype.query);
+		});
+
+		it('adds a query string to the params hash', function () {
+			var req = subject('GET', 'http://www.example.com');
+			var val = 'foo=bar';
+
+			// returns self
+			assert.strictEqual(req.query(val), req);
+
+			sinon.assert.calledOnce(Request.prototype.query);
+			sinon.assert.calledWith(Request.prototype.query, val);
+
+			assert.deepEqual(req.params, { foo: 'bar' });
+		});
+
+		it('adds an object to the params hash', function () {
+			var req = subject('GET', 'http://www.example.com');
+			var val = { foo: 'bar' };
+
+			// returns self
+			assert.strictEqual(req.query(val), req);
+
+			sinon.assert.calledOnce(Request.prototype.query);
+			sinon.assert.calledWith(Request.prototype.query, val);
+
+			assert.deepEqual(req.params, { foo: 'bar' });
+		});
+
+	});
+
+	describe('#field', function () {
+
+		beforeEach(function () {
+			sinon.stub(Request.prototype, 'field').returnsThis();
+		});
+
+		afterEach(function () {
+			sinon.restore(Request.prototype.field);
+		});
+
+		it('adds a key/value to the params hash', function () {
+			var req = subject('GET', 'http://www.example.com');
+			var key = 'foo';
+			var val = 'bar';
+
+			// returns self
+			assert.strictEqual(req.field(key, val), req);
+
+			sinon.assert.calledOnce(Request.prototype.field);
+			sinon.assert.calledWith(Request.prototype.field, key, val);
+
+			assert.deepEqual(req.params, { foo: 'bar' });
+		});
+
+		it('adds an object to the params hash', function () {
+			var req = subject('GET', 'http://www.example.com');
+			var val = { foo: 'bar' };
+
+			// returns self
+			assert.strictEqual(req.field(val), req);
+
+			sinon.assert.calledOnce(Request.prototype.field);
+			sinon.assert.calledWith(Request.prototype.field, val);
+
+			assert.deepEqual(req.params, { foo: 'bar' });
+		});
+
+	});
+
+	describe('#param', function () {
+		var req;
+
+		beforeEach(function () {
+			req = subject('http://www.example.com');
+			sinon.spy(req, 'query');
+			sinon.spy(req, 'field');
+		});
+
+		it('delegates to .query() for GET requests', function () {
+			var obj = {};
+
+			req.method = 'GET';
+
+			// returns self
+			assert.strictEqual(req.param(obj), req);
+
+			sinon.assert.calledOnce(req.query);
+			sinon.assert.calledWith(req.query, obj);
+		});
+
+		it('delegates to .field() for POST requests', function () {
+			var obj = {};
+
+			req.method = 'POST';
+
+			// returns self
+			assert.strictEqual(req.param(obj), req);
+
+			sinon.assert.calledOnce(req.field);
+			sinon.assert.calledWith(req.field, obj);
+		});
+
+	});
+
 });


### PR DESCRIPTION
For oauth signatures, we need to keep track of all of the request parameters in both the query string and multipart fields. Instead of mucking about in superagent's internals, this extends both the `.query()` and `.field()` methods with ones that keep track of all params in a separate hash. This also modifies the oauth class and plugin to use that hash instead of the full request url (since the url won't contain multipart fields) and provides a convenience `.param()` method that calls either `.query()` or `.field()` based on the request's method.