### PR TITLE
All constructors should allow instance creation without "new"

### DIFF
--- a/services/feeds.js
+++ b/services/feeds.js
@@ -22,6 +22,12 @@ var validate = require('../lib/validate');
  */
 
 function Feeds(args) {
+
+	// allow creating a client without `new`
+	if (!(this instanceof Feeds)) {
+		return new Feeds(args);
+	}
+
 	// default arguments
 	this._args = Object.assign({ format: 'json', nojsoncallback: 1 }, args);
 }

--- a/services/oauth.js
+++ b/services/oauth.js
@@ -28,12 +28,19 @@ var oauth = require('../plugins/oauth');
  */
 
 function OAuth(consumerKey, consumerSecret) {
+
+	// allow creating a client without `new`
+	if (!(this instanceof OAuth)) {
+		return new OAuth(consumerKey, consumerSecret);
+	}
+
 	if (!consumerKey) {
 		throw new Error('Missing required argument "consumerKey"');
 	}
 	if (!consumerSecret) {
 		throw new Error('Missing required argument "consumerSecret"');
 	}
+
 	this.consumerKey = consumerKey;
 	this.consumerSecret = consumerSecret;
 }

--- a/services/replace.js
+++ b/services/replace.js
@@ -38,6 +38,12 @@ var Request = require('../lib/request').Request;
  */
 
 function Replace(auth, photoID, file, args) {
+
+	// allow creating a client without `new`
+	if (!(this instanceof Replace)) {
+		return new Replace(auth, photoID, file, args);
+	}
+
 	Request.call(this, 'POST', 'https://up.flickr.com/services/replace');
 
 	if (typeof auth !== 'function') {

--- a/services/upload.js
+++ b/services/upload.js
@@ -37,6 +37,12 @@ var Request = require('../lib/request').Request;
  */
 
 function Upload(auth, file, args) {
+
+	// allow creating a client without `new`
+	if (!(this instanceof Upload)) {
+		return new Upload(auth, file, args);
+	}
+
 	Request.call(this, 'POST', 'https://up.flickr.com/services/upload');
 
 	if (typeof auth !== 'function') {

--- a/test/services.feeds.js
+++ b/test/services.feeds.js
@@ -10,6 +10,10 @@ describe('services/feeds', function () {
 		subject = new Subject();
 	});
 
+	it('does not require "new"', function () {
+		assert(Subject() instanceof Subject);
+	});
+
 	it('returns a superagent Request', function () {
 		assert(subject._('photos_public') instanceof Request);
 	});

--- a/test/services.oauth.js
+++ b/test/services.oauth.js
@@ -19,6 +19,10 @@ describe('services/oauth', function () {
 		sandbox.restore();
 	});
 
+	it('does not require "new"', function () {
+		assert(Subject('consumer key', 'consumer secret') instanceof Subject);
+	});
+
 	it('throws if required parameters are not provided', function () {
 		assert.throws(function () {
 			new Subject(); // eslint-disable-line no-new

--- a/test/services.replace.js
+++ b/test/services.replace.js
@@ -8,6 +8,10 @@ describe('services/replace', function () {
 
 	function auth() { /* noop for tests */ }
 
+	it('does not require "new"', function () {
+		assert(Subject(auth, 41234567890) instanceof Subject);
+	});
+
 	it('is a superagent Request', function () {
 		assert(new Subject(auth, 41234567890) instanceof Request);
 	});

--- a/test/services.rest.js
+++ b/test/services.rest.js
@@ -12,6 +12,10 @@ describe('services/rest', function () {
 		subject = new Subject(auth);
 	});
 
+	it('does not require "new"', function () {
+		assert(Subject(auth) instanceof Subject);
+	});
+
 	it('returns a superagent Request', function () {
 		assert(subject._('flickr.test.echo') instanceof Request);
 	});

--- a/test/services.upload.js
+++ b/test/services.upload.js
@@ -8,6 +8,10 @@ describe('services/upload', function () {
 
 	function auth() { /* noop for tests */ }
 
+	it('does not require "new"', function () {
+		assert(Subject(auth) instanceof Subject);
+	});
+
 	it('is a superagent Request', function () {
 		assert(new Subject(auth) instanceof Request);
 	});


### PR DESCRIPTION
We're already doing this for the REST service, might as well do it everywhere to be consistent.