### PR TITLE
Support passing just an API key to the REST service

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ authentication, use the [OAuth plugin](#Flickr.OAuth.createPlugin).
 **Example** *(Get info about a public photo with your API key)*  
 ```js
 
-var flickr = new Flickr(res => res.query({
+var flickr = new Flickr(req => req.query({
   api_key: process.env.FLICKR_API_KEY
 }));
 
@@ -314,7 +314,7 @@ flickr.photos.getInfo({
 **Example** *(Searching for public photos with your API key)*  
 ```js
 
-var flickr = new Flickr(res => res.query({
+var flickr = new Flickr(req => req.query({
   api_key: process.env.FLICKR_API_KEY
 }));
 

--- a/README.md
+++ b/README.md
@@ -286,22 +286,20 @@ docs for the full list of methods and their supported arguments.
 ### new Flickr(auth)
 Creates a new Flickr REST API client.
 
-You **must** pass a superagent plugin as the first parameter. For
-methods that don't require authentication, this plugin can simply
-add your API key to the request params. For methods that require
-authentication, use the [OAuth plugin](#Flickr.OAuth.createPlugin).
+You **must** pass a superagent plugin or your API key as the first
+parameter. For methods that don't require authentication, you can simply
+provide your API key. For methods that do require authentication,
+use the [OAuth plugin](#Flickr.OAuth.createPlugin).
 
 
 | Param | Type | Description |
 | --- | --- | --- |
-| auth | <code>function</code> | An authentication plugin function |
+| auth | <code>function</code> \| <code>String</code> | An authentication plugin function or an API key |
 
 **Example** *(Get info about a public photo with your API key)*  
 ```js
 
-var flickr = new Flickr(req => req.query({
-  api_key: process.env.FLICKR_API_KEY
-}));
+var flickr = new Flickr(process.env.FLICKR_API_KEY);
 
 flickr.photos.getInfo({
   photo_id: 25825763 // sorry, @dokas
@@ -314,9 +312,7 @@ flickr.photos.getInfo({
 **Example** *(Searching for public photos with your API key)*  
 ```js
 
-var flickr = new Flickr(req => req.query({
-  api_key: process.env.FLICKR_API_KEY
-}));
+var flickr = new Flickr(process.env.FLICKR_API_KEY);
 
 flickr.photos.search({
   photo_id: 25825763 // sorry, @dokas

--- a/examples/flickr.photos.getInfo.js
+++ b/examples/flickr.photos.getInfo.js
@@ -10,7 +10,7 @@ var Flickr = require('..');
 // resource that doesn't require user authentication, we can
 // simply pass our API key as a query param.
 
-var flickr = new Flickr(res => res.query({
+var flickr = new Flickr(req => req.query({
 	api_key: process.env.FLICKR_API_KEY
 }));
 

--- a/examples/flickr.photos.getInfo.js
+++ b/examples/flickr.photos.getInfo.js
@@ -8,11 +8,9 @@ var Flickr = require('..');
 
 // create a new Flickr API client. since we're requesting a
 // resource that doesn't require user authentication, we can
-// simply pass our API key as a query param.
+// just use our API key.
 
-var flickr = new Flickr(req => req.query({
-	api_key: process.env.FLICKR_API_KEY
-}));
+var flickr = new Flickr(process.env.FLICKR_API_KEY);
 
 // call the flickr.photos.getInfo API method and request photo data!
 

--- a/examples/flickr.photos.search.js
+++ b/examples/flickr.photos.search.js
@@ -10,7 +10,7 @@ var Flickr = require('..');
 // resource that doesn't require user authentication, we can
 // simply pass our API key as a query param.
 
-var flickr = new Flickr(res => res.query({
+var flickr = new Flickr(req => req.query({
 	api_key: process.env.FLICKR_API_KEY
 }));
 

--- a/examples/flickr.photos.search.js
+++ b/examples/flickr.photos.search.js
@@ -8,11 +8,9 @@ var Flickr = require('..');
 
 // create a new Flickr API client. since we're requesting a
 // resource that doesn't require user authentication, we can
-// simply pass our API key as a query param.
+// just use our API key.
 
-var flickr = new Flickr(req => req.query({
-	api_key: process.env.FLICKR_API_KEY
-}));
+var flickr = new Flickr(process.env.FLICKR_API_KEY);
 
 // call the flickr.photos.search API method and search the photos!
 

--- a/script/build-rest.ejs
+++ b/script/build-rest.ejs
@@ -8,6 +8,18 @@ var validate = require('../lib/validate');
 var json = require('../plugins/json');
 
 /**
+ * Creates a superagent plugin that simply adds api_key to
+ * the query string of every request.
+ * @param {String} str
+ * @returns {Function}
+ * @private
+ */
+
+function createAPIKeyPlugin(str) {
+	return req => req.query({ api_key: str });
+}
+
+/**
  * Creates a new Flickr API client. This "client" is a factory
  * method that creates a new superagent request pre-configured
  * for talking to the Flickr API. You must pass an "auth"
@@ -20,6 +32,11 @@ var json = require('../plugins/json');
 
 function createClient(auth, opts) {
 	var host;
+
+	// allow passing just an api key instead of a function
+	if (typeof auth === 'string') {
+		auth = createAPIKeyPlugin(auth);
+	}
 
 	if (typeof auth !== 'function') {
 		throw new Error('Missing required argument "auth"');
@@ -54,19 +71,17 @@ function createClient(auth, opts) {
 /**
  * Creates a new Flickr REST API client.
  *
- * You **must** pass a superagent plugin as the first parameter. For
- * methods that don't require authentication, this plugin can simply
- * add your API key to the request params. For methods that require
- * authentication, use the [OAuth plugin]{@link Flickr.OAuth.createPlugin}.
+ * You **must** pass a superagent plugin or your API key as the first
+ * parameter. For methods that don't require authentication, you can simply
+ * provide your API key. For methods that do require authentication,
+ * use the [OAuth plugin]{@link Flickr.OAuth.createPlugin}.
  *
  * @constructor
- * @param {Function} auth An authentication plugin function
+ * @param {Function|String} auth An authentication plugin function or an API key
  *
  * @example <caption>Get info about a public photo with your API key</caption>
  *
- * var flickr = new Flickr(req => req.query({
- *   api_key: process.env.FLICKR_API_KEY
- * }));
+ * var flickr = new Flickr(process.env.FLICKR_API_KEY);
  *
  * flickr.photos.getInfo({
  *   photo_id: 25825763 // sorry, @dokas
@@ -78,9 +93,7 @@ function createClient(auth, opts) {
  *
  * @example <caption>Searching for public photos with your API key</caption>
  *
- * var flickr = new Flickr(req => req.query({
- *   api_key: process.env.FLICKR_API_KEY
- * }));
+ * var flickr = new Flickr(process.env.FLICKR_API_KEY);
  *
  * flickr.photos.search({
  *   photo_id: 25825763 // sorry, @dokas

--- a/script/build-rest.ejs
+++ b/script/build-rest.ejs
@@ -64,7 +64,7 @@ function createClient(auth, opts) {
  *
  * @example <caption>Get info about a public photo with your API key</caption>
  *
- * var flickr = new Flickr(res => res.query({
+ * var flickr = new Flickr(req => req.query({
  *   api_key: process.env.FLICKR_API_KEY
  * }));
  *
@@ -78,7 +78,7 @@ function createClient(auth, opts) {
  *
  * @example <caption>Searching for public photos with your API key</caption>
  *
- * var flickr = new Flickr(res => res.query({
+ * var flickr = new Flickr(req => req.query({
  *   api_key: process.env.FLICKR_API_KEY
  * }));
  *

--- a/test/services.rest.js
+++ b/test/services.rest.js
@@ -30,6 +30,11 @@ describe('services/rest', function () {
 		assert.doesNotThrow(function () {
 			new Subject(auth); // eslint-disable-line no-new
 		});
+
+		// allow passing an api key string for auth
+		assert.doesNotThrow(function () {
+			new Subject('abcd1234'); // eslint-disable-line no-new
+		});
 	});
 
 	it('can provide the host as an option', function () {
@@ -86,6 +91,17 @@ describe('services/rest', function () {
 		assert.equal(url.query.format, 'json');
 		assert.equal(url.query.nojsoncallback, '1');
 		assert.equal(url.query.foo, 'bar');
+	});
+
+	it('adds the api_key query string param if a string is passed for auth', function () {
+		var req, url;
+
+		subject = new Subject('abcd1234');
+
+		req = subject._('GET', 'flickr.test.echo').request();
+		url = parse(req.path, true);
+
+		assert.equal(url.query.api_key, 'abcd1234');
 	});
 
 	it('joins "extras" if passed as an array', function () {


### PR DESCRIPTION
REST API methods that don't require user authentication can be called with just the `?api_key` query string param. This is just a bit of sugar to allow passing just your API key instead of a plugin function.

Basically, instead of this:

``` js
var flickr = new Flickr(req => req.query({
  api_key: process.env.FLICKR_API_KEY
});
```

You can just do this:

``` js
var flickr = new Flickr(process.env.FLICKR_API_KEY);
```