### PR TITLE
Upgrade eslint and fix all the indents

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,11 +49,13 @@
     "ejs": "~2.5.2",
     "eslint": "~2.13.1",
     "eslint-config-flickr": "~1.3.1",
+    "indent-string": "^3.1.0",
     "mocha": "~3.0.2",
     "nock": "~8.0.0",
     "nyc": "^10.3.2",
     "require-dir": "~0.3.1",
-    "sinon": "~1.17.6"
+    "sinon": "~1.17.6",
+    "stringify-object": "^3.2.0"
   },
   "dependencies": {
     "superagent": "^3.5.3-beta.2"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "ejs": "~2.5.2",
-    "eslint": "~2.13.1",
+    "eslint": "^4.2.0",
     "eslint-config-flickr": "~1.3.1",
     "indent-string": "^3.1.0",
     "mocha": "~3.0.2",

--- a/script/build-tests.js
+++ b/script/build-tests.js
@@ -1,5 +1,6 @@
+var stringify = require('stringify-object');
+var indent = require('indent-string');
 var path = require('path');
-var util = require('util');
 var ejs = require('ejs');
 var fs = require('fs');
 
@@ -87,7 +88,9 @@ Object.keys(methods).forEach(function (method) {
 		verb: httpVerb(methods[method]),
 		args: requiredArguments(methods[method]),
 		without: without,
-		toObject: util.inspect
+		toObject: function (obj, n) {
+			return indent(stringify(obj), n, '\t').trimLeft();
+		}
 
 	}, function (err, str) {
 		if (err) {

--- a/script/build.js
+++ b/script/build.js
@@ -88,10 +88,10 @@ ejs.renderFile(__dirname + '/rest.ejs', {
 
 	get namespaces() {
 		return Object.keys(this.methods)
-		.map(namespace)
-		.reduce(parts, [])
-		.reduce(uniq, [])
-		.sort();
+			.map(namespace)
+			.reduce(parts, [])
+			.reduce(uniq, [])
+			.sort();
 	},
 
 	/**
@@ -113,12 +113,12 @@ ejs.renderFile(__dirname + '/rest.ejs', {
 
 	getRequiredArguments: function (method) {
 		return this.methods[method]
-		.arguments
-		.argument
-		.filter(required)
-		.map(function (arg) {
-			return arg.name;
-		});
+			.arguments
+			.argument
+			.filter(required)
+			.map(function (arg) {
+				return arg.name;
+			});
 	},
 
 	/**

--- a/script/reflect.js
+++ b/script/reflect.js
@@ -33,10 +33,10 @@ function stringify(obj) {
 
 function info(method) {
 	return request('GET', 'flickr.reflection.getMethodInfo')
-	.query('method_name=' + method._content)
-	.then(function (res) {
-		fs.writeFileSync(filename(method._content), stringify(res.body));
-	});
+		.query('method_name=' + method._content)
+		.then(function (res) {
+			fs.writeFileSync(filename(method._content), stringify(res.body));
+		});
 }
 
 /**

--- a/script/rest.ejs
+++ b/script/rest.ejs
@@ -36,11 +36,11 @@ function createClient(auth, opts) {
 		}
 
 		return request(verb, 'https://' + host + '/services/rest')
-		.query('method=' + method)
-		.query(args)
-		.set('X-Flickr-API-Method', method)
-		.use(json)
-		.use(auth);
+			.query('method=' + method)
+			.query(args)
+			.set('X-Flickr-API-Method', method)
+			.use(json)
+			.use(auth);
 	};
 
 }
@@ -61,9 +61,8 @@ function Flickr(auth, opts) {
 	<%_ namespaces.forEach(function (ns) { _%>
 	this.<%= ns %>._ =
 	<%_ }); _%>
-	// create passthrough for future/undocumented endpoints
-	this._ =
-	createClient(auth, opts);
+	this._ = // create passthrough for future/undocumented endpoints
+		createClient(auth, opts);
 }
 
 <% namespaces.forEach(function (ns) { %>

--- a/script/test.ejs
+++ b/script/test.ejs
@@ -7,7 +7,7 @@ describe('<%= method %>', function () {
 	it('requires "<%= arg %>"', function () {
 
 		assert.throws(function () {
-			<%= method %>(<%- toObject(without(args, arg)) %>);
+			<%= method %>(<%- toObject(without(args, arg), 3) %>);
 		}, function (err) {
 			return err.message === 'Missing required argument "<%= arg %>"';
 		});
@@ -16,7 +16,7 @@ describe('<%= method %>', function () {
 
 <%_ }); _%>
 	it('returns a Request instance', function () {
-		var req = <%= method %>(<%- toObject(args) %>);
+		var req = <%= method %>(<%- toObject(args, 2) %>);
 
 		assert.equal(req.method, '<%= verb %>');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/services/feeds.js
+++ b/services/feeds.js
@@ -20,8 +20,8 @@ function Feeds(args) {
 
 Feeds.prototype._ = function (feed, args) {
 	return request('GET', 'https://www.flickr.com/services/feeds/' + feed + '.gne')
-	.query(this._args)
-	.query(args);
+		.query(this._args)
+		.query(args);
 };
 
 /**

--- a/services/oauth.js
+++ b/services/oauth.js
@@ -28,9 +28,9 @@ function OAuth(consumerKey, consumerSecret) {
 
 OAuth.prototype.request = function (oauthCallback) {
 	return request('GET', 'https://www.flickr.com/services/oauth/request_token')
-	.query({ oauth_callback: oauthCallback })
-	.parse(this.parse)
-	.use(oauth(this.consumerKey, this.consumerSecret, false, false));
+		.query({ oauth_callback: oauthCallback })
+		.parse(this.parse)
+		.use(oauth(this.consumerKey, this.consumerSecret, false, false));
 
 	/*
 		TODO 'https://www.flickr.com/services/oauth/authorize?oauth_token=' + res.body.oauth_token
@@ -76,9 +76,9 @@ OAuth.prototype.authorizeUrl = function (requestToken, perms) {
 
 OAuth.prototype.verify = function (oauthToken, oauthVerifier, tokenSecret) {
 	return request('GET', 'https://www.flickr.com/services/oauth/access_token')
-	.query({ oauth_verifier: oauthVerifier })
-	.parse(this.parse)
-	.use(oauth(this.consumerKey, this.consumerSecret, oauthToken, tokenSecret));
+		.query({ oauth_verifier: oauthVerifier })
+		.parse(this.parse)
+		.use(oauth(this.consumerKey, this.consumerSecret, oauthToken, tokenSecret));
 
 	/*
 		TODO hand back a new Flickr instance with the oauth plugin set up?

--- a/test/flickr.auth.checkToken.js
+++ b/test/flickr.auth.checkToken.js
@@ -14,7 +14,9 @@ describe('flickr.auth.checkToken', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.auth.checkToken({ auth_token: '_' });
+		var req = flickr.auth.checkToken({
+			auth_token: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.auth.getFullToken.js
+++ b/test/flickr.auth.getFullToken.js
@@ -14,7 +14,9 @@ describe('flickr.auth.getFullToken', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.auth.getFullToken({ mini_token: '_' });
+		var req = flickr.auth.getFullToken({
+			mini_token: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.auth.getToken.js
+++ b/test/flickr.auth.getToken.js
@@ -14,7 +14,9 @@ describe('flickr.auth.getToken', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.auth.getToken({ frob: '_' });
+		var req = flickr.auth.getToken({
+			frob: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.auth.oauth.checkToken.js
+++ b/test/flickr.auth.oauth.checkToken.js
@@ -14,7 +14,9 @@ describe('flickr.auth.oauth.checkToken', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.auth.oauth.checkToken({ oauth_token: '_' });
+		var req = flickr.auth.oauth.checkToken({
+			oauth_token: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.blogs.postPhoto.js
+++ b/test/flickr.blogs.postPhoto.js
@@ -6,7 +6,10 @@ describe('flickr.blogs.postPhoto', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.blogs.postPhoto({ title: '_', description: '_' });
+			flickr.blogs.postPhoto({
+				title: '_',
+				description: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.blogs.postPhoto', function () {
 	it('requires "title"', function () {
 
 		assert.throws(function () {
-			flickr.blogs.postPhoto({ photo_id: '_', description: '_' });
+			flickr.blogs.postPhoto({
+				photo_id: '_',
+				description: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "title"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.blogs.postPhoto', function () {
 	it('requires "description"', function () {
 
 		assert.throws(function () {
-			flickr.blogs.postPhoto({ photo_id: '_', title: '_' });
+			flickr.blogs.postPhoto({
+				photo_id: '_',
+				title: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "description"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.blogs.postPhoto', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.blogs.postPhoto({ photo_id: '_', title: '_', description: '_' });
+		var req = flickr.blogs.postPhoto({
+			photo_id: '_',
+			title: '_',
+			description: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.cameras.getBrandModels.js
+++ b/test/flickr.cameras.getBrandModels.js
@@ -14,7 +14,9 @@ describe('flickr.cameras.getBrandModels', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.cameras.getBrandModels({ brand: '_' });
+		var req = flickr.cameras.getBrandModels({
+			brand: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.collections.getInfo.js
+++ b/test/flickr.collections.getInfo.js
@@ -14,7 +14,9 @@ describe('flickr.collections.getInfo', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.collections.getInfo({ collection_id: '_' });
+		var req = flickr.collections.getInfo({
+			collection_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.contacts.getPublicList.js
+++ b/test/flickr.contacts.getPublicList.js
@@ -14,7 +14,9 @@ describe('flickr.contacts.getPublicList', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.contacts.getPublicList({ user_id: '_' });
+		var req = flickr.contacts.getPublicList({
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.favorites.add.js
+++ b/test/flickr.favorites.add.js
@@ -14,7 +14,9 @@ describe('flickr.favorites.add', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.favorites.add({ photo_id: '_' });
+		var req = flickr.favorites.add({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.favorites.getContext.js
+++ b/test/flickr.favorites.getContext.js
@@ -6,7 +6,9 @@ describe('flickr.favorites.getContext', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.favorites.getContext({ user_id: '_' });
+			flickr.favorites.getContext({
+				user_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.favorites.getContext', function () {
 	it('requires "user_id"', function () {
 
 		assert.throws(function () {
-			flickr.favorites.getContext({ photo_id: '_' });
+			flickr.favorites.getContext({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "user_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.favorites.getContext', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.favorites.getContext({ photo_id: '_', user_id: '_' });
+		var req = flickr.favorites.getContext({
+			photo_id: '_',
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.favorites.getPublicList.js
+++ b/test/flickr.favorites.getPublicList.js
@@ -14,7 +14,9 @@ describe('flickr.favorites.getPublicList', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.favorites.getPublicList({ user_id: '_' });
+		var req = flickr.favorites.getPublicList({
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.favorites.remove.js
+++ b/test/flickr.favorites.remove.js
@@ -14,7 +14,9 @@ describe('flickr.favorites.remove', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.favorites.remove({ photo_id: '_' });
+		var req = flickr.favorites.remove({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.galleries.addPhoto.js
+++ b/test/flickr.galleries.addPhoto.js
@@ -6,7 +6,9 @@ describe('flickr.galleries.addPhoto', function () {
 	it('requires "gallery_id"', function () {
 
 		assert.throws(function () {
-			flickr.galleries.addPhoto({ photo_id: '_' });
+			flickr.galleries.addPhoto({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "gallery_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.galleries.addPhoto', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.galleries.addPhoto({ gallery_id: '_' });
+			flickr.galleries.addPhoto({
+				gallery_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.galleries.addPhoto', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.galleries.addPhoto({ gallery_id: '_', photo_id: '_' });
+		var req = flickr.galleries.addPhoto({
+			gallery_id: '_',
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.galleries.create.js
+++ b/test/flickr.galleries.create.js
@@ -6,7 +6,9 @@ describe('flickr.galleries.create', function () {
 	it('requires "title"', function () {
 
 		assert.throws(function () {
-			flickr.galleries.create({ description: '_' });
+			flickr.galleries.create({
+				description: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "title"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.galleries.create', function () {
 	it('requires "description"', function () {
 
 		assert.throws(function () {
-			flickr.galleries.create({ title: '_' });
+			flickr.galleries.create({
+				title: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "description"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.galleries.create', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.galleries.create({ title: '_', description: '_' });
+		var req = flickr.galleries.create({
+			title: '_',
+			description: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.galleries.editMeta.js
+++ b/test/flickr.galleries.editMeta.js
@@ -6,7 +6,9 @@ describe('flickr.galleries.editMeta', function () {
 	it('requires "gallery_id"', function () {
 
 		assert.throws(function () {
-			flickr.galleries.editMeta({ title: '_' });
+			flickr.galleries.editMeta({
+				title: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "gallery_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.galleries.editMeta', function () {
 	it('requires "title"', function () {
 
 		assert.throws(function () {
-			flickr.galleries.editMeta({ gallery_id: '_' });
+			flickr.galleries.editMeta({
+				gallery_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "title"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.galleries.editMeta', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.galleries.editMeta({ gallery_id: '_', title: '_' });
+		var req = flickr.galleries.editMeta({
+			gallery_id: '_',
+			title: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.galleries.editPhoto.js
+++ b/test/flickr.galleries.editPhoto.js
@@ -6,7 +6,10 @@ describe('flickr.galleries.editPhoto', function () {
 	it('requires "gallery_id"', function () {
 
 		assert.throws(function () {
-			flickr.galleries.editPhoto({ photo_id: '_', comment: '_' });
+			flickr.galleries.editPhoto({
+				photo_id: '_',
+				comment: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "gallery_id"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.galleries.editPhoto', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.galleries.editPhoto({ gallery_id: '_', comment: '_' });
+			flickr.galleries.editPhoto({
+				gallery_id: '_',
+				comment: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.galleries.editPhoto', function () {
 	it('requires "comment"', function () {
 
 		assert.throws(function () {
-			flickr.galleries.editPhoto({ gallery_id: '_', photo_id: '_' });
+			flickr.galleries.editPhoto({
+				gallery_id: '_',
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "comment"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.galleries.editPhoto', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.galleries.editPhoto({ gallery_id: '_', photo_id: '_', comment: '_' });
+		var req = flickr.galleries.editPhoto({
+			gallery_id: '_',
+			photo_id: '_',
+			comment: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.galleries.editPhotos.js
+++ b/test/flickr.galleries.editPhotos.js
@@ -6,7 +6,10 @@ describe('flickr.galleries.editPhotos', function () {
 	it('requires "gallery_id"', function () {
 
 		assert.throws(function () {
-			flickr.galleries.editPhotos({ primary_photo_id: '_', photo_ids: '_' });
+			flickr.galleries.editPhotos({
+				primary_photo_id: '_',
+				photo_ids: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "gallery_id"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.galleries.editPhotos', function () {
 	it('requires "primary_photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.galleries.editPhotos({ gallery_id: '_', photo_ids: '_' });
+			flickr.galleries.editPhotos({
+				gallery_id: '_',
+				photo_ids: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "primary_photo_id"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.galleries.editPhotos', function () {
 	it('requires "photo_ids"', function () {
 
 		assert.throws(function () {
-			flickr.galleries.editPhotos({ gallery_id: '_', primary_photo_id: '_' });
+			flickr.galleries.editPhotos({
+				gallery_id: '_',
+				primary_photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_ids"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.galleries.editPhotos', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.galleries.editPhotos({ gallery_id: '_', primary_photo_id: '_', photo_ids: '_' });
+		var req = flickr.galleries.editPhotos({
+			gallery_id: '_',
+			primary_photo_id: '_',
+			photo_ids: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.galleries.getInfo.js
+++ b/test/flickr.galleries.getInfo.js
@@ -14,7 +14,9 @@ describe('flickr.galleries.getInfo', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.galleries.getInfo({ gallery_id: '_' });
+		var req = flickr.galleries.getInfo({
+			gallery_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.galleries.getList.js
+++ b/test/flickr.galleries.getList.js
@@ -14,7 +14,9 @@ describe('flickr.galleries.getList', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.galleries.getList({ user_id: '_' });
+		var req = flickr.galleries.getList({
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.galleries.getListForPhoto.js
+++ b/test/flickr.galleries.getListForPhoto.js
@@ -14,7 +14,9 @@ describe('flickr.galleries.getListForPhoto', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.galleries.getListForPhoto({ photo_id: '_' });
+		var req = flickr.galleries.getListForPhoto({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.galleries.getPhotos.js
+++ b/test/flickr.galleries.getPhotos.js
@@ -14,7 +14,9 @@ describe('flickr.galleries.getPhotos', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.galleries.getPhotos({ gallery_id: '_' });
+		var req = flickr.galleries.getPhotos({
+			gallery_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.discuss.replies.add.js
+++ b/test/flickr.groups.discuss.replies.add.js
@@ -6,7 +6,10 @@ describe('flickr.groups.discuss.replies.add', function () {
 	it('requires "group_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.add({ topic_id: '_', message: '_' });
+			flickr.groups.discuss.replies.add({
+				topic_id: '_',
+				message: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "group_id"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.groups.discuss.replies.add', function () {
 	it('requires "topic_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.add({ group_id: '_', message: '_' });
+			flickr.groups.discuss.replies.add({
+				group_id: '_',
+				message: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "topic_id"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.groups.discuss.replies.add', function () {
 	it('requires "message"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.add({ group_id: '_', topic_id: '_' });
+			flickr.groups.discuss.replies.add({
+				group_id: '_',
+				topic_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "message"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.groups.discuss.replies.add', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.discuss.replies.add({ group_id: '_', topic_id: '_', message: '_' });
+		var req = flickr.groups.discuss.replies.add({
+			group_id: '_',
+			topic_id: '_',
+			message: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.discuss.replies.delete.js
+++ b/test/flickr.groups.discuss.replies.delete.js
@@ -6,7 +6,10 @@ describe('flickr.groups.discuss.replies.delete', function () {
 	it('requires "group_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.delete({ topic_id: '_', reply_id: '_' });
+			flickr.groups.discuss.replies.delete({
+				topic_id: '_',
+				reply_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "group_id"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.groups.discuss.replies.delete', function () {
 	it('requires "topic_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.delete({ group_id: '_', reply_id: '_' });
+			flickr.groups.discuss.replies.delete({
+				group_id: '_',
+				reply_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "topic_id"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.groups.discuss.replies.delete', function () {
 	it('requires "reply_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.delete({ group_id: '_', topic_id: '_' });
+			flickr.groups.discuss.replies.delete({
+				group_id: '_',
+				topic_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "reply_id"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.groups.discuss.replies.delete', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.discuss.replies.delete({ group_id: '_', topic_id: '_', reply_id: '_' });
+		var req = flickr.groups.discuss.replies.delete({
+			group_id: '_',
+			topic_id: '_',
+			reply_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.discuss.replies.edit.js
+++ b/test/flickr.groups.discuss.replies.edit.js
@@ -6,7 +6,11 @@ describe('flickr.groups.discuss.replies.edit', function () {
 	it('requires "group_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.edit({ topic_id: '_', reply_id: '_', message: '_' });
+			flickr.groups.discuss.replies.edit({
+				topic_id: '_',
+				reply_id: '_',
+				message: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "group_id"';
 		});
@@ -16,7 +20,11 @@ describe('flickr.groups.discuss.replies.edit', function () {
 	it('requires "topic_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.edit({ group_id: '_', reply_id: '_', message: '_' });
+			flickr.groups.discuss.replies.edit({
+				group_id: '_',
+				reply_id: '_',
+				message: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "topic_id"';
 		});
@@ -26,7 +34,11 @@ describe('flickr.groups.discuss.replies.edit', function () {
 	it('requires "reply_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.edit({ group_id: '_', topic_id: '_', message: '_' });
+			flickr.groups.discuss.replies.edit({
+				group_id: '_',
+				topic_id: '_',
+				message: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "reply_id"';
 		});
@@ -36,7 +48,11 @@ describe('flickr.groups.discuss.replies.edit', function () {
 	it('requires "message"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.edit({ group_id: '_', topic_id: '_', reply_id: '_' });
+			flickr.groups.discuss.replies.edit({
+				group_id: '_',
+				topic_id: '_',
+				reply_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "message"';
 		});
@@ -44,7 +60,12 @@ describe('flickr.groups.discuss.replies.edit', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.discuss.replies.edit({ group_id: '_', topic_id: '_', reply_id: '_', message: '_' });
+		var req = flickr.groups.discuss.replies.edit({
+			group_id: '_',
+			topic_id: '_',
+			reply_id: '_',
+			message: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.discuss.replies.getInfo.js
+++ b/test/flickr.groups.discuss.replies.getInfo.js
@@ -6,7 +6,10 @@ describe('flickr.groups.discuss.replies.getInfo', function () {
 	it('requires "group_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.getInfo({ topic_id: '_', reply_id: '_' });
+			flickr.groups.discuss.replies.getInfo({
+				topic_id: '_',
+				reply_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "group_id"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.groups.discuss.replies.getInfo', function () {
 	it('requires "topic_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.getInfo({ group_id: '_', reply_id: '_' });
+			flickr.groups.discuss.replies.getInfo({
+				group_id: '_',
+				reply_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "topic_id"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.groups.discuss.replies.getInfo', function () {
 	it('requires "reply_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.getInfo({ group_id: '_', topic_id: '_' });
+			flickr.groups.discuss.replies.getInfo({
+				group_id: '_',
+				topic_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "reply_id"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.groups.discuss.replies.getInfo', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.discuss.replies.getInfo({ group_id: '_', topic_id: '_', reply_id: '_' });
+		var req = flickr.groups.discuss.replies.getInfo({
+			group_id: '_',
+			topic_id: '_',
+			reply_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.discuss.replies.getList.js
+++ b/test/flickr.groups.discuss.replies.getList.js
@@ -6,7 +6,10 @@ describe('flickr.groups.discuss.replies.getList', function () {
 	it('requires "group_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.getList({ topic_id: '_', per_page: '_' });
+			flickr.groups.discuss.replies.getList({
+				topic_id: '_',
+				per_page: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "group_id"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.groups.discuss.replies.getList', function () {
 	it('requires "topic_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.getList({ group_id: '_', per_page: '_' });
+			flickr.groups.discuss.replies.getList({
+				group_id: '_',
+				per_page: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "topic_id"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.groups.discuss.replies.getList', function () {
 	it('requires "per_page"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.replies.getList({ group_id: '_', topic_id: '_' });
+			flickr.groups.discuss.replies.getList({
+				group_id: '_',
+				topic_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "per_page"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.groups.discuss.replies.getList', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.discuss.replies.getList({ group_id: '_', topic_id: '_', per_page: '_' });
+		var req = flickr.groups.discuss.replies.getList({
+			group_id: '_',
+			topic_id: '_',
+			per_page: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.discuss.topics.add.js
+++ b/test/flickr.groups.discuss.topics.add.js
@@ -6,7 +6,10 @@ describe('flickr.groups.discuss.topics.add', function () {
 	it('requires "group_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.topics.add({ subject: '_', message: '_' });
+			flickr.groups.discuss.topics.add({
+				subject: '_',
+				message: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "group_id"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.groups.discuss.topics.add', function () {
 	it('requires "subject"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.topics.add({ group_id: '_', message: '_' });
+			flickr.groups.discuss.topics.add({
+				group_id: '_',
+				message: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "subject"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.groups.discuss.topics.add', function () {
 	it('requires "message"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.topics.add({ group_id: '_', subject: '_' });
+			flickr.groups.discuss.topics.add({
+				group_id: '_',
+				subject: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "message"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.groups.discuss.topics.add', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.discuss.topics.add({ group_id: '_', subject: '_', message: '_' });
+		var req = flickr.groups.discuss.topics.add({
+			group_id: '_',
+			subject: '_',
+			message: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.discuss.topics.getInfo.js
+++ b/test/flickr.groups.discuss.topics.getInfo.js
@@ -6,7 +6,9 @@ describe('flickr.groups.discuss.topics.getInfo', function () {
 	it('requires "group_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.topics.getInfo({ topic_id: '_' });
+			flickr.groups.discuss.topics.getInfo({
+				topic_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "group_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.groups.discuss.topics.getInfo', function () {
 	it('requires "topic_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.discuss.topics.getInfo({ group_id: '_' });
+			flickr.groups.discuss.topics.getInfo({
+				group_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "topic_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.groups.discuss.topics.getInfo', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.discuss.topics.getInfo({ group_id: '_', topic_id: '_' });
+		var req = flickr.groups.discuss.topics.getInfo({
+			group_id: '_',
+			topic_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.discuss.topics.getList.js
+++ b/test/flickr.groups.discuss.topics.getList.js
@@ -14,7 +14,9 @@ describe('flickr.groups.discuss.topics.getList', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.discuss.topics.getList({ group_id: '_' });
+		var req = flickr.groups.discuss.topics.getList({
+			group_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.getInfo.js
+++ b/test/flickr.groups.getInfo.js
@@ -14,7 +14,9 @@ describe('flickr.groups.getInfo', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.getInfo({ group_id: '_' });
+		var req = flickr.groups.getInfo({
+			group_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.join.js
+++ b/test/flickr.groups.join.js
@@ -14,7 +14,9 @@ describe('flickr.groups.join', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.join({ group_id: '_' });
+		var req = flickr.groups.join({
+			group_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.joinRequest.js
+++ b/test/flickr.groups.joinRequest.js
@@ -6,7 +6,10 @@ describe('flickr.groups.joinRequest', function () {
 	it('requires "group_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.joinRequest({ message: '_', accept_rules: '_' });
+			flickr.groups.joinRequest({
+				message: '_',
+				accept_rules: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "group_id"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.groups.joinRequest', function () {
 	it('requires "message"', function () {
 
 		assert.throws(function () {
-			flickr.groups.joinRequest({ group_id: '_', accept_rules: '_' });
+			flickr.groups.joinRequest({
+				group_id: '_',
+				accept_rules: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "message"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.groups.joinRequest', function () {
 	it('requires "accept_rules"', function () {
 
 		assert.throws(function () {
-			flickr.groups.joinRequest({ group_id: '_', message: '_' });
+			flickr.groups.joinRequest({
+				group_id: '_',
+				message: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "accept_rules"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.groups.joinRequest', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.joinRequest({ group_id: '_', message: '_', accept_rules: '_' });
+		var req = flickr.groups.joinRequest({
+			group_id: '_',
+			message: '_',
+			accept_rules: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.leave.js
+++ b/test/flickr.groups.leave.js
@@ -14,7 +14,9 @@ describe('flickr.groups.leave', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.leave({ group_id: '_' });
+		var req = flickr.groups.leave({
+			group_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.members.getList.js
+++ b/test/flickr.groups.members.getList.js
@@ -14,7 +14,9 @@ describe('flickr.groups.members.getList', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.members.getList({ group_id: '_' });
+		var req = flickr.groups.members.getList({
+			group_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.pools.add.js
+++ b/test/flickr.groups.pools.add.js
@@ -6,7 +6,9 @@ describe('flickr.groups.pools.add', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.pools.add({ group_id: '_' });
+			flickr.groups.pools.add({
+				group_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.groups.pools.add', function () {
 	it('requires "group_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.pools.add({ photo_id: '_' });
+			flickr.groups.pools.add({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "group_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.groups.pools.add', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.pools.add({ photo_id: '_', group_id: '_' });
+		var req = flickr.groups.pools.add({
+			photo_id: '_',
+			group_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.pools.getContext.js
+++ b/test/flickr.groups.pools.getContext.js
@@ -6,7 +6,9 @@ describe('flickr.groups.pools.getContext', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.pools.getContext({ group_id: '_' });
+			flickr.groups.pools.getContext({
+				group_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.groups.pools.getContext', function () {
 	it('requires "group_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.pools.getContext({ photo_id: '_' });
+			flickr.groups.pools.getContext({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "group_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.groups.pools.getContext', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.pools.getContext({ photo_id: '_', group_id: '_' });
+		var req = flickr.groups.pools.getContext({
+			photo_id: '_',
+			group_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.pools.getPhotos.js
+++ b/test/flickr.groups.pools.getPhotos.js
@@ -14,7 +14,9 @@ describe('flickr.groups.pools.getPhotos', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.pools.getPhotos({ group_id: '_' });
+		var req = flickr.groups.pools.getPhotos({
+			group_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.pools.remove.js
+++ b/test/flickr.groups.pools.remove.js
@@ -6,7 +6,9 @@ describe('flickr.groups.pools.remove', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.pools.remove({ group_id: '_' });
+			flickr.groups.pools.remove({
+				group_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.groups.pools.remove', function () {
 	it('requires "group_id"', function () {
 
 		assert.throws(function () {
-			flickr.groups.pools.remove({ photo_id: '_' });
+			flickr.groups.pools.remove({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "group_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.groups.pools.remove', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.pools.remove({ photo_id: '_', group_id: '_' });
+		var req = flickr.groups.pools.remove({
+			photo_id: '_',
+			group_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.groups.search.js
+++ b/test/flickr.groups.search.js
@@ -14,7 +14,9 @@ describe('flickr.groups.search', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.groups.search({ text: '_' });
+		var req = flickr.groups.search({
+			text: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.machinetags.getValues.js
+++ b/test/flickr.machinetags.getValues.js
@@ -6,7 +6,9 @@ describe('flickr.machinetags.getValues', function () {
 	it('requires "namespace"', function () {
 
 		assert.throws(function () {
-			flickr.machinetags.getValues({ predicate: '_' });
+			flickr.machinetags.getValues({
+				predicate: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "namespace"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.machinetags.getValues', function () {
 	it('requires "predicate"', function () {
 
 		assert.throws(function () {
-			flickr.machinetags.getValues({ namespace: '_' });
+			flickr.machinetags.getValues({
+				namespace: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "predicate"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.machinetags.getValues', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.machinetags.getValues({ namespace: '_', predicate: '_' });
+		var req = flickr.machinetags.getValues({
+			namespace: '_',
+			predicate: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.panda.getPhotos.js
+++ b/test/flickr.panda.getPhotos.js
@@ -14,7 +14,9 @@ describe('flickr.panda.getPhotos', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.panda.getPhotos({ panda_name: '_' });
+		var req = flickr.panda.getPhotos({
+			panda_name: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.people.findByEmail.js
+++ b/test/flickr.people.findByEmail.js
@@ -14,7 +14,9 @@ describe('flickr.people.findByEmail', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.people.findByEmail({ find_email: '_' });
+		var req = flickr.people.findByEmail({
+			find_email: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.people.findByUsername.js
+++ b/test/flickr.people.findByUsername.js
@@ -14,7 +14,9 @@ describe('flickr.people.findByUsername', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.people.findByUsername({ username: '_' });
+		var req = flickr.people.findByUsername({
+			username: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.people.getGroups.js
+++ b/test/flickr.people.getGroups.js
@@ -14,7 +14,9 @@ describe('flickr.people.getGroups', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.people.getGroups({ user_id: '_' });
+		var req = flickr.people.getGroups({
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.people.getInfo.js
+++ b/test/flickr.people.getInfo.js
@@ -14,7 +14,9 @@ describe('flickr.people.getInfo', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.people.getInfo({ user_id: '_' });
+		var req = flickr.people.getInfo({
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.people.getPhotos.js
+++ b/test/flickr.people.getPhotos.js
@@ -14,7 +14,9 @@ describe('flickr.people.getPhotos', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.people.getPhotos({ user_id: '_' });
+		var req = flickr.people.getPhotos({
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.people.getPhotosOf.js
+++ b/test/flickr.people.getPhotosOf.js
@@ -14,7 +14,9 @@ describe('flickr.people.getPhotosOf', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.people.getPhotosOf({ user_id: '_' });
+		var req = flickr.people.getPhotosOf({
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.people.getPublicGroups.js
+++ b/test/flickr.people.getPublicGroups.js
@@ -14,7 +14,9 @@ describe('flickr.people.getPublicGroups', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.people.getPublicGroups({ user_id: '_' });
+		var req = flickr.people.getPublicGroups({
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.people.getPublicPhotos.js
+++ b/test/flickr.people.getPublicPhotos.js
@@ -14,7 +14,9 @@ describe('flickr.people.getPublicPhotos', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.people.getPublicPhotos({ user_id: '_' });
+		var req = flickr.people.getPublicPhotos({
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.addTags.js
+++ b/test/flickr.photos.addTags.js
@@ -6,7 +6,9 @@ describe('flickr.photos.addTags', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.addTags({ tags: '_' });
+			flickr.photos.addTags({
+				tags: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photos.addTags', function () {
 	it('requires "tags"', function () {
 
 		assert.throws(function () {
-			flickr.photos.addTags({ photo_id: '_' });
+			flickr.photos.addTags({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "tags"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photos.addTags', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.addTags({ photo_id: '_', tags: '_' });
+		var req = flickr.photos.addTags({
+			photo_id: '_',
+			tags: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.comments.addComment.js
+++ b/test/flickr.photos.comments.addComment.js
@@ -6,7 +6,9 @@ describe('flickr.photos.comments.addComment', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.comments.addComment({ comment_text: '_' });
+			flickr.photos.comments.addComment({
+				comment_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photos.comments.addComment', function () {
 	it('requires "comment_text"', function () {
 
 		assert.throws(function () {
-			flickr.photos.comments.addComment({ photo_id: '_' });
+			flickr.photos.comments.addComment({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "comment_text"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photos.comments.addComment', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.comments.addComment({ photo_id: '_', comment_text: '_' });
+		var req = flickr.photos.comments.addComment({
+			photo_id: '_',
+			comment_text: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.comments.deleteComment.js
+++ b/test/flickr.photos.comments.deleteComment.js
@@ -14,7 +14,9 @@ describe('flickr.photos.comments.deleteComment', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.comments.deleteComment({ comment_id: '_' });
+		var req = flickr.photos.comments.deleteComment({
+			comment_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.comments.editComment.js
+++ b/test/flickr.photos.comments.editComment.js
@@ -6,7 +6,9 @@ describe('flickr.photos.comments.editComment', function () {
 	it('requires "comment_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.comments.editComment({ comment_text: '_' });
+			flickr.photos.comments.editComment({
+				comment_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "comment_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photos.comments.editComment', function () {
 	it('requires "comment_text"', function () {
 
 		assert.throws(function () {
-			flickr.photos.comments.editComment({ comment_id: '_' });
+			flickr.photos.comments.editComment({
+				comment_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "comment_text"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photos.comments.editComment', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.comments.editComment({ comment_id: '_', comment_text: '_' });
+		var req = flickr.photos.comments.editComment({
+			comment_id: '_',
+			comment_text: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.comments.getList.js
+++ b/test/flickr.photos.comments.getList.js
@@ -14,7 +14,9 @@ describe('flickr.photos.comments.getList', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.comments.getList({ photo_id: '_' });
+		var req = flickr.photos.comments.getList({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.delete.js
+++ b/test/flickr.photos.delete.js
@@ -14,7 +14,9 @@ describe('flickr.photos.delete', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.delete({ photo_id: '_' });
+		var req = flickr.photos.delete({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.geo.batchCorrectLocation.js
+++ b/test/flickr.photos.geo.batchCorrectLocation.js
@@ -6,7 +6,10 @@ describe('flickr.photos.geo.batchCorrectLocation', function () {
 	it('requires "lat"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.batchCorrectLocation({ lon: '_', accuracy: '_' });
+			flickr.photos.geo.batchCorrectLocation({
+				lon: '_',
+				accuracy: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "lat"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.photos.geo.batchCorrectLocation', function () {
 	it('requires "lon"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.batchCorrectLocation({ lat: '_', accuracy: '_' });
+			flickr.photos.geo.batchCorrectLocation({
+				lat: '_',
+				accuracy: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "lon"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.photos.geo.batchCorrectLocation', function () {
 	it('requires "accuracy"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.batchCorrectLocation({ lat: '_', lon: '_' });
+			flickr.photos.geo.batchCorrectLocation({
+				lat: '_',
+				lon: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "accuracy"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.photos.geo.batchCorrectLocation', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.geo.batchCorrectLocation({ lat: '_', lon: '_', accuracy: '_' });
+		var req = flickr.photos.geo.batchCorrectLocation({
+			lat: '_',
+			lon: '_',
+			accuracy: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.geo.correctLocation.js
+++ b/test/flickr.photos.geo.correctLocation.js
@@ -6,7 +6,9 @@ describe('flickr.photos.geo.correctLocation', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.correctLocation({ foursquare_id: '_' });
+			flickr.photos.geo.correctLocation({
+				foursquare_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photos.geo.correctLocation', function () {
 	it('requires "foursquare_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.correctLocation({ photo_id: '_' });
+			flickr.photos.geo.correctLocation({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "foursquare_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photos.geo.correctLocation', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.geo.correctLocation({ photo_id: '_', foursquare_id: '_' });
+		var req = flickr.photos.geo.correctLocation({
+			photo_id: '_',
+			foursquare_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.geo.getLocation.js
+++ b/test/flickr.photos.geo.getLocation.js
@@ -14,7 +14,9 @@ describe('flickr.photos.geo.getLocation', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.geo.getLocation({ photo_id: '_' });
+		var req = flickr.photos.geo.getLocation({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.geo.getPerms.js
+++ b/test/flickr.photos.geo.getPerms.js
@@ -14,7 +14,9 @@ describe('flickr.photos.geo.getPerms', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.geo.getPerms({ photo_id: '_' });
+		var req = flickr.photos.geo.getPerms({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.geo.photosForLocation.js
+++ b/test/flickr.photos.geo.photosForLocation.js
@@ -6,7 +6,9 @@ describe('flickr.photos.geo.photosForLocation', function () {
 	it('requires "lat"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.photosForLocation({ lon: '_' });
+			flickr.photos.geo.photosForLocation({
+				lon: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "lat"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photos.geo.photosForLocation', function () {
 	it('requires "lon"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.photosForLocation({ lat: '_' });
+			flickr.photos.geo.photosForLocation({
+				lat: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "lon"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photos.geo.photosForLocation', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.geo.photosForLocation({ lat: '_', lon: '_' });
+		var req = flickr.photos.geo.photosForLocation({
+			lat: '_',
+			lon: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.geo.removeLocation.js
+++ b/test/flickr.photos.geo.removeLocation.js
@@ -14,7 +14,9 @@ describe('flickr.photos.geo.removeLocation', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.geo.removeLocation({ photo_id: '_' });
+		var req = flickr.photos.geo.removeLocation({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.geo.setContext.js
+++ b/test/flickr.photos.geo.setContext.js
@@ -6,7 +6,9 @@ describe('flickr.photos.geo.setContext', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.setContext({ context: '_' });
+			flickr.photos.geo.setContext({
+				context: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photos.geo.setContext', function () {
 	it('requires "context"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.setContext({ photo_id: '_' });
+			flickr.photos.geo.setContext({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "context"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photos.geo.setContext', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.geo.setContext({ photo_id: '_', context: '_' });
+		var req = flickr.photos.geo.setContext({
+			photo_id: '_',
+			context: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.geo.setLocation.js
+++ b/test/flickr.photos.geo.setLocation.js
@@ -6,7 +6,10 @@ describe('flickr.photos.geo.setLocation', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.setLocation({ lat: '_', lon: '_' });
+			flickr.photos.geo.setLocation({
+				lat: '_',
+				lon: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.photos.geo.setLocation', function () {
 	it('requires "lat"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.setLocation({ photo_id: '_', lon: '_' });
+			flickr.photos.geo.setLocation({
+				photo_id: '_',
+				lon: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "lat"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.photos.geo.setLocation', function () {
 	it('requires "lon"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.setLocation({ photo_id: '_', lat: '_' });
+			flickr.photos.geo.setLocation({
+				photo_id: '_',
+				lat: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "lon"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.photos.geo.setLocation', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.geo.setLocation({ photo_id: '_', lat: '_', lon: '_' });
+		var req = flickr.photos.geo.setLocation({
+			photo_id: '_',
+			lat: '_',
+			lon: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.geo.setPerms.js
+++ b/test/flickr.photos.geo.setPerms.js
@@ -6,7 +6,12 @@ describe('flickr.photos.geo.setPerms', function () {
 	it('requires "is_public"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.setPerms({ is_contact: '_', is_friend: '_', is_family: '_', photo_id: '_' });
+			flickr.photos.geo.setPerms({
+				is_contact: '_',
+				is_friend: '_',
+				is_family: '_',
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "is_public"';
 		});
@@ -16,7 +21,12 @@ describe('flickr.photos.geo.setPerms', function () {
 	it('requires "is_contact"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.setPerms({ is_public: '_', is_friend: '_', is_family: '_', photo_id: '_' });
+			flickr.photos.geo.setPerms({
+				is_public: '_',
+				is_friend: '_',
+				is_family: '_',
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "is_contact"';
 		});
@@ -26,7 +36,12 @@ describe('flickr.photos.geo.setPerms', function () {
 	it('requires "is_friend"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.setPerms({ is_public: '_', is_contact: '_', is_family: '_', photo_id: '_' });
+			flickr.photos.geo.setPerms({
+				is_public: '_',
+				is_contact: '_',
+				is_family: '_',
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "is_friend"';
 		});
@@ -36,7 +51,12 @@ describe('flickr.photos.geo.setPerms', function () {
 	it('requires "is_family"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.setPerms({ is_public: '_', is_contact: '_', is_friend: '_', photo_id: '_' });
+			flickr.photos.geo.setPerms({
+				is_public: '_',
+				is_contact: '_',
+				is_friend: '_',
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "is_family"';
 		});
@@ -46,10 +66,12 @@ describe('flickr.photos.geo.setPerms', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.geo.setPerms({ is_public: '_',
-  is_contact: '_',
-  is_friend: '_',
-  is_family: '_' });
+			flickr.photos.geo.setPerms({
+				is_public: '_',
+				is_contact: '_',
+				is_friend: '_',
+				is_family: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -57,11 +79,13 @@ describe('flickr.photos.geo.setPerms', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.geo.setPerms({ is_public: '_',
-  is_contact: '_',
-  is_friend: '_',
-  is_family: '_',
-  photo_id: '_' });
+		var req = flickr.photos.geo.setPerms({
+			is_public: '_',
+			is_contact: '_',
+			is_friend: '_',
+			is_family: '_',
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.getAllContexts.js
+++ b/test/flickr.photos.getAllContexts.js
@@ -14,7 +14,9 @@ describe('flickr.photos.getAllContexts', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.getAllContexts({ photo_id: '_' });
+		var req = flickr.photos.getAllContexts({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.getContactsPublicPhotos.js
+++ b/test/flickr.photos.getContactsPublicPhotos.js
@@ -14,7 +14,9 @@ describe('flickr.photos.getContactsPublicPhotos', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.getContactsPublicPhotos({ user_id: '_' });
+		var req = flickr.photos.getContactsPublicPhotos({
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.getContext.js
+++ b/test/flickr.photos.getContext.js
@@ -14,7 +14,9 @@ describe('flickr.photos.getContext', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.getContext({ photo_id: '_' });
+		var req = flickr.photos.getContext({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.getExif.js
+++ b/test/flickr.photos.getExif.js
@@ -14,7 +14,9 @@ describe('flickr.photos.getExif', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.getExif({ photo_id: '_' });
+		var req = flickr.photos.getExif({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.getFavorites.js
+++ b/test/flickr.photos.getFavorites.js
@@ -14,7 +14,9 @@ describe('flickr.photos.getFavorites', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.getFavorites({ photo_id: '_' });
+		var req = flickr.photos.getFavorites({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.getInfo.js
+++ b/test/flickr.photos.getInfo.js
@@ -14,7 +14,9 @@ describe('flickr.photos.getInfo', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.getInfo({ photo_id: '_' });
+		var req = flickr.photos.getInfo({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.getPerms.js
+++ b/test/flickr.photos.getPerms.js
@@ -14,7 +14,9 @@ describe('flickr.photos.getPerms', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.getPerms({ photo_id: '_' });
+		var req = flickr.photos.getPerms({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.getSizes.js
+++ b/test/flickr.photos.getSizes.js
@@ -14,7 +14,9 @@ describe('flickr.photos.getSizes', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.getSizes({ photo_id: '_' });
+		var req = flickr.photos.getSizes({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.licenses.setLicense.js
+++ b/test/flickr.photos.licenses.setLicense.js
@@ -6,7 +6,9 @@ describe('flickr.photos.licenses.setLicense', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.licenses.setLicense({ license_id: '_' });
+			flickr.photos.licenses.setLicense({
+				license_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photos.licenses.setLicense', function () {
 	it('requires "license_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.licenses.setLicense({ photo_id: '_' });
+			flickr.photos.licenses.setLicense({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "license_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photos.licenses.setLicense', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.licenses.setLicense({ photo_id: '_', license_id: '_' });
+		var req = flickr.photos.licenses.setLicense({
+			photo_id: '_',
+			license_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.notes.add.js
+++ b/test/flickr.photos.notes.add.js
@@ -6,11 +6,13 @@ describe('flickr.photos.notes.add', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.notes.add({ note_x: '_',
-  note_y: '_',
-  note_w: '_',
-  note_h: '_',
-  note_text: '_' });
+			flickr.photos.notes.add({
+				note_x: '_',
+				note_y: '_',
+				note_w: '_',
+				note_h: '_',
+				note_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -20,11 +22,13 @@ describe('flickr.photos.notes.add', function () {
 	it('requires "note_x"', function () {
 
 		assert.throws(function () {
-			flickr.photos.notes.add({ photo_id: '_',
-  note_y: '_',
-  note_w: '_',
-  note_h: '_',
-  note_text: '_' });
+			flickr.photos.notes.add({
+				photo_id: '_',
+				note_y: '_',
+				note_w: '_',
+				note_h: '_',
+				note_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "note_x"';
 		});
@@ -34,11 +38,13 @@ describe('flickr.photos.notes.add', function () {
 	it('requires "note_y"', function () {
 
 		assert.throws(function () {
-			flickr.photos.notes.add({ photo_id: '_',
-  note_x: '_',
-  note_w: '_',
-  note_h: '_',
-  note_text: '_' });
+			flickr.photos.notes.add({
+				photo_id: '_',
+				note_x: '_',
+				note_w: '_',
+				note_h: '_',
+				note_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "note_y"';
 		});
@@ -48,11 +54,13 @@ describe('flickr.photos.notes.add', function () {
 	it('requires "note_w"', function () {
 
 		assert.throws(function () {
-			flickr.photos.notes.add({ photo_id: '_',
-  note_x: '_',
-  note_y: '_',
-  note_h: '_',
-  note_text: '_' });
+			flickr.photos.notes.add({
+				photo_id: '_',
+				note_x: '_',
+				note_y: '_',
+				note_h: '_',
+				note_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "note_w"';
 		});
@@ -62,11 +70,13 @@ describe('flickr.photos.notes.add', function () {
 	it('requires "note_h"', function () {
 
 		assert.throws(function () {
-			flickr.photos.notes.add({ photo_id: '_',
-  note_x: '_',
-  note_y: '_',
-  note_w: '_',
-  note_text: '_' });
+			flickr.photos.notes.add({
+				photo_id: '_',
+				note_x: '_',
+				note_y: '_',
+				note_w: '_',
+				note_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "note_h"';
 		});
@@ -76,11 +86,13 @@ describe('flickr.photos.notes.add', function () {
 	it('requires "note_text"', function () {
 
 		assert.throws(function () {
-			flickr.photos.notes.add({ photo_id: '_',
-  note_x: '_',
-  note_y: '_',
-  note_w: '_',
-  note_h: '_' });
+			flickr.photos.notes.add({
+				photo_id: '_',
+				note_x: '_',
+				note_y: '_',
+				note_w: '_',
+				note_h: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "note_text"';
 		});
@@ -88,12 +100,14 @@ describe('flickr.photos.notes.add', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.notes.add({ photo_id: '_',
-  note_x: '_',
-  note_y: '_',
-  note_w: '_',
-  note_h: '_',
-  note_text: '_' });
+		var req = flickr.photos.notes.add({
+			photo_id: '_',
+			note_x: '_',
+			note_y: '_',
+			note_w: '_',
+			note_h: '_',
+			note_text: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.notes.delete.js
+++ b/test/flickr.photos.notes.delete.js
@@ -14,7 +14,9 @@ describe('flickr.photos.notes.delete', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.notes.delete({ note_id: '_' });
+		var req = flickr.photos.notes.delete({
+			note_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.notes.edit.js
+++ b/test/flickr.photos.notes.edit.js
@@ -6,11 +6,13 @@ describe('flickr.photos.notes.edit', function () {
 	it('requires "note_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.notes.edit({ note_x: '_',
-  note_y: '_',
-  note_w: '_',
-  note_h: '_',
-  note_text: '_' });
+			flickr.photos.notes.edit({
+				note_x: '_',
+				note_y: '_',
+				note_w: '_',
+				note_h: '_',
+				note_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "note_id"';
 		});
@@ -20,11 +22,13 @@ describe('flickr.photos.notes.edit', function () {
 	it('requires "note_x"', function () {
 
 		assert.throws(function () {
-			flickr.photos.notes.edit({ note_id: '_',
-  note_y: '_',
-  note_w: '_',
-  note_h: '_',
-  note_text: '_' });
+			flickr.photos.notes.edit({
+				note_id: '_',
+				note_y: '_',
+				note_w: '_',
+				note_h: '_',
+				note_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "note_x"';
 		});
@@ -34,11 +38,13 @@ describe('flickr.photos.notes.edit', function () {
 	it('requires "note_y"', function () {
 
 		assert.throws(function () {
-			flickr.photos.notes.edit({ note_id: '_',
-  note_x: '_',
-  note_w: '_',
-  note_h: '_',
-  note_text: '_' });
+			flickr.photos.notes.edit({
+				note_id: '_',
+				note_x: '_',
+				note_w: '_',
+				note_h: '_',
+				note_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "note_y"';
 		});
@@ -48,11 +54,13 @@ describe('flickr.photos.notes.edit', function () {
 	it('requires "note_w"', function () {
 
 		assert.throws(function () {
-			flickr.photos.notes.edit({ note_id: '_',
-  note_x: '_',
-  note_y: '_',
-  note_h: '_',
-  note_text: '_' });
+			flickr.photos.notes.edit({
+				note_id: '_',
+				note_x: '_',
+				note_y: '_',
+				note_h: '_',
+				note_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "note_w"';
 		});
@@ -62,11 +70,13 @@ describe('flickr.photos.notes.edit', function () {
 	it('requires "note_h"', function () {
 
 		assert.throws(function () {
-			flickr.photos.notes.edit({ note_id: '_',
-  note_x: '_',
-  note_y: '_',
-  note_w: '_',
-  note_text: '_' });
+			flickr.photos.notes.edit({
+				note_id: '_',
+				note_x: '_',
+				note_y: '_',
+				note_w: '_',
+				note_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "note_h"';
 		});
@@ -76,11 +86,13 @@ describe('flickr.photos.notes.edit', function () {
 	it('requires "note_text"', function () {
 
 		assert.throws(function () {
-			flickr.photos.notes.edit({ note_id: '_',
-  note_x: '_',
-  note_y: '_',
-  note_w: '_',
-  note_h: '_' });
+			flickr.photos.notes.edit({
+				note_id: '_',
+				note_x: '_',
+				note_y: '_',
+				note_w: '_',
+				note_h: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "note_text"';
 		});
@@ -88,12 +100,14 @@ describe('flickr.photos.notes.edit', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.notes.edit({ note_id: '_',
-  note_x: '_',
-  note_y: '_',
-  note_w: '_',
-  note_h: '_',
-  note_text: '_' });
+		var req = flickr.photos.notes.edit({
+			note_id: '_',
+			note_x: '_',
+			note_y: '_',
+			note_w: '_',
+			note_h: '_',
+			note_text: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.people.add.js
+++ b/test/flickr.photos.people.add.js
@@ -6,7 +6,9 @@ describe('flickr.photos.people.add', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.people.add({ user_id: '_' });
+			flickr.photos.people.add({
+				user_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photos.people.add', function () {
 	it('requires "user_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.people.add({ photo_id: '_' });
+			flickr.photos.people.add({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "user_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photos.people.add', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.people.add({ photo_id: '_', user_id: '_' });
+		var req = flickr.photos.people.add({
+			photo_id: '_',
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.people.delete.js
+++ b/test/flickr.photos.people.delete.js
@@ -6,7 +6,9 @@ describe('flickr.photos.people.delete', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.people.delete({ user_id: '_' });
+			flickr.photos.people.delete({
+				user_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photos.people.delete', function () {
 	it('requires "user_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.people.delete({ photo_id: '_' });
+			flickr.photos.people.delete({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "user_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photos.people.delete', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.people.delete({ photo_id: '_', user_id: '_' });
+		var req = flickr.photos.people.delete({
+			photo_id: '_',
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.people.deleteCoords.js
+++ b/test/flickr.photos.people.deleteCoords.js
@@ -6,7 +6,9 @@ describe('flickr.photos.people.deleteCoords', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.people.deleteCoords({ user_id: '_' });
+			flickr.photos.people.deleteCoords({
+				user_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photos.people.deleteCoords', function () {
 	it('requires "user_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.people.deleteCoords({ photo_id: '_' });
+			flickr.photos.people.deleteCoords({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "user_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photos.people.deleteCoords', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.people.deleteCoords({ photo_id: '_', user_id: '_' });
+		var req = flickr.photos.people.deleteCoords({
+			photo_id: '_',
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.people.editCoords.js
+++ b/test/flickr.photos.people.editCoords.js
@@ -6,11 +6,13 @@ describe('flickr.photos.people.editCoords', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.people.editCoords({ user_id: '_',
-  person_x: '_',
-  person_y: '_',
-  person_w: '_',
-  person_h: '_' });
+			flickr.photos.people.editCoords({
+				user_id: '_',
+				person_x: '_',
+				person_y: '_',
+				person_w: '_',
+				person_h: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -20,11 +22,13 @@ describe('flickr.photos.people.editCoords', function () {
 	it('requires "user_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.people.editCoords({ photo_id: '_',
-  person_x: '_',
-  person_y: '_',
-  person_w: '_',
-  person_h: '_' });
+			flickr.photos.people.editCoords({
+				photo_id: '_',
+				person_x: '_',
+				person_y: '_',
+				person_w: '_',
+				person_h: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "user_id"';
 		});
@@ -34,11 +38,13 @@ describe('flickr.photos.people.editCoords', function () {
 	it('requires "person_x"', function () {
 
 		assert.throws(function () {
-			flickr.photos.people.editCoords({ photo_id: '_',
-  user_id: '_',
-  person_y: '_',
-  person_w: '_',
-  person_h: '_' });
+			flickr.photos.people.editCoords({
+				photo_id: '_',
+				user_id: '_',
+				person_y: '_',
+				person_w: '_',
+				person_h: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "person_x"';
 		});
@@ -48,11 +54,13 @@ describe('flickr.photos.people.editCoords', function () {
 	it('requires "person_y"', function () {
 
 		assert.throws(function () {
-			flickr.photos.people.editCoords({ photo_id: '_',
-  user_id: '_',
-  person_x: '_',
-  person_w: '_',
-  person_h: '_' });
+			flickr.photos.people.editCoords({
+				photo_id: '_',
+				user_id: '_',
+				person_x: '_',
+				person_w: '_',
+				person_h: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "person_y"';
 		});
@@ -62,11 +70,13 @@ describe('flickr.photos.people.editCoords', function () {
 	it('requires "person_w"', function () {
 
 		assert.throws(function () {
-			flickr.photos.people.editCoords({ photo_id: '_',
-  user_id: '_',
-  person_x: '_',
-  person_y: '_',
-  person_h: '_' });
+			flickr.photos.people.editCoords({
+				photo_id: '_',
+				user_id: '_',
+				person_x: '_',
+				person_y: '_',
+				person_h: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "person_w"';
 		});
@@ -76,11 +86,13 @@ describe('flickr.photos.people.editCoords', function () {
 	it('requires "person_h"', function () {
 
 		assert.throws(function () {
-			flickr.photos.people.editCoords({ photo_id: '_',
-  user_id: '_',
-  person_x: '_',
-  person_y: '_',
-  person_w: '_' });
+			flickr.photos.people.editCoords({
+				photo_id: '_',
+				user_id: '_',
+				person_x: '_',
+				person_y: '_',
+				person_w: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "person_h"';
 		});
@@ -88,12 +100,14 @@ describe('flickr.photos.people.editCoords', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.people.editCoords({ photo_id: '_',
-  user_id: '_',
-  person_x: '_',
-  person_y: '_',
-  person_w: '_',
-  person_h: '_' });
+		var req = flickr.photos.people.editCoords({
+			photo_id: '_',
+			user_id: '_',
+			person_x: '_',
+			person_y: '_',
+			person_w: '_',
+			person_h: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.people.getList.js
+++ b/test/flickr.photos.people.getList.js
@@ -14,7 +14,9 @@ describe('flickr.photos.people.getList', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.people.getList({ photo_id: '_' });
+		var req = flickr.photos.people.getList({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.recentlyUpdated.js
+++ b/test/flickr.photos.recentlyUpdated.js
@@ -14,7 +14,9 @@ describe('flickr.photos.recentlyUpdated', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.recentlyUpdated({ min_date: '_' });
+		var req = flickr.photos.recentlyUpdated({
+			min_date: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.removeTag.js
+++ b/test/flickr.photos.removeTag.js
@@ -14,7 +14,9 @@ describe('flickr.photos.removeTag', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.removeTag({ tag_id: '_' });
+		var req = flickr.photos.removeTag({
+			tag_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.setContentType.js
+++ b/test/flickr.photos.setContentType.js
@@ -6,7 +6,9 @@ describe('flickr.photos.setContentType', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.setContentType({ content_type: '_' });
+			flickr.photos.setContentType({
+				content_type: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photos.setContentType', function () {
 	it('requires "content_type"', function () {
 
 		assert.throws(function () {
-			flickr.photos.setContentType({ photo_id: '_' });
+			flickr.photos.setContentType({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "content_type"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photos.setContentType', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.setContentType({ photo_id: '_', content_type: '_' });
+		var req = flickr.photos.setContentType({
+			photo_id: '_',
+			content_type: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.setDates.js
+++ b/test/flickr.photos.setDates.js
@@ -14,7 +14,9 @@ describe('flickr.photos.setDates', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.setDates({ photo_id: '_' });
+		var req = flickr.photos.setDates({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.setMeta.js
+++ b/test/flickr.photos.setMeta.js
@@ -14,7 +14,9 @@ describe('flickr.photos.setMeta', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.setMeta({ photo_id: '_' });
+		var req = flickr.photos.setMeta({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.setPerms.js
+++ b/test/flickr.photos.setPerms.js
@@ -6,7 +6,11 @@ describe('flickr.photos.setPerms', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.setPerms({ is_public: '_', is_friend: '_', is_family: '_' });
+			flickr.photos.setPerms({
+				is_public: '_',
+				is_friend: '_',
+				is_family: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +20,11 @@ describe('flickr.photos.setPerms', function () {
 	it('requires "is_public"', function () {
 
 		assert.throws(function () {
-			flickr.photos.setPerms({ photo_id: '_', is_friend: '_', is_family: '_' });
+			flickr.photos.setPerms({
+				photo_id: '_',
+				is_friend: '_',
+				is_family: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "is_public"';
 		});
@@ -26,7 +34,11 @@ describe('flickr.photos.setPerms', function () {
 	it('requires "is_friend"', function () {
 
 		assert.throws(function () {
-			flickr.photos.setPerms({ photo_id: '_', is_public: '_', is_family: '_' });
+			flickr.photos.setPerms({
+				photo_id: '_',
+				is_public: '_',
+				is_family: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "is_friend"';
 		});
@@ -36,7 +48,11 @@ describe('flickr.photos.setPerms', function () {
 	it('requires "is_family"', function () {
 
 		assert.throws(function () {
-			flickr.photos.setPerms({ photo_id: '_', is_public: '_', is_friend: '_' });
+			flickr.photos.setPerms({
+				photo_id: '_',
+				is_public: '_',
+				is_friend: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "is_family"';
 		});
@@ -44,7 +60,12 @@ describe('flickr.photos.setPerms', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.setPerms({ photo_id: '_', is_public: '_', is_friend: '_', is_family: '_' });
+		var req = flickr.photos.setPerms({
+			photo_id: '_',
+			is_public: '_',
+			is_friend: '_',
+			is_family: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.setSafetyLevel.js
+++ b/test/flickr.photos.setSafetyLevel.js
@@ -14,7 +14,9 @@ describe('flickr.photos.setSafetyLevel', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.setSafetyLevel({ photo_id: '_' });
+		var req = flickr.photos.setSafetyLevel({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.setTags.js
+++ b/test/flickr.photos.setTags.js
@@ -6,7 +6,9 @@ describe('flickr.photos.setTags', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.setTags({ tags: '_' });
+			flickr.photos.setTags({
+				tags: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photos.setTags', function () {
 	it('requires "tags"', function () {
 
 		assert.throws(function () {
-			flickr.photos.setTags({ photo_id: '_' });
+			flickr.photos.setTags({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "tags"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photos.setTags', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.setTags({ photo_id: '_', tags: '_' });
+		var req = flickr.photos.setTags({
+			photo_id: '_',
+			tags: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.suggestions.approveSuggestion.js
+++ b/test/flickr.photos.suggestions.approveSuggestion.js
@@ -14,7 +14,9 @@ describe('flickr.photos.suggestions.approveSuggestion', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.suggestions.approveSuggestion({ suggestion_id: '_' });
+		var req = flickr.photos.suggestions.approveSuggestion({
+			suggestion_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.suggestions.rejectSuggestion.js
+++ b/test/flickr.photos.suggestions.rejectSuggestion.js
@@ -14,7 +14,9 @@ describe('flickr.photos.suggestions.rejectSuggestion', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.suggestions.rejectSuggestion({ suggestion_id: '_' });
+		var req = flickr.photos.suggestions.rejectSuggestion({
+			suggestion_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.suggestions.removeSuggestion.js
+++ b/test/flickr.photos.suggestions.removeSuggestion.js
@@ -14,7 +14,9 @@ describe('flickr.photos.suggestions.removeSuggestion', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.suggestions.removeSuggestion({ suggestion_id: '_' });
+		var req = flickr.photos.suggestions.removeSuggestion({
+			suggestion_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.suggestions.suggestLocation.js
+++ b/test/flickr.photos.suggestions.suggestLocation.js
@@ -6,7 +6,10 @@ describe('flickr.photos.suggestions.suggestLocation', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.suggestions.suggestLocation({ lat: '_', lon: '_' });
+			flickr.photos.suggestions.suggestLocation({
+				lat: '_',
+				lon: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.photos.suggestions.suggestLocation', function () {
 	it('requires "lat"', function () {
 
 		assert.throws(function () {
-			flickr.photos.suggestions.suggestLocation({ photo_id: '_', lon: '_' });
+			flickr.photos.suggestions.suggestLocation({
+				photo_id: '_',
+				lon: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "lat"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.photos.suggestions.suggestLocation', function () {
 	it('requires "lon"', function () {
 
 		assert.throws(function () {
-			flickr.photos.suggestions.suggestLocation({ photo_id: '_', lat: '_' });
+			flickr.photos.suggestions.suggestLocation({
+				photo_id: '_',
+				lat: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "lon"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.photos.suggestions.suggestLocation', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.suggestions.suggestLocation({ photo_id: '_', lat: '_', lon: '_' });
+		var req = flickr.photos.suggestions.suggestLocation({
+			photo_id: '_',
+			lat: '_',
+			lon: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.transform.rotate.js
+++ b/test/flickr.photos.transform.rotate.js
@@ -6,7 +6,9 @@ describe('flickr.photos.transform.rotate', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photos.transform.rotate({ degrees: '_' });
+			flickr.photos.transform.rotate({
+				degrees: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photos.transform.rotate', function () {
 	it('requires "degrees"', function () {
 
 		assert.throws(function () {
-			flickr.photos.transform.rotate({ photo_id: '_' });
+			flickr.photos.transform.rotate({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "degrees"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photos.transform.rotate', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.transform.rotate({ photo_id: '_', degrees: '_' });
+		var req = flickr.photos.transform.rotate({
+			photo_id: '_',
+			degrees: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photos.upload.checkTickets.js
+++ b/test/flickr.photos.upload.checkTickets.js
@@ -14,7 +14,9 @@ describe('flickr.photos.upload.checkTickets', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photos.upload.checkTickets({ tickets: '_' });
+		var req = flickr.photos.upload.checkTickets({
+			tickets: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.addPhoto.js
+++ b/test/flickr.photosets.addPhoto.js
@@ -6,7 +6,9 @@ describe('flickr.photosets.addPhoto', function () {
 	it('requires "photoset_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.addPhoto({ photo_id: '_' });
+			flickr.photosets.addPhoto({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photoset_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photosets.addPhoto', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.addPhoto({ photoset_id: '_' });
+			flickr.photosets.addPhoto({
+				photoset_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photosets.addPhoto', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.addPhoto({ photoset_id: '_', photo_id: '_' });
+		var req = flickr.photosets.addPhoto({
+			photoset_id: '_',
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.comments.addComment.js
+++ b/test/flickr.photosets.comments.addComment.js
@@ -6,7 +6,9 @@ describe('flickr.photosets.comments.addComment', function () {
 	it('requires "photoset_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.comments.addComment({ comment_text: '_' });
+			flickr.photosets.comments.addComment({
+				comment_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photoset_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photosets.comments.addComment', function () {
 	it('requires "comment_text"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.comments.addComment({ photoset_id: '_' });
+			flickr.photosets.comments.addComment({
+				photoset_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "comment_text"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photosets.comments.addComment', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.comments.addComment({ photoset_id: '_', comment_text: '_' });
+		var req = flickr.photosets.comments.addComment({
+			photoset_id: '_',
+			comment_text: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.comments.deleteComment.js
+++ b/test/flickr.photosets.comments.deleteComment.js
@@ -14,7 +14,9 @@ describe('flickr.photosets.comments.deleteComment', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.comments.deleteComment({ comment_id: '_' });
+		var req = flickr.photosets.comments.deleteComment({
+			comment_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.comments.editComment.js
+++ b/test/flickr.photosets.comments.editComment.js
@@ -6,7 +6,9 @@ describe('flickr.photosets.comments.editComment', function () {
 	it('requires "comment_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.comments.editComment({ comment_text: '_' });
+			flickr.photosets.comments.editComment({
+				comment_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "comment_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photosets.comments.editComment', function () {
 	it('requires "comment_text"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.comments.editComment({ comment_id: '_' });
+			flickr.photosets.comments.editComment({
+				comment_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "comment_text"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photosets.comments.editComment', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.comments.editComment({ comment_id: '_', comment_text: '_' });
+		var req = flickr.photosets.comments.editComment({
+			comment_id: '_',
+			comment_text: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.comments.getList.js
+++ b/test/flickr.photosets.comments.getList.js
@@ -14,7 +14,9 @@ describe('flickr.photosets.comments.getList', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.comments.getList({ photoset_id: '_' });
+		var req = flickr.photosets.comments.getList({
+			photoset_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.create.js
+++ b/test/flickr.photosets.create.js
@@ -6,7 +6,9 @@ describe('flickr.photosets.create', function () {
 	it('requires "title"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.create({ primary_photo_id: '_' });
+			flickr.photosets.create({
+				primary_photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "title"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photosets.create', function () {
 	it('requires "primary_photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.create({ title: '_' });
+			flickr.photosets.create({
+				title: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "primary_photo_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photosets.create', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.create({ title: '_', primary_photo_id: '_' });
+		var req = flickr.photosets.create({
+			title: '_',
+			primary_photo_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.delete.js
+++ b/test/flickr.photosets.delete.js
@@ -14,7 +14,9 @@ describe('flickr.photosets.delete', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.delete({ photoset_id: '_' });
+		var req = flickr.photosets.delete({
+			photoset_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.editMeta.js
+++ b/test/flickr.photosets.editMeta.js
@@ -6,7 +6,9 @@ describe('flickr.photosets.editMeta', function () {
 	it('requires "photoset_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.editMeta({ title: '_' });
+			flickr.photosets.editMeta({
+				title: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photoset_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photosets.editMeta', function () {
 	it('requires "title"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.editMeta({ photoset_id: '_' });
+			flickr.photosets.editMeta({
+				photoset_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "title"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photosets.editMeta', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.editMeta({ photoset_id: '_', title: '_' });
+		var req = flickr.photosets.editMeta({
+			photoset_id: '_',
+			title: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.editPhotos.js
+++ b/test/flickr.photosets.editPhotos.js
@@ -6,7 +6,10 @@ describe('flickr.photosets.editPhotos', function () {
 	it('requires "photoset_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.editPhotos({ primary_photo_id: '_', photo_ids: '_' });
+			flickr.photosets.editPhotos({
+				primary_photo_id: '_',
+				photo_ids: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photoset_id"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.photosets.editPhotos', function () {
 	it('requires "primary_photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.editPhotos({ photoset_id: '_', photo_ids: '_' });
+			flickr.photosets.editPhotos({
+				photoset_id: '_',
+				photo_ids: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "primary_photo_id"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.photosets.editPhotos', function () {
 	it('requires "photo_ids"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.editPhotos({ photoset_id: '_', primary_photo_id: '_' });
+			flickr.photosets.editPhotos({
+				photoset_id: '_',
+				primary_photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_ids"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.photosets.editPhotos', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.editPhotos({ photoset_id: '_', primary_photo_id: '_', photo_ids: '_' });
+		var req = flickr.photosets.editPhotos({
+			photoset_id: '_',
+			primary_photo_id: '_',
+			photo_ids: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.getContext.js
+++ b/test/flickr.photosets.getContext.js
@@ -6,7 +6,9 @@ describe('flickr.photosets.getContext', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.getContext({ photoset_id: '_' });
+			flickr.photosets.getContext({
+				photoset_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photosets.getContext', function () {
 	it('requires "photoset_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.getContext({ photo_id: '_' });
+			flickr.photosets.getContext({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photoset_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photosets.getContext', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.getContext({ photo_id: '_', photoset_id: '_' });
+		var req = flickr.photosets.getContext({
+			photo_id: '_',
+			photoset_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.getInfo.js
+++ b/test/flickr.photosets.getInfo.js
@@ -6,7 +6,9 @@ describe('flickr.photosets.getInfo', function () {
 	it('requires "photoset_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.getInfo({ user_id: '_' });
+			flickr.photosets.getInfo({
+				user_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photoset_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photosets.getInfo', function () {
 	it('requires "user_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.getInfo({ photoset_id: '_' });
+			flickr.photosets.getInfo({
+				photoset_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "user_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photosets.getInfo', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.getInfo({ photoset_id: '_', user_id: '_' });
+		var req = flickr.photosets.getInfo({
+			photoset_id: '_',
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.getPhotos.js
+++ b/test/flickr.photosets.getPhotos.js
@@ -6,7 +6,9 @@ describe('flickr.photosets.getPhotos', function () {
 	it('requires "photoset_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.getPhotos({ user_id: '_' });
+			flickr.photosets.getPhotos({
+				user_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photoset_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photosets.getPhotos', function () {
 	it('requires "user_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.getPhotos({ photoset_id: '_' });
+			flickr.photosets.getPhotos({
+				photoset_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "user_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photosets.getPhotos', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.getPhotos({ photoset_id: '_', user_id: '_' });
+		var req = flickr.photosets.getPhotos({
+			photoset_id: '_',
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.orderSets.js
+++ b/test/flickr.photosets.orderSets.js
@@ -14,7 +14,9 @@ describe('flickr.photosets.orderSets', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.orderSets({ photoset_ids: '_' });
+		var req = flickr.photosets.orderSets({
+			photoset_ids: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.removePhoto.js
+++ b/test/flickr.photosets.removePhoto.js
@@ -6,7 +6,9 @@ describe('flickr.photosets.removePhoto', function () {
 	it('requires "photoset_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.removePhoto({ photo_id: '_' });
+			flickr.photosets.removePhoto({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photoset_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photosets.removePhoto', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.removePhoto({ photoset_id: '_' });
+			flickr.photosets.removePhoto({
+				photoset_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photosets.removePhoto', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.removePhoto({ photoset_id: '_', photo_id: '_' });
+		var req = flickr.photosets.removePhoto({
+			photoset_id: '_',
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.removePhotos.js
+++ b/test/flickr.photosets.removePhotos.js
@@ -6,7 +6,9 @@ describe('flickr.photosets.removePhotos', function () {
 	it('requires "photoset_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.removePhotos({ photo_ids: '_' });
+			flickr.photosets.removePhotos({
+				photo_ids: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photoset_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photosets.removePhotos', function () {
 	it('requires "photo_ids"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.removePhotos({ photoset_id: '_' });
+			flickr.photosets.removePhotos({
+				photoset_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_ids"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photosets.removePhotos', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.removePhotos({ photoset_id: '_', photo_ids: '_' });
+		var req = flickr.photosets.removePhotos({
+			photoset_id: '_',
+			photo_ids: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.reorderPhotos.js
+++ b/test/flickr.photosets.reorderPhotos.js
@@ -6,7 +6,9 @@ describe('flickr.photosets.reorderPhotos', function () {
 	it('requires "photoset_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.reorderPhotos({ photo_ids: '_' });
+			flickr.photosets.reorderPhotos({
+				photo_ids: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photoset_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photosets.reorderPhotos', function () {
 	it('requires "photo_ids"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.reorderPhotos({ photoset_id: '_' });
+			flickr.photosets.reorderPhotos({
+				photoset_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_ids"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photosets.reorderPhotos', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.reorderPhotos({ photoset_id: '_', photo_ids: '_' });
+		var req = flickr.photosets.reorderPhotos({
+			photoset_id: '_',
+			photo_ids: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.photosets.setPrimaryPhoto.js
+++ b/test/flickr.photosets.setPrimaryPhoto.js
@@ -6,7 +6,9 @@ describe('flickr.photosets.setPrimaryPhoto', function () {
 	it('requires "photoset_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.setPrimaryPhoto({ photo_id: '_' });
+			flickr.photosets.setPrimaryPhoto({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photoset_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.photosets.setPrimaryPhoto', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.photosets.setPrimaryPhoto({ photoset_id: '_' });
+			flickr.photosets.setPrimaryPhoto({
+				photoset_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.photosets.setPrimaryPhoto', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.photosets.setPrimaryPhoto({ photoset_id: '_', photo_id: '_' });
+		var req = flickr.photosets.setPrimaryPhoto({
+			photoset_id: '_',
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.places.find.js
+++ b/test/flickr.places.find.js
@@ -14,7 +14,9 @@ describe('flickr.places.find', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.places.find({ query: '_' });
+		var req = flickr.places.find({
+			query: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.places.findByLatLon.js
+++ b/test/flickr.places.findByLatLon.js
@@ -6,7 +6,9 @@ describe('flickr.places.findByLatLon', function () {
 	it('requires "lat"', function () {
 
 		assert.throws(function () {
-			flickr.places.findByLatLon({ lon: '_' });
+			flickr.places.findByLatLon({
+				lon: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "lat"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.places.findByLatLon', function () {
 	it('requires "lon"', function () {
 
 		assert.throws(function () {
-			flickr.places.findByLatLon({ lat: '_' });
+			flickr.places.findByLatLon({
+				lat: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "lon"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.places.findByLatLon', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.places.findByLatLon({ lat: '_', lon: '_' });
+		var req = flickr.places.findByLatLon({
+			lat: '_',
+			lon: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.places.getInfoByUrl.js
+++ b/test/flickr.places.getInfoByUrl.js
@@ -14,7 +14,9 @@ describe('flickr.places.getInfoByUrl', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.places.getInfoByUrl({ url: '_' });
+		var req = flickr.places.getInfoByUrl({
+			url: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.places.getTopPlacesList.js
+++ b/test/flickr.places.getTopPlacesList.js
@@ -14,7 +14,9 @@ describe('flickr.places.getTopPlacesList', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.places.getTopPlacesList({ place_type_id: '_' });
+		var req = flickr.places.getTopPlacesList({
+			place_type_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.places.placesForBoundingBox.js
+++ b/test/flickr.places.placesForBoundingBox.js
@@ -14,7 +14,9 @@ describe('flickr.places.placesForBoundingBox', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.places.placesForBoundingBox({ bbox: '_' });
+		var req = flickr.places.placesForBoundingBox({
+			bbox: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.places.placesForTags.js
+++ b/test/flickr.places.placesForTags.js
@@ -14,7 +14,9 @@ describe('flickr.places.placesForTags', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.places.placesForTags({ place_type_id: '_' });
+		var req = flickr.places.placesForTags({
+			place_type_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.places.resolvePlaceId.js
+++ b/test/flickr.places.resolvePlaceId.js
@@ -14,7 +14,9 @@ describe('flickr.places.resolvePlaceId', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.places.resolvePlaceId({ place_id: '_' });
+		var req = flickr.places.resolvePlaceId({
+			place_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.places.resolvePlaceURL.js
+++ b/test/flickr.places.resolvePlaceURL.js
@@ -14,7 +14,9 @@ describe('flickr.places.resolvePlaceURL', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.places.resolvePlaceURL({ url: '_' });
+		var req = flickr.places.resolvePlaceURL({
+			url: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.profile.getProfile.js
+++ b/test/flickr.profile.getProfile.js
@@ -14,7 +14,9 @@ describe('flickr.profile.getProfile', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.profile.getProfile({ user_id: '_' });
+		var req = flickr.profile.getProfile({
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.push.subscribe.js
+++ b/test/flickr.push.subscribe.js
@@ -6,7 +6,10 @@ describe('flickr.push.subscribe', function () {
 	it('requires "topic"', function () {
 
 		assert.throws(function () {
-			flickr.push.subscribe({ callback: '_', verify: '_' });
+			flickr.push.subscribe({
+				callback: '_',
+				verify: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "topic"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.push.subscribe', function () {
 	it('requires "callback"', function () {
 
 		assert.throws(function () {
-			flickr.push.subscribe({ topic: '_', verify: '_' });
+			flickr.push.subscribe({
+				topic: '_',
+				verify: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "callback"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.push.subscribe', function () {
 	it('requires "verify"', function () {
 
 		assert.throws(function () {
-			flickr.push.subscribe({ topic: '_', callback: '_' });
+			flickr.push.subscribe({
+				topic: '_',
+				callback: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "verify"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.push.subscribe', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.push.subscribe({ topic: '_', callback: '_', verify: '_' });
+		var req = flickr.push.subscribe({
+			topic: '_',
+			callback: '_',
+			verify: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.push.unsubscribe.js
+++ b/test/flickr.push.unsubscribe.js
@@ -6,7 +6,10 @@ describe('flickr.push.unsubscribe', function () {
 	it('requires "topic"', function () {
 
 		assert.throws(function () {
-			flickr.push.unsubscribe({ callback: '_', verify: '_' });
+			flickr.push.unsubscribe({
+				callback: '_',
+				verify: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "topic"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.push.unsubscribe', function () {
 	it('requires "callback"', function () {
 
 		assert.throws(function () {
-			flickr.push.unsubscribe({ topic: '_', verify: '_' });
+			flickr.push.unsubscribe({
+				topic: '_',
+				verify: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "callback"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.push.unsubscribe', function () {
 	it('requires "verify"', function () {
 
 		assert.throws(function () {
-			flickr.push.unsubscribe({ topic: '_', callback: '_' });
+			flickr.push.unsubscribe({
+				topic: '_',
+				callback: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "verify"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.push.unsubscribe', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.push.unsubscribe({ topic: '_', callback: '_', verify: '_' });
+		var req = flickr.push.unsubscribe({
+			topic: '_',
+			callback: '_',
+			verify: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.reflection.getMethodInfo.js
+++ b/test/flickr.reflection.getMethodInfo.js
@@ -14,7 +14,9 @@ describe('flickr.reflection.getMethodInfo', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.reflection.getMethodInfo({ method_name: '_' });
+		var req = flickr.reflection.getMethodInfo({
+			method_name: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.stats.getCollectionDomains.js
+++ b/test/flickr.stats.getCollectionDomains.js
@@ -14,7 +14,9 @@ describe('flickr.stats.getCollectionDomains', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.stats.getCollectionDomains({ date: '_' });
+		var req = flickr.stats.getCollectionDomains({
+			date: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.stats.getCollectionReferrers.js
+++ b/test/flickr.stats.getCollectionReferrers.js
@@ -6,7 +6,9 @@ describe('flickr.stats.getCollectionReferrers', function () {
 	it('requires "date"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getCollectionReferrers({ domain: '_' });
+			flickr.stats.getCollectionReferrers({
+				domain: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "date"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.stats.getCollectionReferrers', function () {
 	it('requires "domain"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getCollectionReferrers({ date: '_' });
+			flickr.stats.getCollectionReferrers({
+				date: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "domain"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.stats.getCollectionReferrers', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.stats.getCollectionReferrers({ date: '_', domain: '_' });
+		var req = flickr.stats.getCollectionReferrers({
+			date: '_',
+			domain: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.stats.getCollectionStats.js
+++ b/test/flickr.stats.getCollectionStats.js
@@ -6,7 +6,9 @@ describe('flickr.stats.getCollectionStats', function () {
 	it('requires "date"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getCollectionStats({ collection_id: '_' });
+			flickr.stats.getCollectionStats({
+				collection_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "date"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.stats.getCollectionStats', function () {
 	it('requires "collection_id"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getCollectionStats({ date: '_' });
+			flickr.stats.getCollectionStats({
+				date: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "collection_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.stats.getCollectionStats', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.stats.getCollectionStats({ date: '_', collection_id: '_' });
+		var req = flickr.stats.getCollectionStats({
+			date: '_',
+			collection_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.stats.getPhotoDomains.js
+++ b/test/flickr.stats.getPhotoDomains.js
@@ -14,7 +14,9 @@ describe('flickr.stats.getPhotoDomains', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.stats.getPhotoDomains({ date: '_' });
+		var req = flickr.stats.getPhotoDomains({
+			date: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.stats.getPhotoReferrers.js
+++ b/test/flickr.stats.getPhotoReferrers.js
@@ -6,7 +6,9 @@ describe('flickr.stats.getPhotoReferrers', function () {
 	it('requires "date"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getPhotoReferrers({ domain: '_' });
+			flickr.stats.getPhotoReferrers({
+				domain: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "date"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.stats.getPhotoReferrers', function () {
 	it('requires "domain"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getPhotoReferrers({ date: '_' });
+			flickr.stats.getPhotoReferrers({
+				date: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "domain"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.stats.getPhotoReferrers', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.stats.getPhotoReferrers({ date: '_', domain: '_' });
+		var req = flickr.stats.getPhotoReferrers({
+			date: '_',
+			domain: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.stats.getPhotoStats.js
+++ b/test/flickr.stats.getPhotoStats.js
@@ -6,7 +6,9 @@ describe('flickr.stats.getPhotoStats', function () {
 	it('requires "date"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getPhotoStats({ photo_id: '_' });
+			flickr.stats.getPhotoStats({
+				photo_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "date"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.stats.getPhotoStats', function () {
 	it('requires "photo_id"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getPhotoStats({ date: '_' });
+			flickr.stats.getPhotoStats({
+				date: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photo_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.stats.getPhotoStats', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.stats.getPhotoStats({ date: '_', photo_id: '_' });
+		var req = flickr.stats.getPhotoStats({
+			date: '_',
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.stats.getPhotosetDomains.js
+++ b/test/flickr.stats.getPhotosetDomains.js
@@ -14,7 +14,9 @@ describe('flickr.stats.getPhotosetDomains', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.stats.getPhotosetDomains({ date: '_' });
+		var req = flickr.stats.getPhotosetDomains({
+			date: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.stats.getPhotosetReferrers.js
+++ b/test/flickr.stats.getPhotosetReferrers.js
@@ -6,7 +6,9 @@ describe('flickr.stats.getPhotosetReferrers', function () {
 	it('requires "date"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getPhotosetReferrers({ domain: '_' });
+			flickr.stats.getPhotosetReferrers({
+				domain: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "date"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.stats.getPhotosetReferrers', function () {
 	it('requires "domain"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getPhotosetReferrers({ date: '_' });
+			flickr.stats.getPhotosetReferrers({
+				date: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "domain"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.stats.getPhotosetReferrers', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.stats.getPhotosetReferrers({ date: '_', domain: '_' });
+		var req = flickr.stats.getPhotosetReferrers({
+			date: '_',
+			domain: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.stats.getPhotosetStats.js
+++ b/test/flickr.stats.getPhotosetStats.js
@@ -6,7 +6,9 @@ describe('flickr.stats.getPhotosetStats', function () {
 	it('requires "date"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getPhotosetStats({ photoset_id: '_' });
+			flickr.stats.getPhotosetStats({
+				photoset_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "date"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.stats.getPhotosetStats', function () {
 	it('requires "photoset_id"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getPhotosetStats({ date: '_' });
+			flickr.stats.getPhotosetStats({
+				date: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "photoset_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.stats.getPhotosetStats', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.stats.getPhotosetStats({ date: '_', photoset_id: '_' });
+		var req = flickr.stats.getPhotosetStats({
+			date: '_',
+			photoset_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.stats.getPhotostreamDomains.js
+++ b/test/flickr.stats.getPhotostreamDomains.js
@@ -14,7 +14,9 @@ describe('flickr.stats.getPhotostreamDomains', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.stats.getPhotostreamDomains({ date: '_' });
+		var req = flickr.stats.getPhotostreamDomains({
+			date: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.stats.getPhotostreamReferrers.js
+++ b/test/flickr.stats.getPhotostreamReferrers.js
@@ -6,7 +6,9 @@ describe('flickr.stats.getPhotostreamReferrers', function () {
 	it('requires "date"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getPhotostreamReferrers({ domain: '_' });
+			flickr.stats.getPhotostreamReferrers({
+				domain: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "date"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.stats.getPhotostreamReferrers', function () {
 	it('requires "domain"', function () {
 
 		assert.throws(function () {
-			flickr.stats.getPhotostreamReferrers({ date: '_' });
+			flickr.stats.getPhotostreamReferrers({
+				date: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "domain"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.stats.getPhotostreamReferrers', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.stats.getPhotostreamReferrers({ date: '_', domain: '_' });
+		var req = flickr.stats.getPhotostreamReferrers({
+			date: '_',
+			domain: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.stats.getPhotostreamStats.js
+++ b/test/flickr.stats.getPhotostreamStats.js
@@ -14,7 +14,9 @@ describe('flickr.stats.getPhotostreamStats', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.stats.getPhotostreamStats({ date: '_' });
+		var req = flickr.stats.getPhotostreamStats({
+			date: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.tags.getClusterPhotos.js
+++ b/test/flickr.tags.getClusterPhotos.js
@@ -6,7 +6,9 @@ describe('flickr.tags.getClusterPhotos', function () {
 	it('requires "tag"', function () {
 
 		assert.throws(function () {
-			flickr.tags.getClusterPhotos({ cluster_id: '_' });
+			flickr.tags.getClusterPhotos({
+				cluster_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "tag"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.tags.getClusterPhotos', function () {
 	it('requires "cluster_id"', function () {
 
 		assert.throws(function () {
-			flickr.tags.getClusterPhotos({ tag: '_' });
+			flickr.tags.getClusterPhotos({
+				tag: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "cluster_id"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.tags.getClusterPhotos', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.tags.getClusterPhotos({ tag: '_', cluster_id: '_' });
+		var req = flickr.tags.getClusterPhotos({
+			tag: '_',
+			cluster_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.tags.getClusters.js
+++ b/test/flickr.tags.getClusters.js
@@ -14,7 +14,9 @@ describe('flickr.tags.getClusters', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.tags.getClusters({ tag: '_' });
+		var req = flickr.tags.getClusters({
+			tag: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.tags.getListPhoto.js
+++ b/test/flickr.tags.getListPhoto.js
@@ -14,7 +14,9 @@ describe('flickr.tags.getListPhoto', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.tags.getListPhoto({ photo_id: '_' });
+		var req = flickr.tags.getListPhoto({
+			photo_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.tags.getRelated.js
+++ b/test/flickr.tags.getRelated.js
@@ -14,7 +14,9 @@ describe('flickr.tags.getRelated', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.tags.getRelated({ tag: '_' });
+		var req = flickr.tags.getRelated({
+			tag: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.testimonials.addTestimonial.js
+++ b/test/flickr.testimonials.addTestimonial.js
@@ -6,7 +6,9 @@ describe('flickr.testimonials.addTestimonial', function () {
 	it('requires "user_id"', function () {
 
 		assert.throws(function () {
-			flickr.testimonials.addTestimonial({ testimonial_text: '_' });
+			flickr.testimonials.addTestimonial({
+				testimonial_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "user_id"';
 		});
@@ -16,7 +18,9 @@ describe('flickr.testimonials.addTestimonial', function () {
 	it('requires "testimonial_text"', function () {
 
 		assert.throws(function () {
-			flickr.testimonials.addTestimonial({ user_id: '_' });
+			flickr.testimonials.addTestimonial({
+				user_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "testimonial_text"';
 		});
@@ -24,7 +28,10 @@ describe('flickr.testimonials.addTestimonial', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.testimonials.addTestimonial({ user_id: '_', testimonial_text: '_' });
+		var req = flickr.testimonials.addTestimonial({
+			user_id: '_',
+			testimonial_text: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.testimonials.approveTestimonial.js
+++ b/test/flickr.testimonials.approveTestimonial.js
@@ -14,7 +14,9 @@ describe('flickr.testimonials.approveTestimonial', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.testimonials.approveTestimonial({ testimonial_id: '_' });
+		var req = flickr.testimonials.approveTestimonial({
+			testimonial_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.testimonials.deleteTestimonial.js
+++ b/test/flickr.testimonials.deleteTestimonial.js
@@ -14,7 +14,9 @@ describe('flickr.testimonials.deleteTestimonial', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.testimonials.deleteTestimonial({ testimonial_id: '_' });
+		var req = flickr.testimonials.deleteTestimonial({
+			testimonial_id: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.testimonials.editTestimonial.js
+++ b/test/flickr.testimonials.editTestimonial.js
@@ -6,7 +6,10 @@ describe('flickr.testimonials.editTestimonial', function () {
 	it('requires "user_id"', function () {
 
 		assert.throws(function () {
-			flickr.testimonials.editTestimonial({ testimonial_id: '_', testimonial_text: '_' });
+			flickr.testimonials.editTestimonial({
+				testimonial_id: '_',
+				testimonial_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "user_id"';
 		});
@@ -16,7 +19,10 @@ describe('flickr.testimonials.editTestimonial', function () {
 	it('requires "testimonial_id"', function () {
 
 		assert.throws(function () {
-			flickr.testimonials.editTestimonial({ user_id: '_', testimonial_text: '_' });
+			flickr.testimonials.editTestimonial({
+				user_id: '_',
+				testimonial_text: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "testimonial_id"';
 		});
@@ -26,7 +32,10 @@ describe('flickr.testimonials.editTestimonial', function () {
 	it('requires "testimonial_text"', function () {
 
 		assert.throws(function () {
-			flickr.testimonials.editTestimonial({ user_id: '_', testimonial_id: '_' });
+			flickr.testimonials.editTestimonial({
+				user_id: '_',
+				testimonial_id: '_'
+			});
 		}, function (err) {
 			return err.message === 'Missing required argument "testimonial_text"';
 		});
@@ -34,7 +43,11 @@ describe('flickr.testimonials.editTestimonial', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.testimonials.editTestimonial({ user_id: '_', testimonial_id: '_', testimonial_text: '_' });
+		var req = flickr.testimonials.editTestimonial({
+			user_id: '_',
+			testimonial_id: '_',
+			testimonial_text: '_'
+		});
 
 		assert.equal(req.method, 'POST');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.testimonials.getTestimonialsAbout.js
+++ b/test/flickr.testimonials.getTestimonialsAbout.js
@@ -14,7 +14,9 @@ describe('flickr.testimonials.getTestimonialsAbout', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.testimonials.getTestimonialsAbout({ user_id: '_' });
+		var req = flickr.testimonials.getTestimonialsAbout({
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.testimonials.getTestimonialsBy.js
+++ b/test/flickr.testimonials.getTestimonialsBy.js
@@ -14,7 +14,9 @@ describe('flickr.testimonials.getTestimonialsBy', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.testimonials.getTestimonialsBy({ user_id: '_' });
+		var req = flickr.testimonials.getTestimonialsBy({
+			user_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.urls.getGroup.js
+++ b/test/flickr.urls.getGroup.js
@@ -14,7 +14,9 @@ describe('flickr.urls.getGroup', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.urls.getGroup({ group_id: '_' });
+		var req = flickr.urls.getGroup({
+			group_id: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.urls.lookupGallery.js
+++ b/test/flickr.urls.lookupGallery.js
@@ -14,7 +14,9 @@ describe('flickr.urls.lookupGallery', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.urls.lookupGallery({ url: '_' });
+		var req = flickr.urls.lookupGallery({
+			url: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.urls.lookupGroup.js
+++ b/test/flickr.urls.lookupGroup.js
@@ -14,7 +14,9 @@ describe('flickr.urls.lookupGroup', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.urls.lookupGroup({ url: '_' });
+		var req = flickr.urls.lookupGroup({
+			url: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/flickr.urls.lookupUser.js
+++ b/test/flickr.urls.lookupUser.js
@@ -14,7 +14,9 @@ describe('flickr.urls.lookupUser', function () {
 	});
 
 	it('returns a Request instance', function () {
-		var req = flickr.urls.lookupUser({ url: '_' });
+		var req = flickr.urls.lookupUser({
+			url: '_'
+		});
 
 		assert.equal(req.method, 'GET');
 		assert.equal(req.url, 'https://api.flickr.com/services/rest');

--- a/test/plugins.api-key.js
+++ b/test/plugins.api-key.js
@@ -23,26 +23,26 @@ describe('plugins/api-key', function () {
 
 	it('signs an api call', function () {
 		var api = nock('https://api.flickr.com')
-		.get('/services/rest')
-		.query({
-			api_key: 'api key',
-			method: 'flickr.test.echo',
-			foo: 'bar',
-			format: 'json',
-			nojsoncallback: '1'
-		})
-		.reply(200, {
-			stat: 'ok'
-		});
+			.get('/services/rest')
+			.query({
+				api_key: 'api key',
+				method: 'flickr.test.echo',
+				foo: 'bar',
+				format: 'json',
+				nojsoncallback: '1'
+			})
+			.reply(200, {
+				stat: 'ok'
+			});
 
 		var flickr = new Flickr(subject('api key'));
 
 		return flickr.test.echo({ foo: 'bar' })
-		.then(function (res) {
-			assert(api.isDone(), 'Expected mock to have been called');
-			assert.equal(res.statusCode, 200);
-			assert.equal(res.body.stat, 'ok');
-		});
+			.then(function (res) {
+				assert(api.isDone(), 'Expected mock to have been called');
+				assert.equal(res.statusCode, 200);
+				assert.equal(res.body.stat, 'ok');
+			});
 
 	});
 

--- a/test/plugins.json.js
+++ b/test/plugins.json.js
@@ -7,35 +7,35 @@ describe('plugins/json', function () {
 
 	function createMockResponse() {
 		return nock('https://api.flickr.com')
-		.get('/services/rest')
-		.query({
-			format: 'json',
-			nojsoncallback: 1
-		});
+			.get('/services/rest')
+			.query({
+				format: 'json',
+				nojsoncallback: 1
+			});
 	}
 
 	it('parses a json response', function () {
 		var api = createMockResponse().reply(200, '{"stat":"ok"}');
 
 		return request('GET', 'https://api.flickr.com/services/rest')
-		.use(subject)
-		.then(function (res) {
-			assert(api.isDone(), 'Expected mock to have been called');
-			assert.deepEqual(res.body, { stat: 'ok' });
-		});
+			.use(subject)
+			.then(function (res) {
+				assert(api.isDone(), 'Expected mock to have been called');
+				assert.deepEqual(res.body, { stat: 'ok' });
+			});
 	});
 
 	it('yields a SyntaxError if JSON parsing fails', function () {
 		var api = createMockResponse().reply(200, '{');
 
 		return request('GET', 'https://api.flickr.com/services/rest')
-		.use(subject)
-		.then(function () {
-			throw new Error('Expected errback');
-		}, function (err) {
-			assert(api.isDone(), 'Expected mock to have been called');
-			assert.equal(err.name, 'SyntaxError');
-		});
+			.use(subject)
+			.then(function () {
+				throw new Error('Expected errback');
+			}, function (err) {
+				assert(api.isDone(), 'Expected mock to have been called');
+				assert.equal(err.name, 'SyntaxError');
+			});
 
 	});
 
@@ -47,14 +47,14 @@ describe('plugins/json', function () {
 		});
 
 		return request('GET', 'https://api.flickr.com/services/rest')
-		.use(subject)
-		.then(function () {
-			throw new Error('Expected errback');
-		}, function (err) {
-			assert(api.isDone(), 'Expected mock to have been called');
-			assert.equal(err.message, 'Invalid API Key (Key has invalid format)');
-			assert.equal(err.code, 100);
-		});
+			.use(subject)
+			.then(function () {
+				throw new Error('Expected errback');
+			}, function (err) {
+				assert(api.isDone(), 'Expected mock to have been called');
+				assert.equal(err.message, 'Invalid API Key (Key has invalid format)');
+				assert.equal(err.code, 100);
+			});
 
 	});
 

--- a/test/plugins.oauth.js
+++ b/test/plugins.oauth.js
@@ -20,31 +20,31 @@ describe('plugins/oauth', function () {
 
 	it('signs an api call', function () {
 		var api = nock('https://api.flickr.com')
-		.get('/services/rest')
-		.query({
-			oauth_nonce: 'p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k=',
-			oauth_consumer_key: 'consumer key',
-			oauth_token: 'oauth token',
-			oauth_version: '1.0',
-			oauth_timestamp: 499166400,
-			oauth_signature_method: 'HMAC-SHA1',
-			oauth_signature: '5WSz6hwZ6F8jbeYv3eyErif1ySo=',
-			method: 'flickr.test.echo',
-			foo: 'bar',
-			format: 'json',
-			nojsoncallback: '1'
-		})
-		.reply(200, {stat: 'ok'});
+			.get('/services/rest')
+			.query({
+				oauth_nonce: 'p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k=',
+				oauth_consumer_key: 'consumer key',
+				oauth_token: 'oauth token',
+				oauth_version: '1.0',
+				oauth_timestamp: 499166400,
+				oauth_signature_method: 'HMAC-SHA1',
+				oauth_signature: '5WSz6hwZ6F8jbeYv3eyErif1ySo=',
+				method: 'flickr.test.echo',
+				foo: 'bar',
+				format: 'json',
+				nojsoncallback: '1'
+			})
+			.reply(200, {stat: 'ok'});
 
 		var flickr = new Flickr(subject('consumer key', 'consumer secret', 'oauth token', 'oauth token secret'));
 
 		return flickr.test.echo()
-		.query({ foo: 'bar' })
-		.then(function (res) {
-			assert(api.isDone(), 'Expected mock to have been called');
-			assert.equal(res.statusCode, 200);
-			assert.equal(res.body.stat, 'ok');
-		});
+			.query({ foo: 'bar' })
+			.then(function (res) {
+				assert(api.isDone(), 'Expected mock to have been called');
+				assert.equal(res.statusCode, 200);
+				assert.equal(res.body.stat, 'ok');
+			});
 
 	});
 

--- a/test/services.oauth.js
+++ b/test/services.oauth.js
@@ -23,17 +23,17 @@ describe('services/oauth', function () {
 
 		it('makes the correct API call', function () {
 			var api = nock('https://www.flickr.com')
-			.get('/services/oauth/request_token')
-			.query({
-				oauth_nonce: 'p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k=',
-				oauth_timestamp: 499166400,
-				oauth_consumer_key: subject.consumerKey,
-				oauth_signature_method: 'HMAC-SHA1',
-				oauth_version: '1.0',
-				oauth_callback: 'https://www.example.com/callback',
-				oauth_signature: 'JC6IWgvysQg30vh3Xk6TjARQWps='
-			})
-			.reply(200, 'oauth_callback_confirmed=true&oauth_token=foo&oauth_token_secret=bar');
+				.get('/services/oauth/request_token')
+				.query({
+					oauth_nonce: 'p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k=',
+					oauth_timestamp: 499166400,
+					oauth_consumer_key: subject.consumerKey,
+					oauth_signature_method: 'HMAC-SHA1',
+					oauth_version: '1.0',
+					oauth_callback: 'https://www.example.com/callback',
+					oauth_signature: 'JC6IWgvysQg30vh3Xk6TjARQWps='
+				})
+				.reply(200, 'oauth_callback_confirmed=true&oauth_token=foo&oauth_token_secret=bar');
 
 			return subject.request('https://www.example.com/callback').then(function (res) {
 				assert(api.isDone());
@@ -91,18 +91,18 @@ describe('services/oauth', function () {
 
 		it('makes the correct API call', function () {
 			var api = nock('https://www.flickr.com')
-			.get('/services/oauth/access_token')
-			.query({
-				oauth_token: 'token',
-				oauth_verifier: 'verfier',
-				oauth_nonce: 'p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k=',
-				oauth_timestamp: 499166400,
-				oauth_consumer_key: subject.consumerKey,
-				oauth_signature_method: 'HMAC-SHA1',
-				oauth_version: '1.0',
-				oauth_signature: '7+3k1AWzUyxOoNO4rymh0Txz5FA='
-			})
-			.reply(200, 'fullname=Jamal%20Fanaian&oauth_token=foo&oauth_token_secret=bar&user_nsid=21207597%40N07&username=jamalfanaian');
+				.get('/services/oauth/access_token')
+				.query({
+					oauth_token: 'token',
+					oauth_verifier: 'verfier',
+					oauth_nonce: 'p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k=',
+					oauth_timestamp: 499166400,
+					oauth_consumer_key: subject.consumerKey,
+					oauth_signature_method: 'HMAC-SHA1',
+					oauth_version: '1.0',
+					oauth_signature: '7+3k1AWzUyxOoNO4rymh0Txz5FA='
+				})
+				.reply(200, 'fullname=Jamal%20Fanaian&oauth_token=foo&oauth_token_secret=bar&user_nsid=21207597%40N07&username=jamalfanaian');
 
 			return subject.verify('token', 'verfier', 'tokenSecret').then(function (res) {
 				assert(api.isDone());


### PR DESCRIPTION
The latest version of eslint's [indent rule is much more strict][1] that the current one we use. We're mostly compliant, but this fixes indentation violations around the repo, including in generated files like services/rest.js and the rest API method tests.

[1]: http://eslint.org/docs/user-guide/migrating-to-4.0.0#-the-indent-rule-is-more-strict