### PR TITLE
Encode OAuth params following RFC3986

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -2,6 +2,39 @@ var crypto = require('crypto');
 var stringify = require('querystring').stringify;
 
 /**
+ * A hashmap of characters that also need to be encoded per RFC3986.
+ * @type {Object}
+ */
+
+var chars = {
+	'!': '%21',
+	'\'': '%27',
+	'(': '%28',
+	')': '%29',
+	'*': '%2A'
+};
+
+/**
+ * RegExp pattern that will match any of the keys in `chars` globally.
+ * @type {RegExp}
+ */
+
+var regex = new RegExp('[' + Object.keys(chars).join('') + ']', 'g');
+
+/**
+ * Encodes `str` per RFC3986, which is basically what encodeURIComponent
+ * does plus a few extra encoded characters.
+ * @param {String} str
+ * @returns {String}
+ */
+
+function encodeRFC3986(str) {
+	return encodeURIComponent(str).replace(regex, function (c) {
+		return chars[c];
+	});
+}
+
+/**
  * Returns the HMAC-SHA1 digest of `text` and `key` in baset64 encoding.
  * @param {String} text
  * @param {String} key
@@ -25,7 +58,7 @@ function hmac(text, key) {
  */
 
 function join(arr) {
-	return arr.map(encodeURIComponent).join('&');
+	return arr.map(encodeRFC3986).join('&');
 }
 
 /**
@@ -41,7 +74,9 @@ function sortParams(obj) {
 		tmp[key] = obj[key];
 	});
 
-	return stringify(tmp);
+	return stringify(tmp, '&', '=', {
+		encodeURIComponent: encodeRFC3986
+	});
 }
 
 /**

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -115,6 +115,29 @@ OAuth.prototype.params = function () {
 };
 
 /**
+ * Calculates the OAuth 1.0 signing key for this consumer secret,
+ * optionally supplying `tokenSecret`.
+ * @param {String} tokenSecret
+ * @returns {String}
+ */
+
+OAuth.prototype.signingKey = function (tokenSecret) {
+	return join([ this.consumerSecret, tokenSecret || '' ]);
+};
+
+/**
+ * Calculates the OAuth 1.0 base string for `method`, `url` and `params`.
+ * @param {String} method
+ * @param {String} url
+ * @param {Object} params
+ * @returns {String}
+ */
+
+OAuth.prototype.baseString = function (method, url, params) {
+	return join([ method, url, sortParams(params) ]);
+};
+
+/**
  * Calculates the OAuth 1.0 signature for `method` and `url`,
  * optionally including `tokenSecret`.
  * @param {String} method
@@ -125,10 +148,10 @@ OAuth.prototype.params = function () {
  */
 
 OAuth.prototype.signature = function (method, url, params, tokenSecret) {
-	var signingKey = join([ this.consumerSecret, tokenSecret || '' ]);
-	var baseString = join([ method, url, sortParams(params) ]);
-
-	return hmac(baseString, signingKey);
+	return hmac(
+		this.baseString(method, url, params),
+		this.signingKey(tokenSecret)
+	);
 };
 
 /**

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -103,6 +103,17 @@ describe('oauth', function () {
 			);
 		});
 
+		it('encodes params following RFC3986', function () {
+			assert.equal(
+				subject.baseString('GET', 'http://www.example.com', {
+					foo: '!\'()*'
+				}),
+				// params get double-encoded, once when stringifying the
+				// query string and again when encoded into the base string
+				'GET&http%3A%2F%2Fwww.example.com&foo%3D%2521%2527%2528%2529%252A'
+			);
+		});
+
 	});
 
 	describe('#signature', function () {

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -79,6 +79,32 @@ describe('oauth', function () {
 
 	});
 
+	describe('#tokenSecret', function () {
+
+		it('creates the correct string without a token secret', function () {
+			assert.equal(subject.signingKey(), 'consumer%20secret&');
+		});
+
+		it('creates the correct string with a token secret', function () {
+			assert.equal(subject.signingKey('keyboard cat'), 'consumer%20secret&keyboard%20cat');
+		});
+
+	});
+
+	describe('#baseString', function () {
+
+		it('creates the correct base string for the method, url and params', function () {
+			assert.equal(
+				subject.baseString('GET', 'http://www.example.com', {
+					foo: '123',
+					bar: '456'
+				}),
+				'GET&http%3A%2F%2Fwww.example.com&bar%3D456%26foo%3D123'
+			);
+		});
+
+	});
+
 	describe('#signature', function () {
 
 		it('returns the signature without a token secret', function () {


### PR DESCRIPTION
OAuth 1.0 specifies that params need to encoded as specified in [RFC3986][1], which is considerably more aggressive than encodeURIComponent. 

[1]: https://tools.ietf.org/html/rfc3986