### PR TITLE
Reduce the amount of stored data + reflect/build against current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,13 @@ docs for the full list of methods and their supported arguments.
 | [flickr.testimonials.deleteTestimonial](https://www.flickr.com/services/api/flickr.testimonials.deleteTestimonial.html) | write | `testimonial_id` |
 | [flickr.testimonials.editTestimonial](https://www.flickr.com/services/api/flickr.testimonials.editTestimonial.html) | write | `user_id`, `testimonial_id`, `testimonial_text` |
 | [flickr.testimonials.getAllTestimonialsAbout](https://www.flickr.com/services/api/flickr.testimonials.getAllTestimonialsAbout.html) | read |  |
+| [flickr.testimonials.getAllTestimonialsAboutBy](https://www.flickr.com/services/api/flickr.testimonials.getAllTestimonialsAboutBy.html) | read | `user_id` |
 | [flickr.testimonials.getAllTestimonialsBy](https://www.flickr.com/services/api/flickr.testimonials.getAllTestimonialsBy.html) | read |  |
 | [flickr.testimonials.getPendingTestimonialsAbout](https://www.flickr.com/services/api/flickr.testimonials.getPendingTestimonialsAbout.html) | read |  |
+| [flickr.testimonials.getPendingTestimonialsAboutBy](https://www.flickr.com/services/api/flickr.testimonials.getPendingTestimonialsAboutBy.html) | read | `user_id` |
 | [flickr.testimonials.getPendingTestimonialsBy](https://www.flickr.com/services/api/flickr.testimonials.getPendingTestimonialsBy.html) | read |  |
 | [flickr.testimonials.getTestimonialsAbout](https://www.flickr.com/services/api/flickr.testimonials.getTestimonialsAbout.html) | none | `user_id` |
+| [flickr.testimonials.getTestimonialsAboutBy](https://www.flickr.com/services/api/flickr.testimonials.getTestimonialsAboutBy.html) | read | `user_id` |
 | [flickr.testimonials.getTestimonialsBy](https://www.flickr.com/services/api/flickr.testimonials.getTestimonialsBy.html) | none | `user_id` |
 | [flickr.urls.getGroup](https://www.flickr.com/services/api/flickr.urls.getGroup.html) | none | `group_id` |
 | [flickr.urls.getUserPhotos](https://www.flickr.com/services/api/flickr.urls.getUserPhotos.html) | none |  |

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "chalk": "^2.0.1",
+    "dotprune": "^0.1.10",
     "ejs": "~2.5.2",
     "eslint": "^4.2.0",
     "eslint-config-flickr": "~1.3.1",

--- a/script/reflect.js
+++ b/script/reflect.js
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var path = require('path');
 var limit = require('p-limit')(2); // concurrency
+var prune = require('dotprune').prune;
 var spinner = require('ora')(require('./fun/spinner'));
 var flickr = require('..')(process.env.FLICKR_API_KEY);
 
@@ -27,6 +28,21 @@ function stringify(obj) {
 }
 
 /**
+ * Returns only the properties of `obj` that we want to store.
+ * @param {Object} obj
+ * @returns {Object}
+ */
+
+function filter(obj) {
+	return prune(obj, [
+		'method.name',
+		'method.requiredperms',
+		'arguments.argument.name',
+		'arguments.argument.optional'
+	]);
+}
+
+/**
  * Get the method info for `method` and write it to disk
  * @param {Object} method
  * @returns {Promise}
@@ -38,7 +54,7 @@ function info(method) {
 	}).on('request', function (req) {
 	  spinner.text = method._content;
 	}).then(function (res) {
-		fs.writeFileSync(filename(method._content), stringify(res.body));
+		fs.writeFileSync(filename(method._content), stringify(filter(res.body)));
 	}));
 }
 

--- a/src/flickr.activity.userComments.json
+++ b/src/flickr.activity.userComments.json
@@ -1,103 +1,22 @@
 {
   "method": {
     "name": "flickr.activity.userComments",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns a list of recent activity on photos commented on by the calling user. <b>Do not poll this method more than once an hour</b>."
-    },
-    "response": {
-      "_content": "<items>\r\n\t<item type=\"photoset\" id=\"395\" owner=\"12037949754@N01\" \r\n\t\tprimary=\"6521\" secret=\"5a3cc65d72\" server=\"2\" \r\n\t\tcomments=\"1\" views=\"33\" photos=\"7\" more=\"0\">\r\n\t\t<title>A set of photos</title>\r\n\t\t<activity>\r\n\t\t\t<event type=\"comment\"\r\n\t\t\tuser=\"12037949754@N01\" username=\"Bees\"\r\n\t\t\tdateadded=\"1144086424\">yay</event>\r\n\t\t</activity>\r\n\t</item>\r\n\r\n\t<item type=\"photo\" id=\"10289\" owner=\"12037949754@N01\"\r\n\t\tsecret=\"34da0d3891\" server=\"2\" comments=\"1\"\r\n\t\tnotes=\"0\" views=\"47\" faves=\"0\" more=\"0\">\r\n\t\t<title>A photo</title>\r\n\t\t<activity>\r\n\t\t\t<event type=\"comment\"\r\n\t\t\tuser=\"12037949754@N01\" username=\"Bees\"\r\n\t\t\tdateadded=\"1133806604\">test</event>\r\n\t\t\t<event type=\"note\"\r\n\t\t\tuser=\"12037949754@N01\" username=\"Bees\"\r\n\t\t\tdateadded=\"1118785229\">nice</event>\r\n\t\t</activity>\r\n\t</item>\r\n</items>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of items to return per page. If this argument is omitted, it defaults to 10. The maximum allowed value is 50."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.activity.userPhotos.json
+++ b/src/flickr.activity.userPhotos.json
@@ -1,108 +1,26 @@
 {
   "method": {
     "name": "flickr.activity.userPhotos",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns a list of recent activity on photos belonging to the calling user. <b>Do not poll this method more than once an hour</b>."
-    },
-    "response": {
-      "_content": "<items>\r\n\t<item type=\"photoset\" id=\"395\" owner=\"12037949754@N01\" \r\n\t\tprimary=\"6521\" secret=\"5a3cc65d72\" server=\"2\" \r\n\t\tcommentsold=\"1\" commentsnew=\"1\"\r\n\t\tviews=\"33\" photos=\"7\" more=\"0\">\r\n\t\t<title>A set of photos</title>\r\n\t\t<activity>\r\n\t\t\t<event type=\"comment\"\r\n\t\t\tuser=\"12037949754@N01\" username=\"Bees\"\r\n\t\t\tdateadded=\"1144086424\">yay</event>\r\n\t\t</activity>\r\n\t</item>\r\n\r\n\t<item type=\"photo\" id=\"10289\" owner=\"12037949754@N01\"\r\n\t\tsecret=\"34da0d3891\" server=\"2\"\r\n\t\tcommentsold=\"1\" commentsnew=\"1\"\r\n\t\tnotesold=\"0\" notesnew=\"1\"\r\n\t\tviews=\"47\" faves=\"0\" more=\"0\">\r\n\t\t<title>A photo</title>\r\n\t\t<activity>\r\n\t\t\t<event type=\"comment\"\r\n\t\t\tuser=\"12037949754@N01\" username=\"Bees\"\r\n\t\t\tdateadded=\"1133806604\">test</event>\r\n\t\t\t<event type=\"note\"\r\n\t\t\tuser=\"12037949754@N01\" username=\"Bees\"\r\n\t\t\tdateadded=\"1118785229\">nice</event>\r\n\t\t</activity>\r\n\t</item>\r\n</items>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "timeframe",
-        "optional": "1",
-        "_content": "The timeframe in which to return updates for. This can be specified in days (<code>'2d'</code>) or hours (<code>'4h'</code>). The default behavoir is to return changes since the beginning of the previous user session."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of items to return per page. If this argument is omitted, it defaults to 10. The maximum allowed value is 50."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.auth.checkToken.json
+++ b/src/flickr.auth.checkToken.json
@@ -1,81 +1,18 @@
 {
   "method": {
     "name": "flickr.auth.checkToken",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the credentials attached to an authentication token. This call <b>must</b> be signed, and is <b><a href=\"/services/api/auth.oauth.html\">deprecated in favour of OAuth</a></b>."
-    },
-    "response": {
-      "_content": "<auth>\r\n\t<token>976598454353455</token>\r\n\t<perms>read</perms>\r\n\t<user nsid=\"12037949754@N01\" username=\"Bees\" fullname=\"Cal H\" />\r\n</auth>"
-    },
-    "explanation": {
-      "_content": "<p><code>perms</code> can have values of <code>none</code>, <code>read</code>, <code>write</code> or <code>delete</code>. For more information, see the <a href=\"/services/api/auth.spec.html\">Auth API spec</a>.</p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "auth_token",
-        "optional": "0",
-        "_content": "The authentication token to check."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.auth.getFrob.json
+++ b/src/flickr.auth.getFrob.json
@@ -1,78 +1,14 @@
 {
   "method": {
     "name": "flickr.auth.getFrob",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns a frob to be used during authentication. <b>This method call must be signed</b>, and is <b><a href=\"/services/api/auth.oauth.html\">deprecated in favour of OAuth</a></b>."
-    },
-    "response": {
-      "_content": "<frob>746563215463214621</frob>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.auth.getFullToken.json
+++ b/src/flickr.auth.getFullToken.json
@@ -1,81 +1,18 @@
 {
   "method": {
     "name": "flickr.auth.getFullToken",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get the full authentication token for a mini-token. <b>This method call must be signed</b>, and is <b><a href=\"/services/api/auth.oauth.html\">deprecated in favour of OAuth</a></b>."
-    },
-    "response": {
-      "_content": "<auth>\r\n\t<token>976598454353455</token>\r\n\t<perms>write</perms>\r\n\t<user nsid=\"12037949754@N01\" username=\"Bees\" fullname=\"Cal H\" />\r\n</auth>"
-    },
-    "explanation": {
-      "_content": "<p><code>perms</code> can have values of <code>none</code>, <code>read</code>, <code>write</code> or <code>delete</code>. For more information, see the <a href=\"/services/api/auth.spec.html\">Auth API spec</a>.</p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "mini_token",
-        "optional": "0",
-        "_content": "The mini-token typed in by a user. It should be 9 digits long. It may optionally contain dashes."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Mini-token not found",
-        "_content": "The passed mini-token was not valid."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.auth.getToken.json
+++ b/src/flickr.auth.getToken.json
@@ -1,91 +1,18 @@
 {
   "method": {
     "name": "flickr.auth.getToken",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the auth token for the given frob, if one has been attached. <b>This method call must be signed</b>, and is <b><a href=\"/services/api/auth.oauth.html\">deprecated in favour of OAuth</a></b>."
-    },
-    "response": {
-      "_content": "<auth>\r\n\t<token>976598454353455</token>\r\n\t<perms>write</perms>\r\n\t<user nsid=\"12037949754@N01\" username=\"Bees\" fullname=\"Cal H\" />\r\n</auth>"
-    },
-    "explanation": {
-      "_content": "<p><code>perms</code> can have values of <code>none</code>, <code>read</code>, <code>write</code> or <code>delete</code>. For more information, see the <a href=\"/services/api/auth.spec.html\">Auth API spec</a>.</p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "frob",
-        "optional": "0",
-        "_content": "The frob to check."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "108",
-        "message": "Invalid frob",
-        "_content": "The specified frob does not exist or has already been used."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.auth.oauth.checkToken.json
+++ b/src/flickr.auth.oauth.checkToken.json
@@ -1,83 +1,18 @@
 {
   "method": {
     "name": "flickr.auth.oauth.checkToken",
-    "needslogin": 0,
-    "needssigning": 1,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the credentials attached to an OAuth authentication token."
-    },
-    "response": {
-      "_content": "<oauth>\r\n    <token>72157627611980735-09e87c3024f733da</token>\r\n    <perms>write</perms>\r\n    <user nsid=\"1121451801@N07\" username=\"jamalf\" fullname=\"Jamal F\"/>\r\n</oauth>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "oauth_token",
-        "optional": "0",
-        "_content": "The OAuth authentication token to check."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.auth.oauth.getAccessToken.json
+++ b/src/flickr.auth.oauth.getAccessToken.json
@@ -1,78 +1,14 @@
 {
   "method": {
     "name": "flickr.auth.oauth.getAccessToken",
-    "needslogin": 0,
-    "needssigning": 1,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Exchange an auth token from the old Authentication API, to an OAuth access token. Calling this method will delete the auth token used to make the request."
-    },
-    "response": {
-      "_content": "<auth> \r\n\t<access_token oauth_token=\"72157607082540144-8d5d7ea7696629bf\" oauth_token_secret=\"f38bf58b2d95bc8b\" /> \r\n</auth> "
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.blogs.getList.json
+++ b/src/flickr.blogs.getList.json
@@ -1,101 +1,18 @@
 {
   "method": {
     "name": "flickr.blogs.getList",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get a list of configured blogs for the calling user."
-    },
-    "response": {
-      "_content": "<blogs>\r\n\t<blog id=\"73\" name=\"Bloxus test\" needspassword=\"0\"\r\n\t\turl=\"http://remote.bloxus.com/\" /> \r\n\t<blog id=\"74\" name=\"Manila Test\" needspassword=\"1\"\r\n\t\turl=\"http://flickrtest1.userland.com/\" /> \r\n</blogs>"
-    },
-    "explanation": {
-      "_content": "<p>The <code>needspassword</code> attribute indicates whether a call to <code>flickr.blogs.postPhoto</code> for this blog will require a password to be sent. When flickr has a password already stored, <code>needspassword</code> is 0</p>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "service",
-        "optional": "1",
-        "_content": "Optionally only return blogs for a given service id.  You can get a list of from <a href=\"/services/api/flickr.blogs.getServices.html\">flickr.blogs.getServices()</a>."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.blogs.getServices.json
+++ b/src/flickr.blogs.getServices.json
@@ -1,68 +1,14 @@
 {
   "method": {
     "name": "flickr.blogs.getServices",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a list of Flickr supported blogging services"
-    },
-    "response": {
-      "_content": "<services>\r\n<service id=\"beta.blogger.com\">Blogger</service>\r\n<service id=\"Typepad\">Typepad</service>\r\n<service id=\"MovableType\">Movable Type</service>\r\n<service id=\"LiveJournal\">LiveJournal</service>\r\n<service id=\"MetaWeblogAPI\">Wordpress</service>\r\n<service id=\"MetaWeblogAPI\">MetaWeblogAPI</service>\r\n<service id=\"Manila\">Manila</service>\r\n<service id=\"AtomAPI\">AtomAPI</service>\r\n<service id=\"BloggerAPI\">BloggerAPI</service>\r\n<service id=\"Vox\">Vox</service>\r\n<service id=\"Twitter\">Twitter</service>\r\n</services>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.blogs.postPhoto.json
+++ b/src/flickr.blogs.postPhoto.json
@@ -1,140 +1,38 @@
 {
   "method": {
     "name": "flickr.blogs.postPhoto",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": ""
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "blog_id",
-        "optional": "1",
-        "_content": "The id of the blog to post to."
+        "optional": "1"
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to blog"
+        "optional": "0"
       },
       {
         "name": "title",
-        "optional": "0",
-        "_content": "The blog post title"
+        "optional": "0"
       },
       {
         "name": "description",
-        "optional": "0",
-        "_content": "The blog post body"
+        "optional": "0"
       },
       {
         "name": "blog_password",
-        "optional": "1",
-        "_content": "The password for the blog (used when the blog does not have a stored password)."
+        "optional": "1"
       },
       {
         "name": "service",
-        "optional": "1",
-        "_content": "A Flickr supported blogging service.  Instead of passing a blog id you can pass a service id and we'll post to the first blog of that service we find."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Blog not found",
-        "_content": "The blog id was not the id of a blog belonging to the calling user"
-      },
-      {
-        "code": "2",
-        "message": "Photo not found",
-        "_content": "The photo id was not the id of a public photo"
-      },
-      {
-        "code": "3",
-        "message": "Password needed",
-        "_content": "A password is not stored for the blog and one was not passed with the request"
-      },
-      {
-        "code": "4",
-        "message": "Blog post failed",
-        "_content": "The blog posting failed (a blogging API failure of some sort)"
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.cameras.getBrandModels.json
+++ b/src/flickr.cameras.getBrandModels.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.cameras.getBrandModels",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Retrieve all the models for a given camera brand."
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n  <cameras brand=\"apple\">\r\n    <camera id=\"iphone_9000\">\r\n      <name>iPhone 9000</name>\r\n      <details>\r\n        <megapixels>22.0</megapixels>\r\n        <zoom>3.0</zoom>\r\n        <lcd_size>40.5</lcd_size>\r\n        <storage_type>Flash</storage_type>\r\n      </details>\r\n      <images>\r\n        <small>http://farm3.staticflickr.com/1234/cameras/123456_model_small_123456.jpg</small>\r\n        <large>http://farm3.staticflickr.com/1234/cameras/123456_model_large_123456.jpg</large>\r\n      </images>\r\n    </camera>\r\n  </cameras>\r\n</rsp>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "brand",
-        "optional": "0",
-        "_content": "The ID of the requested brand (as returned from flickr.cameras.getBrands)."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Brand not found",
-        "_content": "Unable to find the given brand ID."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.cameras.getBrands.json
+++ b/src/flickr.cameras.getBrands.json
@@ -1,68 +1,14 @@
 {
   "method": {
     "name": "flickr.cameras.getBrands",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns all the brands of cameras that Flickr knows about."
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n<brands>\r\n\t<brand id=\"canon\">Canon</brand>\r\n\t<brand id=\"nikon\">Nikon</brand>\r\n        <brand id=\"apple\">Apple</brand>\r\n</brands>\r\n</rsp>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.collections.getInfo.json
+++ b/src/flickr.collections.getInfo.json
@@ -1,103 +1,18 @@
 {
   "method": {
     "name": "flickr.collections.getInfo",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns information for a single collection.  Currently can only be called by the collection owner, this may change."
-    },
-    "response": {
-      "_content": "<collection id=\"12-72157594586579649\" child_count=\"6\" datecreate=\"1173812218\" iconlarge=\"http://farm1.static.flickr.com/187/cols/73743fac2cf79_l.jpg\" iconsmall=\"http://farm1.static.flickr.com/187/cols/72157594586579649_43fac2cf79_s.jpg\" server=\"187\" secret=\"36\">\r\n<title>All My Photos</title>\r\n<description>Photos!</description>\r\n<iconphotos>\r\n<photo id=\"14\" owner=\"12@N01\" secret=\"b57ba5c\" server=\"51\" farm=\"1\" title=\"in full cap and gown\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"/>\r\n<photo id=\"15\" owner=\"12@N01\" secret=\"ba1c2a8\" server=\"58\" farm=\"1\" title=\"Just beyond the door\" ispublic=\"0\" isfriend=\"1\" isfamily=\"0\"/>\r\n<photo id=\"17\" owner=\"12@N01\" secret=\"0001969\" server=\"73\" farm=\"1\" title=\"IMG_3787.JPG\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"/>\r\n....\r\n</iconphotos>\r\n</collection>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "collection_id",
-        "optional": "0",
-        "_content": "The ID of the collection to fetch information for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Collection not found",
-        "_content": "The requested collection could not be found or is not visible to the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.collections.getTree.json
+++ b/src/flickr.collections.getTree.json
@@ -1,91 +1,22 @@
 {
   "method": {
     "name": "flickr.collections.getTree",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns a tree (or sub tree) of collections belonging to a given user."
-    },
-    "response": {
-      "_content": "<collections>\r\n<collection id=\"12-72157594586579649\" title=\"All My Photos\" description=\"a collection\" iconlarge=\"http://farm1.static.flickr.com/187/cols/37_43fac2cf79_l.jpg\" \r\niconsmall=\"http://farm1.static.flickr.com/187/cols/56_43fac2cf79_s.jpg\">\r\n<set id=\"92157594171298291\" title=\"kitesurfing\" description=\"a set\"/>\r\n<set id=\"72157594247596158\" title=\"faves\" description=\"some favorites.\"/>\r\n</collection>\r\n</collections>"
-    },
-    "explanation": {
-      "_content": "A nested tree of collections, and the collections and sets they contain."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "collection_id",
-        "optional": "1",
-        "_content": "The ID of the collection to fetch a tree for, or zero to fetch the root collection. Defaults to zero."
+        "optional": "1"
       },
       {
         "name": "user_id",
-        "optional": "1",
-        "_content": "The ID of the account to fetch the collection tree for. Deafults to the calling user."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The specified user could not be found."
-      },
-      {
-        "code": "2",
-        "message": "Collection not found",
-        "_content": "The specified collection does not exist."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.commons.getInstitutions.json
+++ b/src/flickr.commons.getInstitutions.json
@@ -1,68 +1,14 @@
 {
   "method": {
     "name": "flickr.commons.getInstitutions",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Retrieves a list of the current Commons institutions."
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n <institutions>\r\n  <institution nsid=\"123456@N01\" date_launch=\"1232000000\">\r\n   <name>Institution</name>\r\n    <urls>\r\n     <url type=\"site\">http://example.com/</url>\r\n     <url type=\"license\">http://example.com/commons/license</url>\r\n     <url type=\"flickr\">http://flickr.com/photos/institution</url>\r\n    </urls>\r\n   </institution>\r\n  </institutions>\r\n</rsp>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.contacts.getList.json
+++ b/src/flickr.contacts.getList.json
@@ -1,118 +1,30 @@
 {
   "method": {
     "name": "flickr.contacts.getList",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get a list of contacts for the calling user."
-    },
-    "response": {
-      "_content": "<contacts page=\"1\" pages=\"1\" perpage=\"1000\" total=\"3\">\r\n\t<contact nsid=\"12037949629@N01\" username=\"Eric\" iconserver=\"1\"\r\n\t\trealname=\"Eric Costello\"\r\n\t\tfriend=\"1\" family=\"0\" ignored=\"1\" /> \r\n\t<contact nsid=\"12037949631@N01\" username=\"neb\" iconserver=\"1\"\r\n\t\trealname=\"Ben Cerveny\"\r\n\t\tfriend=\"0\" family=\"0\" ignored=\"0\" /> \r\n\t<contact nsid=\"41578656547@N01\" username=\"cal_abc\" iconserver=\"1\"\r\n\t\trealname=\"Cal Henderson\"\r\n\t\tfriend=\"1\" family=\"1\" ignored=\"0\" />\r\n</contacts>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "filter",
-        "optional": "1",
-        "_content": "An optional filter of the results. The following values are valid:<br />\r\n&nbsp;\r\n<dl>\r\n\t<dt><b><code>friends</code></b></dt>\r\n\t<dl>Only contacts who are friends (and not family)</dl>\r\n\r\n\t<dt><b><code>family</code></b></dt>\r\n\t<dl>Only contacts who are family (and not friends)</dl>\r\n\r\n\t<dt><b><code>both</code></b></dt>\r\n\t<dl>Only contacts who are both friends and family</dl>\r\n\r\n\t<dt><b><code>neither</code></b></dt>\r\n\t<dl>Only contacts who are neither friends nor family</dl>\r\n</dl>"
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 1000. The maximum allowed value is 1000."
+        "optional": "1"
       },
       {
         "name": "sort",
-        "optional": "1",
-        "_content": "The order in which to sort the returned contacts. Defaults to name. The possible values are: name and time."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid sort parameter.",
-        "_content": "The possible values are: name and time."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.contacts.getListRecentlyUploaded.json
+++ b/src/flickr.contacts.getListRecentlyUploaded.json
@@ -1,100 +1,22 @@
 {
   "method": {
     "name": "flickr.contacts.getListRecentlyUploaded",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Return a list of contacts for a user who have recently uploaded photos along with the total count of photos uploaded.<br /><br />\r\n\r\nThis method is still considered experimental. We don't plan for it to change or to go away but so long as this notice is present you should write your code accordingly."
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date_lastupload",
-        "optional": "1",
-        "_content": "Limits the resultset to contacts that have uploaded photos since this date. The date should be in the form of a Unix timestamp.\r\n\r\nThe default offset is (1) hour and the maximum (24) hours. "
+        "optional": "1"
       },
       {
         "name": "filter",
-        "optional": "1",
-        "_content": "Limit the result set to all contacts or only those who are friends or family. Valid options are:\r\n\r\n<ul>\r\n<li><strong>ff</strong> friends and family</li>\r\n<li><strong>all</strong> all your contacts</li>\r\n</ul>\r\nDefault value is \"all\"."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.contacts.getPublicList.json
+++ b/src/flickr.contacts.getPublicList.json
@@ -1,91 +1,26 @@
 {
   "method": {
     "name": "flickr.contacts.getPublicList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get the contact list for a user."
-    },
-    "response": {
-      "_content": "<contacts page=\"1\" pages=\"1\" perpage=\"1000\" total=\"3\">\r\n\t<contact nsid=\"12037949629@N01\" username=\"Eric\" iconserver=\"1\" ignored=\"1\" /> \r\n\t<contact nsid=\"12037949631@N01\" username=\"neb\" iconserver=\"1\" ignored=\"0\" /> \r\n\t<contact nsid=\"41578656547@N01\" username=\"cal_abc\" iconserver=\"1\" ignored=\"0\" />\r\n</contacts>"
-    },
-    "explanation": {
-      "_content": "<p>See <a href=\"/services/api/flickr.contacts.getList.html\">flickr.contacts.getList</a> for an explanation of the response.</p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the user to fetch the contact list for."
+        "optional": "0"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 1000. The maximum allowed value is 1000."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The specified user NSID was not a valid user."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.contacts.getTaggingSuggestions.json
+++ b/src/flickr.contacts.getTaggingSuggestions.json
@@ -1,103 +1,22 @@
 {
   "method": {
     "name": "flickr.contacts.getTaggingSuggestions",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get suggestions for tagging people in photos based on the calling user's contacts."
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n<contacts page=\"1\" pages=\"1\" perpage=\"1000\" total=\"1\">\r\n\t<contact nsid=\"30135021@N05\" username=\"Hugo Haas\" iconserver=\"1\" iconfarm=\"1\" realname=\"\" friend=\"0\" family=\"0\" path_alias=\"\" />\r\n</contacts>\r\n</rsp>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of contacts to return per page. If this argument is omitted, all contacts will be returned."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.favorites.add.json
+++ b/src/flickr.favorites.add.json
@@ -1,115 +1,18 @@
 {
   "method": {
     "name": "flickr.favorites.add",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Adds a photo to a user's favorites list."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to add to the user's favorites."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id."
-      },
-      {
-        "code": "2",
-        "message": "Photo is owned by you",
-        "_content": "The photo belongs to the user and so cannot be added to their favorites."
-      },
-      {
-        "code": "3",
-        "message": "Photo is already in favorites",
-        "_content": "The photo is already in the user's list of favorites."
-      },
-      {
-        "code": "4",
-        "message": "User cannot see photo",
-        "_content": "The user does not have permission to add the photo to their favorites."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.favorites.getContext.json
+++ b/src/flickr.favorites.getContext.json
@@ -1,96 +1,22 @@
 {
   "method": {
     "name": "flickr.favorites.getContext",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns next and previous favorites for a photo in a user's favorites."
-    },
-    "response": {
-      "_content": "<rsp stat='ok'>\r\n<count>3</count>\r\n<prevphoto id=\"2980\" secret=\"973da1e709\"\r\n\ttitle=\"boo!\" url=\"/photos/bees/2980/\" /> \r\n<nextphoto id=\"2985\" secret=\"059b664012\"\r\n\ttitle=\"Amsterdam Amstel\" url=\"/photos/bees/2985/\" />\r\n</rsp>"
-    },
-    "explanation": {
-      "_content": "<p>See <a href=\"/services/api/flickr.photos.getContext.html\">flickr.photos.getContext</a></p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to fetch the context for."
+        "optional": "0"
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The user who counts the photo as a favorite."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id, or was the id of a photo that the calling user does not have permission to view."
-      },
-      {
-        "code": "2",
-        "message": "User not found",
-        "_content": "The specified user was not found."
-      },
-      {
-        "code": "3",
-        "message": "Photo not a favorite",
-        "_content": "The specified photo is not a favorite of the specified user."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.favorites.getList.json
+++ b/src/flickr.favorites.getList.json
@@ -1,100 +1,38 @@
 {
   "method": {
     "name": "flickr.favorites.getList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns a list of the user's favorite photos. Only photos which the calling user has permission to see are returned."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "1",
-        "_content": "The NSID of the user to fetch the favorites list for. If this argument is omitted, the favorites list for the calling user is returned."
+        "optional": "1"
       },
       {
         "name": "min_fave_date",
-        "optional": "1",
-        "_content": "Minimum date that a photo was favorited on. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "max_fave_date",
-        "optional": "1",
-        "_content": "Maximum date that a photo was favorited on. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The specified user NSID was not a valid flickr user."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.favorites.getPublicList.json
+++ b/src/flickr.favorites.getPublicList.json
@@ -1,100 +1,38 @@
 {
   "method": {
     "name": "flickr.favorites.getPublicList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns a list of favorite public photos for the given user."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The user to fetch the favorites list for."
+        "optional": "0"
       },
       {
         "name": "min_fave_date",
-        "optional": "1",
-        "_content": "Minimum date that a photo was favorited on. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "max_fave_date",
-        "optional": "1",
-        "_content": "Maximum date that a photo was favorited on. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The specified user NSID was not a valid flickr user."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.favorites.remove.json
+++ b/src/flickr.favorites.remove.json
@@ -1,110 +1,18 @@
 {
   "method": {
     "name": "flickr.favorites.remove",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Removes a photo from a user's favorites list."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to remove from the user's favorites."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not in favorites",
-        "_content": "The photo id passed was not in the user's favorites."
-      },
-      {
-        "code": "2",
-        "message": "Cannot remove photo from that user's favorites",
-        "_content": "user_id was passed as an argument, but photo_id is not owned by the authenticated user."
-      },
-      {
-        "code": "3",
-        "message": "User not found",
-        "_content": "Invalid user_id argument."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.galleries.addPhoto.json
+++ b/src/flickr.galleries.addPhoto.json
@@ -1,130 +1,26 @@
 {
   "method": {
     "name": "flickr.galleries.addPhoto",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Add a photo to a gallery."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "gallery_id",
-        "optional": "0",
-        "_content": "The ID of the gallery to add a photo to.  Note: this is the compound ID returned in methods like <a href=\"/services/api/flickr.galleries.getList.html\">flickr.galleries.getList</a>, and <a href=\"/services/api/flickr.galleries.getListForPhoto.html\">flickr.galleries.getListForPhoto</a>."
+        "optional": "0"
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The photo ID to add to the gallery"
+        "optional": "0"
       },
       {
         "name": "comment",
-        "optional": "1",
-        "_content": "A short comment or story to accompany the photo."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required parameter missing",
-        "_content": "One or more required parameters was not included with your API call."
-      },
-      {
-        "code": "2",
-        "message": "Invalid gallery ID",
-        "_content": "That gallery could not be found."
-      },
-      {
-        "code": "3",
-        "message": "Invalid photo ID",
-        "_content": "The requested photo could not be found."
-      },
-      {
-        "code": "4",
-        "message": "Invalid comment",
-        "_content": "The comment body could not be validated."
-      },
-      {
-        "code": "5",
-        "message": "Failed to add photo",
-        "_content": "Unable to add the photo to the gallery."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.galleries.create.json
+++ b/src/flickr.galleries.create.json
@@ -1,131 +1,30 @@
 {
   "method": {
     "name": "flickr.galleries.create",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Create a new gallery for the calling user."
-    },
-    "response": {
-      "_content": "  <gallery id=\"50736-72157623680420409\" url=\"http://www.flickr.com/photos/kellan/galleries/72157623680420409\" /> \r\n"
-    },
-    "explanation": {
-      "_content": "The ID of the newly created gallery, and its URL."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "title",
-        "optional": "0",
-        "_content": "The name of the gallery"
+        "optional": "0"
       },
       {
         "name": "description",
-        "optional": "0",
-        "_content": "A short description for the gallery"
+        "optional": "0"
       },
       {
         "name": "primary_photo_id",
-        "optional": "1",
-        "_content": "The first photo to add to your gallery"
+        "optional": "1"
       },
       {
         "name": "full_result",
-        "optional": "1",
-        "_content": "Get the result in the same format as galleries.getList"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required parameter missing",
-        "_content": "One or more of the required parameters was missing from your API call."
-      },
-      {
-        "code": "2",
-        "message": "Invalid title or description",
-        "_content": "The title or the description could not be validated."
-      },
-      {
-        "code": "3",
-        "message": "Failed to add gallery",
-        "_content": "There was a problem creating the gallery."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.galleries.editMeta.json
+++ b/src/flickr.galleries.editMeta.json
@@ -1,115 +1,26 @@
 {
   "method": {
     "name": "flickr.galleries.editMeta",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Modify the meta-data for a gallery."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "gallery_id",
-        "optional": "0",
-        "_content": "The gallery ID to update."
+        "optional": "0"
       },
       {
         "name": "title",
-        "optional": "0",
-        "_content": "The new title for the gallery."
+        "optional": "0"
       },
       {
         "name": "description",
-        "optional": "1",
-        "_content": "The new description for the gallery."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required parameter missing",
-        "_content": "One or more required parameters was missing from your request."
-      },
-      {
-        "code": "2",
-        "message": "Invalid title or description",
-        "_content": "The title or description arguments could not be validated."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.galleries.editPhoto.json
+++ b/src/flickr.galleries.editPhoto.json
@@ -1,110 +1,26 @@
 {
   "method": {
     "name": "flickr.galleries.editPhoto",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Edit the comment for a gallery photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "gallery_id",
-        "optional": "0",
-        "_content": "The ID of the gallery to add a photo to. Note: this is the compound ID returned in methods like flickr.galleries.getList, and flickr.galleries.getListForPhoto."
+        "optional": "0"
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The photo ID to add to the gallery."
+        "optional": "0"
       },
       {
         "name": "comment",
-        "optional": "0",
-        "_content": "The updated comment the photo."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid gallery ID",
-        "_content": "That gallery could not be found."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.galleries.editPhotos.json
+++ b/src/flickr.galleries.editPhotos.json
@@ -1,105 +1,26 @@
 {
   "method": {
     "name": "flickr.galleries.editPhotos",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Modify the photos in a gallery. Use this method to add, remove and re-order photos."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "gallery_id",
-        "optional": "0",
-        "_content": "The id of the gallery to modify. The gallery must belong to the calling user."
+        "optional": "0"
       },
       {
         "name": "primary_photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to use as the 'primary' photo for the gallery. This id must also be passed along in photo_ids list argument."
+        "optional": "0"
       },
       {
         "name": "photo_ids",
-        "optional": "0",
-        "_content": "A comma-delimited list of photo ids to include in the gallery. They will appear in the set in the order sent. This list must contain the primary photo id. This list of photos replaces the existing list."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.galleries.getInfo.json
+++ b/src/flickr.galleries.getInfo.json
@@ -1,73 +1,18 @@
 {
   "method": {
     "name": "flickr.galleries.getInfo",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": ""
-    },
-    "response": {
-      "_content": "<gallery id=\"6065-72157617483228192\" url=\"http://www.flickr.com/photos/straup/galleries/72157617483228192\" \r\nowner=\"35034348999@N01\" \r\n         primary_photo_id=\"292882708\" date_create=\"1241028772\" date_update=\"1270111667\" count_photos=\"17\"\r\n count_videos=\"0\" primary_photo_server=\"112\" primary_photo_farm=\"1\" primary_photo_secret=\"7f29861bc4\">\r\n\t<title>Cat Pictures I've Sent To Kevin Collins</title>\r\n\t<description />\r\n</gallery>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "gallery_id",
-        "optional": "0",
-        "_content": "The gallery ID you are requesting information for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.galleries.getList.json
+++ b/src/flickr.galleries.getList.json
@@ -1,88 +1,30 @@
 {
   "method": {
     "name": "flickr.galleries.getList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return the list of galleries created by a user.  Sorted from newest to oldest."
-    },
-    "response": {
-      "_content": "<galleries total=\"9\" page=\"1\" pages=\"1\" per_page=\"100\" user_id=\"34427469121@N01\">\r\n   <gallery id=\"5704-72157622637971865\" \r\n             url=\"http://www.flickr.com/photos/george/galleries/72157622637971865\" \r\n             owner=\"34427469121@N01\" date_create=\"1257711422\" date_update=\"1260360756\"\r\n             primary_photo_id=\"107391222\"  primary_photo_server=\"39\" \r\n             primary_photo_farm=\"1\" primary_photo_secret=\"ffa\"\r\n             count_photos=\"16\" count_videos=\"2\" >\r\n       <title>I like me some black &amp; white</title>\r\n       <description>black and whites</description>\r\n   </gallery>\r\n   <gallery id=\"5704-72157622566655097\" \r\n            url=\"http://www.flickr.com/photos/george/galleries/72157622566655097\" \r\n            owner=\"34427469121@N01\" date_create=\"1256852229\" date_update=\"1260462343\" \r\n            primary_photo_id=\"497374910\" primary_photo_server=\"231\" \r\n            primary_photo_farm=\"1\" primary_photo_secret=\"9ae0f\"\r\n            count_photos=\"18\" count_videos=\"0\" >\r\n       <title>People Sleeping in Libraries</title>\r\n       <description />\r\n   </gallery>\r\n</galleries>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the user to get a galleries list for. If none is specified, the calling user is assumed."
+        "optional": "0"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of galleries to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       },
       {
         "name": "primary_photo_extras",
-        "optional": "1",
-        "_content": "A comma-delimited list of extra information to fetch for the primary photo. Currently supported fields are: license, date_upload, date_taken, owner_name, icon_server, original_format, last_update, geo, tags, machine_tags, o_dims, views, media, path_alias, url_sq, url_t, url_s, url_m, url_o"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.galleries.getListForPhoto.json
+++ b/src/flickr.galleries.getListForPhoto.json
@@ -1,83 +1,26 @@
 {
   "method": {
     "name": "flickr.galleries.getListForPhoto",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return the list of galleries to which a photo has been added.  Galleries are returned sorted by date which the photo was added to the gallery."
-    },
-    "response": {
-      "_content": "<galleries total=\"7\" page=\"1\" pages=\"1\" per_page=\"100\">\r\n    <gallery id=\"9634-72157621980433950\" \r\n             url=\"http://www.flickr.com/photos/revdancatt/galleries/72157621980433950\" \r\n             owner=\"35468159852@N01\" date_create=\"1249748647\" date_update=\"1260486168\" \r\n\t     primary_photo_id=\"2080242123\" primary_photo_server=\"2209\" \r\n\t     primary_photo_farm=\"3\" primary_photo_secret=\"55c9\"\r\n             count_photos=\"18\" count_videos=\"0\">\r\n        <title>Vivitar Ultra Wide &amp; Slim Selection</title>\r\n        <description>The cheap and cheerful camera that isn't quite as cheap as it used to be.</description>\r\n    </gallery>\r\n   <gallery id=\"22342631-72157622254010831\" \r\n             url=\"http://www.flickr.com/photos/22365685@N03/galleries/72157622254010831\" \r\n             owner=\"22365685@N03\" date_create=\"1253035020\" date_update=\"1260431618\" \r\n             primary_photo_id=\"3182914049\" primary_photo_server=\"3319\" \r\n             primary_photo_farm=\"4\" primary_photo_secret=\"b94fb\"\r\n             count_photos=\"13\" count_videos=\"0\">\r\n        <title>Awesome Pics</title>\r\n        <description />\r\n    </gallery>\r\n</galleries>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The ID of the photo to fetch a list of galleries for."
+        "optional": "0"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of galleries to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.galleries.getPhotos.json
+++ b/src/flickr.galleries.getPhotos.json
@@ -1,91 +1,30 @@
 {
   "method": {
     "name": "flickr.galleries.getPhotos",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return the list of photos for a gallery"
-    },
-    "response": {
-      "_content": "<photos page=\"1\" pages=\"1\" perpage=\"500\" total=\"2\">\r\n\t<photo id=\"2822546461\" owner=\"78398753@N00\" secret=\"2dbcdb589f\" server=\"1\" farm=\"1\" title=\"FOO\" \r\n     ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" is_primary=\"1\" has_comment=\"1\">\r\n\t\t<comment>best cat picture ever!</comment>\r\n\t</photo>\r\n\t<photo id=\"2822544806\" owner=\"78398753@N00\" secret=\"bd93cbe917\" server=\"1\" farm=\"1\" title=\"OOK\" \r\n     ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" is_primary=\"0\" has_comment=\"0\" />\r\n</photos>"
-    },
-    "explanation": {
-      "_content": "Returns a <a href=\"http://code.flickr.com/blog/2008/08/19/standard-photos-response-apis-for-civilized-age/\">standard photo response</a>.  Additionally if the gallery creator has included a comment with the photo this will be then the photo element will have the attribute has_comment=\"1\" and the child element \"comment\" will be present."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "gallery_id",
-        "optional": "0",
-        "_content": "The ID of the gallery of photos to return"
+        "optional": "0"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.browse.json
+++ b/src/flickr.groups.browse.json
@@ -1,106 +1,18 @@
 {
   "method": {
     "name": "flickr.groups.browse",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Browse the group category tree, finding groups and sub-categories."
-    },
-    "response": {
-      "_content": "<category name=\"Alt\" path=\"/Alt\" pathids=\"/63\">\r\n\t<subcat id=\"80\" name=\"18+\" count=\"0\" /> \r\n\t<subcat id=\"82\" name=\"Absurd\" count=\"4\" /> \r\n\t<group nsid=\"34955637532@N01\" name=\"Cal's Public Test Group\"\r\n\t\tmembers=\"13\" online=\"1\" chatnsid=\"34955637533@N01\" inchat=\"0\" /> \r\n\t<group nsid=\"34158032587@N01\" name=\"Eric's Alt Group Test\"\r\n\t\tmembers=\"3\" online=\"0\" chatnsid=\"34158032588@N01\" inchat=\"0\" /> \r\n</category>\r\n"
-    },
-    "explanation": {
-      "_content": "<p>The <code>count</code> attribute of the <code>subcat</code> element gives the number of groups inside the subcat.</p>\r\n\r\n<p>The <code>members</code> attribute of the <code>group</code> element gives the total number of members in the group. The <code>online</code> attribute gives a count of the members who are currently online. The <code>inchat</code> attribute gives a count of the number of people in the group's chat, regardless of whether they are members of the group.</p>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "cat_id",
-        "optional": "1",
-        "_content": "The category id to fetch a list of groups and sub-categories for. If not specified, it defaults to zero, the root of the category tree."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Category not found",
-        "_content": "The value passed for cat_id was not a valid category id."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.discuss.replies.add.json
+++ b/src/flickr.groups.discuss.replies.add.json
@@ -1,120 +1,26 @@
 {
   "method": {
     "name": "flickr.groups.discuss.replies.add",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Post a new reply to a group discussion topic."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "Pass in the group id to where the topic belongs. Can be NSID or group alias. Making this parameter optional for legacy reasons, but it is highly recommended to pass this in to get faster performance. "
+        "optional": "0"
       },
       {
         "name": "topic_id",
-        "optional": "0",
-        "_content": "The ID of the topic to post a comment to."
+        "optional": "0"
       },
       {
         "name": "message",
-        "optional": "0",
-        "_content": "The message to post to the topic."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Topic not found",
-        "_content": "The topic_id is invalid."
-      },
-      {
-        "code": "2",
-        "message": "Cannot post to group",
-        "_content": "Either this account is not a member of the group, or discussion in this group is disabled.\r\n"
-      },
-      {
-        "code": "3",
-        "message": "Missing required arguments",
-        "_content": "The topic_id and message are required."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.discuss.replies.delete.json
+++ b/src/flickr.groups.discuss.replies.delete.json
@@ -1,120 +1,26 @@
 {
   "method": {
     "name": "flickr.groups.discuss.replies.delete",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "3",
-    "description": {
-      "_content": "Delete a reply from a group topic."
-    }
+    "requiredperms": "3"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "Pass in the group id to where the topic belongs. Can be NSID or group alias. Making this parameter optional for legacy reasons, but it is highly recommended to pass this in to get faster performance. "
+        "optional": "0"
       },
       {
         "name": "topic_id",
-        "optional": "0",
-        "_content": "The ID of the topic the post is in."
+        "optional": "0"
       },
       {
         "name": "reply_id",
-        "optional": "0",
-        "_content": "The ID of the reply to delete."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Topic not found",
-        "_content": "The topic_id is invalid."
-      },
-      {
-        "code": "2",
-        "message": "Reply not found",
-        "_content": "The reply_id is invalid."
-      },
-      {
-        "code": "3",
-        "message": "Cannot delete reply",
-        "_content": "Replies can only be edited by their owner."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.discuss.replies.edit.json
+++ b/src/flickr.groups.discuss.replies.edit.json
@@ -1,135 +1,30 @@
 {
   "method": {
     "name": "flickr.groups.discuss.replies.edit",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Edit a topic reply."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "Pass in the group id to where the topic belongs. Can be NSID or group alias. Making this parameter optional for legacy reasons, but it is highly recommended to pass this in to get faster performance. "
+        "optional": "0"
       },
       {
         "name": "topic_id",
-        "optional": "0",
-        "_content": "The ID of the topic the post is in."
+        "optional": "0"
       },
       {
         "name": "reply_id",
-        "optional": "0",
-        "_content": "The ID of the reply post to edit."
+        "optional": "0"
       },
       {
         "name": "message",
-        "optional": "0",
-        "_content": "The message to edit the post with."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Topic not found",
-        "_content": "The topic_id is invalid"
-      },
-      {
-        "code": "2",
-        "message": "Reply not found",
-        "_content": "The reply_id is invalid."
-      },
-      {
-        "code": "3",
-        "message": "Missing required arguments",
-        "_content": "The topic_id and reply_id are required."
-      },
-      {
-        "code": "4",
-        "message": "Cannot edit reply",
-        "_content": "Replies can only be edited by their owner."
-      },
-      {
-        "code": "5",
-        "message": "Cannot post to group",
-        "_content": "Either this account is not a member of the group, or discussion in this group is disabled."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.discuss.replies.getInfo.json
+++ b/src/flickr.groups.discuss.replies.getInfo.json
@@ -1,93 +1,26 @@
 {
   "method": {
     "name": "flickr.groups.discuss.replies.getInfo",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get information on a group topic reply."
-    },
-    "response": {
-      "_content": "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n<rsp stat=\"ok\">\r\n  <reply id=\"72157607082559968\" author=\"30134652@N05\" authorname=\"JAMAL'S ACCOUNT\" is_pro=\"0\" role=\"admin\" iconserver=\"0\" iconfarm=\"0\" can_edit=\"1\" can_delete=\"1\" datecreate=\"1337975921\" lastedit=\"0\">\r\n    <message>...well, too bad.</message>\r\n  </reply>\r\n</rsp>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "Pass in the group id to where the topic belongs. Can be NSID or group alias. Making this parameter optional for legacy reasons, but it is highly recommended to pass this in to get faster performance. "
+        "optional": "0"
       },
       {
         "name": "topic_id",
-        "optional": "0",
-        "_content": "The ID of the topic the post is in."
+        "optional": "0"
       },
       {
         "name": "reply_id",
-        "optional": "0",
-        "_content": "The ID of the reply to fetch."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Topic not found",
-        "_content": "The topic_id is invalid"
-      },
-      {
-        "code": "2",
-        "message": "Reply not found",
-        "_content": "The reply_id is invalid"
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.discuss.replies.getList.json
+++ b/src/flickr.groups.discuss.replies.getList.json
@@ -1,93 +1,30 @@
 {
   "method": {
     "name": "flickr.groups.discuss.replies.getList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get a list of replies from a group discussion topic."
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n  <replies>\r\n    <topic topic_id=\"72157625038324579\" subject=\"A long time ago in a galaxy far, far away...\" group_id=\"46744914@N00\" iconserver=\"1\" iconfarm=\"1\" name=\"Tell a story in 5 frames (Visual story telling)\" author=\"53930889@N04\" authorname=\"Smallportfolio_jm08\" role=\"member\" author_iconserver=\"5169\" author_iconfarm=\"6\" can_edit=\"0\" can_delete=\"0\" can_reply=\"0\" is_sticky=\"0\" is_locked=\"\" datecreate=\"1287070965\" datelastpost=\"1336905518\" total=\"8\" page=\"1\" per_page=\"3\" pages=\"2\">\r\n      <message>&lt;div&gt;&lt;span class=&quot;photo_container pc_m bbml_img&quot;&gt;&lt;a href=&quot;/photos/53930889@N04/5080874079/&quot; title=&quot;Star Wars 1 by Smallportfolio_jm08&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm5.staticflickr.com/4035/5080874079_684cf874e0_m.jpg&quot; width=&quot;240&quot; height=&quot;180&quot; alt=&quot;Star Wars 1 by Smallportfolio_jm08&quot;  class=&quot;pc_img&quot; border=&quot;0&quot; /&gt;&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;\r\n\r\n&lt;div&gt;&lt;span class=&quot;photo_container pc_m bbml_img&quot;&gt;&lt;a href=&quot;/photos/53930889@N04/5081467846/&quot; title=&quot;Star Wars 2 by Smallportfolio_jm08&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm5.staticflickr.com/4071/5081467846_2eec86176d_m.jpg&quot; width=&quot;240&quot; height=&quot;180&quot; alt=&quot;Star Wars 2 by Smallportfolio_jm08&quot;  class=&quot;pc_img&quot; border=&quot;0&quot; /&gt;&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;\r\n\r\n&lt;div&gt;&lt;span class=&quot;photo_container pc_m bbml_img&quot;&gt;&lt;a href=&quot;/photos/53930889@N04/5081467886/&quot; title=&quot;Star Wars 3 by Smallportfolio_jm08&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm5.staticflickr.com/4021/5081467886_d8cca6c8e8_m.jpg&quot; width=&quot;240&quot; height=&quot;180&quot; alt=&quot;Star Wars 3 by Smallportfolio_jm08&quot;  class=&quot;pc_img&quot; border=&quot;0&quot; /&gt;&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;\r\n\r\n&lt;div&gt;&lt;span class=&quot;photo_container pc_m bbml_img&quot;&gt;&lt;a href=&quot;/photos/53930889@N04/5081467910/&quot; title=&quot;Star Wars 4 by Smallportfolio_jm08&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm5.staticflickr.com/4084/5081467910_274bb11fdc_m.jpg&quot; width=&quot;240&quot; height=&quot;180&quot; alt=&quot;Star Wars 4 by Smallportfolio_jm08&quot;  class=&quot;pc_img&quot; border=&quot;0&quot; /&gt;&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;\r\n\r\n&lt;div&gt;&lt;span class=&quot;photo_container pc_m bbml_img&quot;&gt;&lt;a href=&quot;/photos/53930889@N04/5081467948/&quot; title=&quot;Star Wars 5 by Smallportfolio_jm08&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm5.staticflickr.com/4154/5081467948_1a5f200bc0_m.jpg&quot; width=&quot;240&quot; height=&quot;180&quot; alt=&quot;Star Wars 5 by Smallportfolio_jm08&quot;  class=&quot;pc_img&quot; border=&quot;0&quot; /&gt;&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;</message>\r\n    </topic>\r\n    <reply id=\"72157625163054214\" author=\"41380738@N05\" authorname=\"BlueRidgeKitties\" role=\"member\" iconserver=\"2459\" iconfarm=\"3\" can_edit=\"0\" can_delete=\"0\" datecreate=\"1287071539\" lastedit=\"0\">\r\n      <message>*LOL* The universe is full of &lt;a href=&quot;http://www.flickr.com/groups/visualstory/discuss/72157622533160886/&quot;&gt;giant furry space monsters&lt;/a&gt; it seems! Love it.</message>\r\n    </reply>\r\n    <reply id=\"72157625163539300\" author=\"52101018@N00\" authorname=\"pterandon\" role=\"admin\" iconserver=\"1\" iconfarm=\"1\" can_edit=\"0\" can_delete=\"0\" datecreate=\"1287076748\" lastedit=\"0\">\r\n      <message>Great work. Good focus on different aspects of scene in each frame.  Funny ending-- even better that I didn't notice the cat right away!  Being a hopeless Trekkie, I was wondering why Han was doing the Vulcan death grip on one of his allies....</message>\r\n    </reply>\r\n    <reply id=\"72157625040116805\" author=\"54830408@N02\" authorname=\"tay.grisham\" role=\"member\" iconserver=\"0\" iconfarm=\"0\" can_edit=\"0\" can_delete=\"0\" datecreate=\"1287089858\" lastedit=\"0\">\r\n      <message>On a scale of 1 to 10 of awesome. This is a 15</message>\r\n    </reply>\r\n  </replies>\r\n</rsp>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "Pass in the group id to where the topic belongs. Can be NSID or group alias. Making this parameter optional for legacy reasons, but it is highly recommended to pass this in to get faster performance. "
+        "optional": "0"
       },
       {
         "name": "topic_id",
-        "optional": "0",
-        "_content": "The ID of the topic to fetch replies for."
+        "optional": "0"
       },
       {
         "name": "per_page",
-        "optional": "0",
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": "0"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Topic not found",
-        "_content": "The topic_id is invalid."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.discuss.topics.add.json
+++ b/src/flickr.groups.discuss.topics.add.json
@@ -1,125 +1,26 @@
 {
   "method": {
     "name": "flickr.groups.discuss.topics.add",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Post a new discussion topic to a group."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "The NSID or path alias of the group to add a topic to.\r\n"
+        "optional": "0"
       },
       {
         "name": "subject",
-        "optional": "0",
-        "_content": "The topic subject."
+        "optional": "0"
       },
       {
         "name": "message",
-        "optional": "0",
-        "_content": "The topic message."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Group not found",
-        "_content": "The group by that ID does not exist\r\n"
-      },
-      {
-        "code": "2",
-        "message": "Cannot post to group",
-        "_content": "Either this account is not a member of the group, or discussion in this group is disabled."
-      },
-      {
-        "code": "3",
-        "message": "Message is too long",
-        "_content": "The post message is too long."
-      },
-      {
-        "code": "4",
-        "message": "Missing required arguments",
-        "_content": "Subject and message are required."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.discuss.topics.getInfo.json
+++ b/src/flickr.groups.discuss.topics.getInfo.json
@@ -1,83 +1,22 @@
 {
   "method": {
     "name": "flickr.groups.discuss.topics.getInfo",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get information about a group discussion topic."
-    },
-    "response": {
-      "_content": "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n<rsp stat=\"ok\">\r\n  <topic id=\"72157607082559966\" subject=\"Who's still around?\" author=\"30134652@N05\" authorname=\"JAMAL'S ACCOUNT\" is_pro=\"0\" role=\"admin\" iconserver=\"0\" iconfarm=\"0\" count_replies=\"1\" can_edit=\"1\" can_delete=\"0\" can_reply=\"0\" is_sticky=\"0\" is_locked=\"0\" datecreate=\"1337975869\" datelastpost=\"1337975921\" last_reply=\"72157607082559968\">\r\n    <message>Is anyone still around in this group?</message>\r\n  </topic>\r\n</rsp>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "NSID or group alias of the group to which the topic belongs. Making this parameter optional for legacy reasons, but it is highly recommended to pass this in to get better performance. "
+        "optional": "0"
       },
       {
         "name": "topic_id",
-        "optional": "0",
-        "_content": "The ID for the topic to edit."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Topic not found",
-        "_content": "The topic_id is invalid"
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.discuss.topics.getList.json
+++ b/src/flickr.groups.discuss.topics.getList.json
@@ -1,88 +1,26 @@
 {
   "method": {
     "name": "flickr.groups.discuss.topics.getList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get a list of discussion topics in a group."
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n  <topics group_id=\"46744914@N00\" iconserver=\"1\" iconfarm=\"1\" name=\"Tell a story in 5 frames (Visual story telling)\" members=\"12428\" privacy=\"3\" lang=\"en-us\" ispoolmoderated=\"1\" total=\"4621\" page=\"1\" per_page=\"2\" pages=\"2310\">\r\n    <topic id=\"72157625038324579\" subject=\"A long time ago in a galaxy far, far away...\" author=\"53930889@N04\" authorname=\"Smallportfolio_jm08\" role=\"member\" iconserver=\"5169\" iconfarm=\"6\" count_replies=\"8\" can_edit=\"0\" can_delete=\"0\" can_reply=\"0\" is_sticky=\"0\" is_locked=\"\" datecreate=\"1287070965\" datelastpost=\"1336905518\">\r\n      <message>&lt;div&gt;&lt;span class=&quot;photo_container pc_m bbml_img&quot;&gt;&lt;a href=&quot;/photos/53930889@N04/5080874079/&quot; title=&quot;Star Wars 1 by Smallportfolio_jm08&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm5.staticflickr.com/4035/5080874079_684cf874e0_m.jpg&quot; width=&quot;240&quot; height=&quot;180&quot; alt=&quot;Star Wars 1 by Smallportfolio_jm08&quot;  class=&quot;pc_img&quot; border=&quot;0&quot; /&gt;&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;\r\n\r\n&lt;div&gt;&lt;span class=&quot;photo_container pc_m bbml_img&quot;&gt;&lt;a href=&quot;/photos/53930889@N04/5081467846/&quot; title=&quot;Star Wars 2 by Smallportfolio_jm08&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm5.staticflickr.com/4071/5081467846_2eec86176d_m.jpg&quot; width=&quot;240&quot; height=&quot;180&quot; alt=&quot;Star Wars 2 by Smallportfolio_jm08&quot;  class=&quot;pc_img&quot; border=&quot;0&quot; /&gt;&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;\r\n\r\n&lt;div&gt;&lt;span class=&quot;photo_container pc_m bbml_img&quot;&gt;&lt;a href=&quot;/photos/53930889@N04/5081467886/&quot; title=&quot;Star Wars 3 by Smallportfolio_jm08&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm5.staticflickr.com/4021/5081467886_d8cca6c8e8_m.jpg&quot; width=&quot;240&quot; height=&quot;180&quot; alt=&quot;Star Wars 3 by Smallportfolio_jm08&quot;  class=&quot;pc_img&quot; border=&quot;0&quot; /&gt;&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;\r\n\r\n&lt;div&gt;&lt;span class=&quot;photo_container pc_m bbml_img&quot;&gt;&lt;a href=&quot;/photos/53930889@N04/5081467910/&quot; title=&quot;Star Wars 4 by Smallportfolio_jm08&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm5.staticflickr.com/4084/5081467910_274bb11fdc_m.jpg&quot; width=&quot;240&quot; height=&quot;180&quot; alt=&quot;Star Wars 4 by Smallportfolio_jm08&quot;  class=&quot;pc_img&quot; border=&quot;0&quot; /&gt;&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;\r\n\r\n&lt;div&gt;&lt;span class=&quot;photo_container pc_m bbml_img&quot;&gt;&lt;a href=&quot;/photos/53930889@N04/5081467948/&quot; title=&quot;Star Wars 5 by Smallportfolio_jm08&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm5.staticflickr.com/4154/5081467948_1a5f200bc0_m.jpg&quot; width=&quot;240&quot; height=&quot;180&quot; alt=&quot;Star Wars 5 by Smallportfolio_jm08&quot;  class=&quot;pc_img&quot; border=&quot;0&quot; /&gt;&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;</message>\r\n    </topic>\r\n    <topic id=\"72157629635119774\" subject=\"Where The Fish Are\" author=\"75240402@N04\" authorname=\"Nokinrocks\" role=\"member\" iconserver=\"7027\" iconfarm=\"8\" count_replies=\"0\" can_edit=\"0\" can_delete=\"0\" can_reply=\"0\" is_sticky=\"0\" is_locked=\"\" datecreate=\"1336485653\" datelastpost=\"1336485653\">\r\n      <message>&lt;a href=&quot;http://www.flickr.com/photos/nokinrocks/7120495637/&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm9.staticflickr.com/8005/7120495637_fec0382b4b_n.jpg&quot; width=&quot;320&quot; height=&quot;256&quot; alt=&quot;Step It Up&quot; /&gt;&lt;/a&gt;\r\n\r\n&lt;a href=&quot;http://www.flickr.com/photos/nokinrocks/7122908705/&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm8.staticflickr.com/7259/7122908705_3bef338378_n.jpg&quot; width=&quot;240&quot; height=&quot;320&quot; alt=&quot;P1050351&quot; /&gt;&lt;/a&gt;\r\n\r\n&lt;a href=&quot;http://www.flickr.com/photos/nokinrocks/7122922123/&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm8.staticflickr.com/7052/7122922123_2bfcb6707c_n.jpg&quot; width=&quot;214&quot; height=&quot;320&quot; alt=&quot;Frog On A Log&quot; /&gt;&lt;/a&gt;\r\n\r\n&lt;a href=&quot;http://www.flickr.com/photos/nokinrocks/7122929521/&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm8.staticflickr.com/7047/7122929521_8ffebdd424_n.jpg&quot; width=&quot;320&quot; height=&quot;200&quot; alt=&quot;P1050397&quot; /&gt;&lt;/a&gt;\r\n\r\n&lt;a href=&quot;http://www.flickr.com/photos/nokinrocks/7122916999/&quot;&gt;&lt;img class=&quot;notsowide&quot; src=&quot;http://farm8.staticflickr.com/7200/7122916999_a7328f9dcc_n.jpg&quot; width=&quot;320&quot; height=&quot;261&quot; alt=&quot;P1050361&quot; /&gt;&lt;/a&gt;</message>\r\n    </topic>\r\n  </topics>\r\n</rsp>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "The NSID or path alias of the group to fetch information for."
+        "optional": "0"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Group not found",
-        "_content": "The group_id is invalid"
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.getInfo.json
+++ b/src/flickr.groups.getInfo.json
@@ -1,93 +1,26 @@
 {
   "method": {
     "name": "flickr.groups.getInfo",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get information about a group."
-    },
-    "response": {
-      "_content": "<group id=\"34427465497@N01\" iconserver=\"1\" iconfarm=\"1\" lang=\"en-us\" ispoolmoderated=\"0\">\r\n\t<name>GNEverybody</name>\r\n\t<description>The group for GNE players</description>\r\n\t<members>69</members>\r\n\t<privacy>3</privacy>\r\n\t<throttle count=\"10\" mode=\"month\" remaining=\"3\"/>\r\n        <restrictions photos_ok=\"1\" videos_ok=\"1\" images_ok=\"1\" screens_ok=\"1\" art_ok=\"1\" safe_ok=\"1\" moderate_ok=\"0\" restricted_ok=\"0\" has_geo=\"0\" />\r\n</group>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "The NSID of the group to fetch information for."
+        "optional": "0"
       },
       {
         "name": "group_path_alias",
-        "optional": "1",
-        "_content": "The path alias of the group. One of this or the group_id param is required"
+        "optional": "1"
       },
       {
         "name": "lang",
-        "optional": "1",
-        "_content": "The language of the group name and description to fetch.  If the language is not found, the primary language of the group will be returned.\r\n\r\nValid values are the same as <a href=\"/services/feeds/\">in feeds</a>."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Group not found",
-        "_content": "The group NSID passed did not refer to a group that the calling user can see - either an invalid group is or a group that can't be seen by the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Group is private",
-        "_content": "This is a private group."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.join.json
+++ b/src/flickr.groups.join.json
@@ -1,140 +1,22 @@
 {
   "method": {
     "name": "flickr.groups.join",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Join a public group as a member."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "The NSID of the Group in question"
+        "optional": "0"
       },
       {
         "name": "accept_rules",
-        "optional": "1",
-        "_content": "If the group has rules, they must be displayed to the user prior to joining. Passing a true value for this argument specifies that the application has displayed the group rules to the user, and that the user has agreed to them. (See flickr.groups.getInfo)."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required arguments missing",
-        "_content": "The group_id doesn't exist"
-      },
-      {
-        "code": "2",
-        "message": "Group does not exist",
-        "_content": "The Group does not exist"
-      },
-      {
-        "code": "3",
-        "message": "Group not availabie to the account",
-        "_content": "The authed account does not have permission to view/join the group."
-      },
-      {
-        "code": "4",
-        "message": "Account is already in that group",
-        "_content": "The authed account has previously joined this group"
-      },
-      {
-        "code": "5",
-        "message": "Membership in group is by invitation only.",
-        "_content": "Use flickr.groups.joinRequest to contact the administrations for an invitation."
-      },
-      {
-        "code": "6",
-        "message": "User must accept the group rules before joining",
-        "_content": "The user must read and accept the rules before joining. Please see the accept_rules argument for this method."
-      },
-      {
-        "code": "10",
-        "message": "Account in maximum number of groups",
-        "_content": "The account is a member of the maximum number of groups."
-      },
-      {
-        "code": "11",
-        "message": "User unable to join",
-        "_content": "This user is unable to join this group."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.joinRequest.json
+++ b/src/flickr.groups.joinRequest.json
@@ -1,140 +1,26 @@
 {
   "method": {
     "name": "flickr.groups.joinRequest",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Request to join a group that is invitation-only."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "The NSID of the group to request joining."
+        "optional": "0"
       },
       {
         "name": "message",
-        "optional": "0",
-        "_content": "Message to the administrators."
+        "optional": "0"
       },
       {
         "name": "accept_rules",
-        "optional": "0",
-        "_content": "If the group has rules, they must be displayed to the user prior to joining. Passing a true value for this argument specifies that the application has displayed the group rules to the user, and that the user has agreed to them. (See flickr.groups.getInfo)."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required arguments missing",
-        "_content": "The group_id or message argument are missing."
-      },
-      {
-        "code": "2",
-        "message": "Group does not exist",
-        "_content": "The Group does not exist"
-      },
-      {
-        "code": "3",
-        "message": "Group not available to the account",
-        "_content": "The authed account does not have permission to view/join the group."
-      },
-      {
-        "code": "4",
-        "message": "Account is already in that group",
-        "_content": "The authed account has previously joined this group"
-      },
-      {
-        "code": "5",
-        "message": "Group is public and open",
-        "_content": "The group does not require an invitation to join, please use flickr.groups.join."
-      },
-      {
-        "code": "6",
-        "message": "User must accept the group rules before joining",
-        "_content": "The user must read and accept the rules before joining. Please see the accept_rules argument for this method."
-      },
-      {
-        "code": "7",
-        "message": "User has already requested to join that group",
-        "_content": "A request has already been sent and is pending approval."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.leave.json
+++ b/src/flickr.groups.leave.json
@@ -1,115 +1,22 @@
 {
   "method": {
     "name": "flickr.groups.leave",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "3",
-    "description": {
-      "_content": "Leave a group.\r\n\r\n<br /><br />If the user is the only administrator left, and there are other members, the oldest member will be promoted to administrator.\r\n\r\n<br /><br />If the user is the last person in the group, the group will be deleted."
-    }
+    "requiredperms": "3"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "The NSID of the Group to leave"
+        "optional": "0"
       },
       {
         "name": "delete_photos",
-        "optional": "1",
-        "_content": "Delete all photos by this user from the group"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required arguments missing",
-        "_content": "The group_id doesn't exist"
-      },
-      {
-        "code": "2",
-        "message": "Group does not exist",
-        "_content": "The group by that ID does not exist"
-      },
-      {
-        "code": "3",
-        "message": "Account is not in that group",
-        "_content": "The user is not a member of the group that was specified"
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.members.getList.json
+++ b/src/flickr.groups.members.getList.json
@@ -1,118 +1,30 @@
 {
   "method": {
     "name": "flickr.groups.members.getList",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get a list of the members of a group.  The call must be signed on behalf of a Flickr member, and the ability to see the group membership will be determined by the Flickr member's group privileges."
-    },
-    "response": {
-      "_content": "<members page=\"1\" pages=\"1\" perpage=\"100\" total=\"33\">\r\n<member nsid=\"123456@N01\" username=\"foo\" iconserver=\"1\" iconfarm=\"1\" membertype=\"2\"/>\r\n<member nsid=\"118210@N07\" username=\"kewlchops666\" iconserver=\"0\" iconfarm=\"0\" membertype=\"4\"/>\r\n<member nsid=\"119377@N07\" username=\"Alpha Shanan\" iconserver=\"0\" iconfarm=\"0\" membertype=\"2\"/>\r\n<member nsid=\"67783977@N00\" username=\"fakedunstanp1\" iconserver=\"1003\" iconfarm=\"2\" membertype=\"3\"/>\r\n...\r\n</members>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "Return a list of members for this group.  The group must be viewable by the Flickr member on whose behalf the API call is made."
+        "optional": "0"
       },
       {
         "name": "membertypes",
-        "optional": "1",
-        "_content": "Comma separated list of member types\r\n<ul>\r\n<li>2: member</li>\r\n<li>3: moderator</li>\r\n<li>4: admin</li>\r\n</ul>\r\nBy default returns all types.  (Returning super rare member type \"1: narwhal\" isn't supported by this API method)"
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of members to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Group not found",
-        "_content": ""
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.pools.add.json
+++ b/src/flickr.groups.pools.add.json
@@ -1,145 +1,22 @@
 {
   "method": {
     "name": "flickr.groups.pools.add",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Add a photo to a group's pool."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to add to the group pool. The photo must belong to the calling user."
+        "optional": "0"
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "The NSID of the group who's pool the photo is to be added to."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not the id of a photo owned by the caling user."
-      },
-      {
-        "code": "2",
-        "message": "Group not found",
-        "_content": "The group id passed was not a valid id for a group the user is a member of."
-      },
-      {
-        "code": "3",
-        "message": "Photo already in pool",
-        "_content": "The specified photo is already in the pool for the specified group."
-      },
-      {
-        "code": "4",
-        "message": "Photo in maximum number of pools",
-        "_content": "The photo has already been added to the maximum allowed number of pools."
-      },
-      {
-        "code": "5",
-        "message": "Photo limit reached",
-        "_content": "The user has already added the maximum amount of allowed photos to the pool."
-      },
-      {
-        "code": "6",
-        "message": "Your Photo has been added to the Pending Queue for this Pool",
-        "_content": "The pool is moderated, and the photo has been added to the Pending Queue. If it is approved by a group administrator, it will be added to the pool."
-      },
-      {
-        "code": "7",
-        "message": "Your Photo has already been added to the Pending Queue for this Pool",
-        "_content": "The pool is moderated, and the photo has already been added to the Pending Queue."
-      },
-      {
-        "code": "8",
-        "message": "Content not allowed",
-        "_content": "The content has been disallowed from the pool by the group admin(s)."
-      },
-      {
-        "code": "10",
-        "message": "Maximum number of photos in Group Pool",
-        "_content": "A group pool has reached the upper limit for the number of photos allowed."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.pools.getContext.json
+++ b/src/flickr.groups.pools.getContext.json
@@ -1,96 +1,22 @@
 {
   "method": {
     "name": "flickr.groups.pools.getContext",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns next and previous photos for a photo in a group pool."
-    },
-    "response": {
-      "_content": "<prevphoto id=\"2980\" secret=\"973da1e709\"\r\n\ttitle=\"boo!\" url=\"/photos/bees/2980/\" /> \r\n<nextphoto id=\"2985\" secret=\"059b664012\"\r\n\ttitle=\"Amsterdam Amstel\" url=\"/photos/bees/2985/\" /> "
-    },
-    "explanation": {
-      "_content": "<p>See <a href=\"/services/api/flickr.photos.getContext.html\">flickr.photos.getContext</a></p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to fetch the context for."
+        "optional": "0"
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "The nsid of the group who's pool to fetch the photo's context for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id, or was the id of a photo that the calling user does not have permission to view."
-      },
-      {
-        "code": "2",
-        "message": "Photo not in pool",
-        "_content": "The specified photo is not in the specified group's pool."
-      },
-      {
-        "code": "3",
-        "message": "Group not found",
-        "_content": "The specified group nsid was not a valid group or the caller does not have permission to view the group's pool."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.pools.getGroups.json
+++ b/src/flickr.groups.pools.getGroups.json
@@ -1,106 +1,22 @@
 {
   "method": {
     "name": "flickr.groups.pools.getGroups",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns a list of groups to which you can add photos."
-    },
-    "response": {
-      "_content": "<groups page=\"1\" pages=\"1\" per_page=\"400\" total=\"3\">\r\n\t<group nsid=\"33853651696@N01\" name=\"Art and Literature Hoedown\"\r\n\t\tadmin=\"0\" privacy=\"3\" photos=\"2\" iconserver=\"1\" /> \r\n\t<group nsid=\"34427465446@N01\" name=\"FlickrIdeas\"\r\n\t\tadmin=\"1\" privacy=\"3\" photos=\"20\" iconserver=\"1\" /> \r\n\t<group nsid=\"34427465497@N01\" name=\"GNEverybody\"\r\n\t\tadmin=\"0\" privacy=\"3\" photos=\"4\" iconserver=\"1\" /> \r\n</groups>"
-    },
-    "explanation": {
-      "_content": "<p>The <code>privacy</code> attribute is 1 for private groups, 2 for invite-only public groups and 3 for open public groups.</p>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of groups to return per page. If this argument is omitted, it defaults to 400. The maximum allowed value is 400."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.pools.getPhotos.json
+++ b/src/flickr.groups.pools.getPhotos.json
@@ -1,118 +1,38 @@
 {
   "method": {
     "name": "flickr.groups.pools.getPhotos",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns a list of pool photos for a given group, based on the permissions of the group and the user logged in (if any)."
-    },
-    "response": {
-      "_content": "<photos page=\"1\" pages=\"1\" perpage=\"1\" total=\"1\">\r\n\t<photo id=\"2645\" owner=\"12037949754@N01\" title=\"36679_o\"\r\n\tsecret=\"a9f4a06091\" server=\"2\"\r\n\tispublic=\"1\" isfriend=\"0\" isfamily=\"0\"\r\n\townername=\"Bees / ?\" dateadded=\"1089918707\" /> \r\n</photos>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "The id of the group who's pool you which to get the photo list for."
+        "optional": "0"
       },
       {
         "name": "tags",
-        "optional": "1",
-        "_content": "A tag to filter the pool with. At the moment only one tag at a time is supported."
+        "optional": "1"
       },
       {
         "name": "user_id",
-        "optional": "1",
-        "_content": "The nsid of a user. Specifiying this parameter will retrieve for you only those photos that the user has contributed to the group pool."
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Group not found",
-        "_content": "The group id passed was not a valid group id."
-      },
-      {
-        "code": "2",
-        "message": "You don't have permission to view this pool",
-        "_content": "The logged in user (if any) does not have permission to view the pool for this group."
-      },
-      {
-        "code": "3",
-        "message": "Unknown user",
-        "_content": "The user specified by user_id does not exist."
-      },
-      {
-        "code": "4",
-        "message": "Group/pool is member only",
-        "_content": ""
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.pools.remove.json
+++ b/src/flickr.groups.pools.remove.json
@@ -1,115 +1,22 @@
 {
   "method": {
     "name": "flickr.groups.pools.remove",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Remove a photo from a group pool."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to remove from the group pool. The photo must either be owned by the calling user of the calling user must be an administrator of the group."
+        "optional": "0"
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "The NSID of the group who's pool the photo is to removed from."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Group not found",
-        "_content": "The group_id passed did not refer to a valid group."
-      },
-      {
-        "code": "2",
-        "message": "Photo not in pool",
-        "_content": "The photo_id passed was not a valid id of a photo in the group pool."
-      },
-      {
-        "code": "3",
-        "message": "Insufficient permission to remove photo",
-        "_content": "The calling user doesn't own the photo and is not an administrator of the group, so may not remove the photo from the pool."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.groups.search.json
+++ b/src/flickr.groups.search.json
@@ -1,88 +1,26 @@
 {
   "method": {
     "name": "flickr.groups.search",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Search for groups. 18+ groups will only be returned for authenticated calls where the authenticated user is over 18."
-    },
-    "response": {
-      "_content": "<groups page=\"1\" pages=\"14\" perpage=\"5\" total=\"67\">\r\n\t<group nsid=\"3000@N02\"\r\n\t\tname=\"Frito's Test Group\" eighteenplus=\"0\" /> \r\n\t<group nsid=\"32825757@N00\"\r\n\t\tname=\"Free for All\" eighteenplus=\"0\" /> \r\n\t<group nsid=\"33335981560@N01\"\r\n\t\tname=\"joly's mothers\" eighteenplus=\"0\" /> \r\n\t<group nsid=\"33853651681@N01\"\r\n\t\tname=\"Wintermute tower\" eighteenplus=\"0\" /> \r\n\t<group nsid=\"33853651696@N01\"\r\n\t\tname=\"Art and Literature Hoedown\" eighteenplus=\"0\" /> \r\n</groups>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "text",
-        "optional": "0",
-        "_content": "The text to search for."
+        "optional": "0"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of groups to return per page. If this argument is ommited, it defaults to 100. The maximum allowed value is 500."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is ommited, it defaults to 1. "
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "No text passed",
-        "_content": "The required text argument was ommited."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.interestingness.getList.json
+++ b/src/flickr.interestingness.getList.json
@@ -1,90 +1,30 @@
 {
   "method": {
     "name": "flickr.interestingness.getList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the list of interesting photos for the most recent day or a user-specified date."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "1",
-        "_content": "A specific date, formatted as YYYY-MM-DD, to return interesting photos for."
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Not a valid date string.",
-        "_content": "The date string passed did not validate. All dates must be formatted : YYYY-MM-DD"
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.machinetags.getNamespaces.json
+++ b/src/flickr.machinetags.getNamespaces.json
@@ -1,91 +1,26 @@
 {
   "method": {
     "name": "flickr.machinetags.getNamespaces",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a list of unique namespaces, optionally limited by a given predicate, in alphabetical order."
-    },
-    "response": {
-      "_content": "<namespaces page=\"1\" total=\"5\" perpage=\"500\" pages=\"1\">\r\n  <namespace usage=\"6538\" predicates=\"13\">aero</namespace>\r\n  <namespace usage=\"9072\" predicates=\"24\">flickr</namespace>\r\n  <namespace usage=\"670270\" predicates=\"35\">geo</namespace>\r\n  <namespace usage=\"23903\" predicates=\"36\">taxonomy</namespace>\r\n  <namespace usage=\"50449\" predicates=\"4\">upcoming</namespace>\r\n</namespaces>\r\n"
-    },
-    "explanation": {
-      "_content": "\"Usage\" gives you roughly how popular a machine tags, while \"predicates\" is the count of distinct predicates a namespace has."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "predicate",
-        "optional": "1",
-        "_content": "Limit the list of namespaces returned to those that have the following predicate."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Not a valid predicate.",
-        "_content": "Missing or invalid predicate argument."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.machinetags.getPairs.json
+++ b/src/flickr.machinetags.getPairs.json
@@ -1,98 +1,30 @@
 {
   "method": {
     "name": "flickr.machinetags.getPairs",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a list of unique namespace and predicate pairs, optionally limited by predicate or namespace, in alphabetical order."
-    },
-    "response": {
-      "_content": "<pairs page=\"1\" total=\"1228\" perpage=\"500\" pages=\"3\">\r\n   <pair namespace=\"aero\" predicate=\"airline\" usage=\"1093\">aero:airline</pair>\r\n   <pair namespace=\"aero\" predicate=\"icao\" usage=\"4\">aero:icao</pair>\r\n   <pair namespace=\"aero\" predicate=\"model\" usage=\"1026\">aero:model</pair>\r\n   <pair namespace=\"aero\" predicate=\"tail\" usage=\"1048\">aero:tail</pair>\r\n</pairs>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "namespace",
-        "optional": "1",
-        "_content": "Limit the list of pairs returned to those that have the following namespace."
+        "optional": "1"
       },
       {
         "name": "predicate",
-        "optional": "1",
-        "_content": "Limit the list of pairs returned to those that have the following predicate."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Not a valid namespace",
-        "_content": "Missing or invalid namespace argument."
-      },
-      {
-        "code": "2",
-        "message": "Not a valid predicate",
-        "_content": "Missing or invalid predicate argument."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.machinetags.getPredicates.json
+++ b/src/flickr.machinetags.getPredicates.json
@@ -1,88 +1,26 @@
 {
   "method": {
     "name": "flickr.machinetags.getPredicates",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a list of unique predicates, optionally limited by a given namespace."
-    },
-    "response": {
-      "_content": "<predicates page=\"1\" pages=\"1\" total=\"3\" perpage=\"500\">\r\n    <predicate usage=\"20\" namespaces=\"1\">elbow</predicate>\r\n    <predicate usage=\"52\" namespaces=\"2\">face</predicate>\r\n    <predicate usage=\"10\" namespaces=\"1\">hand</predicate>\r\n</predicates>\r\n"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "namespace",
-        "optional": "1",
-        "_content": "Limit the list of predicates returned to those that have the following namespace."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Not a valid namespace",
-        "_content": "Missing or invalid namespace argument."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.machinetags.getRecentValues.json
+++ b/src/flickr.machinetags.getRecentValues.json
@@ -1,83 +1,26 @@
 {
   "method": {
     "name": "flickr.machinetags.getRecentValues",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Fetch recently used (or created) machine tags values."
-    },
-    "response": {
-      "_content": "<values namespace=\"taxonomy\" predicate=\"common\" page=\"1\" total=\"500\" perpage=\"500\" pages=\"1\">\r\n    <value usage=\"4\" namespace=\"taxonomy\" predicate=\"common\"\r\n           first_added=\"1244232796\" last_added=\"1244232796\">maui chaff flower</value>\r\n\r\n    <!-- and so on... -->\r\n</values>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "namespace",
-        "optional": "1",
-        "_content": "A namespace that all values should be restricted to."
+        "optional": "1"
       },
       {
         "name": "predicate",
-        "optional": "1",
-        "_content": "A predicate that all values should be restricted to."
+        "optional": "1"
       },
       {
         "name": "added_since",
-        "optional": "1",
-        "_content": "Only return machine tags values that have been added since this timestamp, in epoch seconds.  "
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.machinetags.getValues.json
+++ b/src/flickr.machinetags.getValues.json
@@ -1,98 +1,30 @@
 {
   "method": {
     "name": "flickr.machinetags.getValues",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a list of unique values for a namespace and predicate."
-    },
-    "response": {
-      "_content": "<values namespace=\"upcoming\" predicate=\"event\" page=\"1\" pages=\"1\" total=\"3\" perpage=\"500\">\r\n    <value usage=\"3\">123</value>\r\n    <value usage=\"1\">456</value>\r\n    <value usage=\"147\">789</value>\r\n</values>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "namespace",
-        "optional": "0",
-        "_content": "The namespace that all values should be restricted to."
+        "optional": "0"
       },
       {
         "name": "predicate",
-        "optional": "0",
-        "_content": "The predicate that all values should be restricted to."
+        "optional": "0"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Not a valid namespace",
-        "_content": "Missing or invalid namespace argument."
-      },
-      {
-        "code": "2",
-        "message": "Not a valid predicate",
-        "_content": "Missing or invalid predicate argument."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.panda.getList.json
+++ b/src/flickr.panda.getList.json
@@ -1,68 +1,14 @@
 {
   "method": {
     "name": "flickr.panda.getList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a list of <a href=\"http://www.flickr.com/explore/panda\">Flickr pandas</a>, from whom you can request photos using the <a href=\"/services/api/flickr.panda.getPhotos.htm\">flickr.panda.getPhotos</a> API method.\r\n<br/><br/>\r\nMore information about the pandas can be found on the <a href=\"http://code.flickr.com/blog/2009/03/03/panda-tuesday-the-history-of-the-panda-new-apis-explore-and-you/\">dev blog</a>."
-    },
-    "response": {
-      "_content": "<pandas>\r\n   <panda>ling ling</panda>\r\n   <panda>hsing hsing</panda>\r\n   <panda>wang wang</panda>\r\n</pandas>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.panda.getPhotos.json
+++ b/src/flickr.panda.getPhotos.json
@@ -1,101 +1,30 @@
 {
   "method": {
     "name": "flickr.panda.getPhotos",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Ask the <a href=\"http://www.flickr.com/explore/panda\">Flickr Pandas</a> for a list of recent public (and \"safe\") photos.\r\n<br/><br/>\r\nMore information about the pandas can be found on the <a href=\"http://code.flickr.com/blog/2009/03/03/panda-tuesday-the-history-of-the-panda-new-apis-explore-and-you/\">dev blog</a>."
-    },
-    "response": {
-      "_content": "<photos interval=\"60000\" lastupdate=\"1235765058272\" total=\"120\" panda=\"ling ling\">\r\n    <photo title=\"Shorebirds at Pillar Point\" id=\"3313428913\" secret=\"2cd3cb44cb\"\r\n        server=\"3609\" farm=\"4\" owner=\"72442527@N00\" ownername=\"Pat Ulrich\"/>\r\n    <photo title=\"Battle of the sky\" id=\"3313713993\" secret=\"3f7f51500f\"\r\n        server=\"3382\" farm=\"4\" owner=\"10459691@N05\" ownername=\"Sven Ericsson\"/>\r\n    <!-- and so on -->\r\n</photos>"
-    },
-    "explanation": {
-      "_content": "When calling this API method please ensure that your code uses the <strong>lastupdate</strong> and <strong>interval</strong> attributes to determine when to request new photos. <em>lastupdate</em> is a Unix timestamp indicating when the list of photos was generated and <em>interval</em> is the number of seconds to wait before polling the Flickr API again."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "panda_name",
-        "optional": "0",
-        "_content": "The name of the panda to ask for photos from. There are currently three pandas named:<br /><br />\r\n\r\n<ul>\r\n<li><strong><a href=\"http://flickr.com/photos/ucumari/126073203/\">ling ling</a></strong></li>\r\n<li><strong><a href=\"http://flickr.com/photos/lynnehicks/136407353\">hsing hsing</a></strong></li>\r\n<li><strong><a href=\"http://flickr.com/photos/perfectpandas/1597067182/\">wang wang</a></strong></li>\r\n</ul>\r\n\r\n<br />You can fetch a list of all the current pandas using the <a href=\"/services/api/flickr.panda.getList.html\">flickr.panda.getList</a> API method."
+        "optional": "0"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required parameter missing.",
-        "_content": "One or more required parameters was not included with your request."
-      },
-      {
-        "code": "2",
-        "message": "Unknown panda",
-        "_content": "You requested a panda we haven't met yet."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.people.findByEmail.json
+++ b/src/flickr.people.findByEmail.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.people.findByEmail",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a user's NSID, given their email address"
-    },
-    "response": {
-      "_content": "<user nsid=\"12037949632@N01\">\r\n\t<username>Stewart</username> \r\n</user>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "find_email",
-        "optional": "0",
-        "_content": "The email address of the user to find  (may be primary or secondary)."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "No user with the supplied email address was found."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.people.findByUsername.json
+++ b/src/flickr.people.findByUsername.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.people.findByUsername",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a user's NSID, given their username."
-    },
-    "response": {
-      "_content": "<user nsid=\"12037949632@N01\">\r\n\t<username>Stewart</username> \r\n</user>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "username",
-        "optional": "0",
-        "_content": "The username of the user to lookup."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "No user with the supplied username was found."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.people.getGroups.json
+++ b/src/flickr.people.getGroups.json
@@ -1,111 +1,22 @@
 {
   "method": {
     "name": "flickr.people.getGroups",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns the list of groups a user is a member of."
-    },
-    "response": {
-      "_content": "<groups>\r\n  <group nsid=\"17274427@N00\" name=\"Cream of the Crop - Please read the rules\" iconfarm=\"1\" iconserver=\"1\" admin=\"0\" eighteenplus=\"0\" invitation_only=\"0\" members=\"11935\" pool_count=\"12522\" />\r\n  <group nsid=\"20083316@N00\" name=\"Apple\" iconfarm=\"1\" iconserver=\"1\" admin=\"0\" eighteenplus=\"0\" invitation_only=\"0\" members=\"11776\" pool_count=\"62438\" />\r\n  <group nsid=\"34427469792@N01\" name=\"FlickrCentral\" iconfarm=\"1\" iconserver=\"1\" admin=\"0\" eighteenplus=\"0\" invitation_only=\"0\" members=\"168055\" pool_count=\"5280930\" />\r\n  <group nsid=\"37718678610@N01\" name=\"Typography and Lettering\" iconfarm=\"1\" iconserver=\"1\" admin=\"0\" eighteenplus=\"0\" invitation_only=\"0\" members=\"17318\" pool_count=\"130169\" />\r\n</groups>"
-    },
-    "explanation": {
-      "_content": "The admin attribute indicates whether the user is an administrator of the group. The eighteenplus attribute indicates if the group is visible to members over 18 only. The invite_only attribute indicates whether a user can join the group without administrator approval."
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the user to fetch groups for."
+        "optional": "0"
       },
       {
         "name": "extras",
-        "optional": "1",
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>privacy</code>, <code>throttle</code>, <code>restrictions</code>"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The user id passed did not match a Flickr user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.people.getInfo.json
+++ b/src/flickr.people.getInfo.json
@@ -1,81 +1,18 @@
 {
   "method": {
     "name": "flickr.people.getInfo",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get information about a user."
-    },
-    "response": {
-      "_content": "<person nsid=\"12037949754@N01\" ispro=\"0\" iconserver=\"122\" iconfarm=\"1\">\r\n\t<username>bees</username>\r\n\t<realname>Cal Henderson</realname>\r\n        <mbox_sha1sum>eea6cd28e3d0003ab51b0058a684d94980b727ac</mbox_sha1sum>\r\n\t<location>Vancouver, Canada</location>\r\n\t<photosurl>http://www.flickr.com/photos/bees/</photosurl> \r\n\t<profileurl>http://www.flickr.com/people/bees/</profileurl> \r\n\t<photos>\r\n\t\t<firstdate>1071510391</firstdate>\r\n\t\t<firstdatetaken>1900-09-02 09:11:24</firstdatetaken>\r\n\t\t<count>449</count>\r\n\t</photos>\r\n</person>"
-    },
-    "explanation": {
-      "_content": "<p>The <code>firstdate</code> element contains the unix timestamp of the first photo uploaded by the user. The <code>firstdatetaken</code> element contains the mysql datetime of the first photo taken by the user.</p>\r\n<p>The <code>iconserver</code> element is used to build the url to the users' buddyicon - for more information please read the <a href=\"/services/api/misc.buddyicons.html\">buddyicon guide</a>.</p>\r\n<p>\r\nIf the API call is authenticated contact information will also be returned as attributes on the person element.  <code>contact</code>, <code>friend</code>, and <code>family</code> are boolean flags describing the relationship between the <a href=\"/services/api/auth.spec.html\">authenticated</a> user, and the person currently being inspected.   <code>revcontact</code>, <code>revfriend</code>, and <code>revfamily</code> is the reciprocal relationship.\r\n</p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the user to fetch information about."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The user id passed did not match a Flickr user."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.people.getLimits.json
+++ b/src/flickr.people.getLimits.json
@@ -1,96 +1,14 @@
 {
   "method": {
     "name": "flickr.people.getLimits",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns the photo and video limits that apply to the calling user account."
-    },
-    "response": {
-      "_content": "<person nsid=\"30135021@N05\">\r\n\t<photos maxdisplaypx=\"1024\" maxupload=\"15728640\" />\r\n\t<videos maxduration=\"90\" maxupload=\"157286400\" />\r\n</person>"
-    },
-    "explanation": {
-      "_content": "<ul>\r\n<li>photos/@maxdisplaypx: maximum size in pixels for photos displayed on the site (0 means that no limit is in place). No limit is placed on the dimension of photos uploaded.</li>\r\n<li>photos/@maxupload: maximum file size in bytes for photo uploads.</li>\r\n<li>videos/@maxduration: maximum duration in seconds of a video.</li>\r\n<li>videos/@maxupload: maximum file size in bytes for video uploads.</li>\r\n</ul>\r\n\r\n<p>For more details, see the documentation about <a href=\"http://www.flickr.com/help/limits/\">limits</a>.</p>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.people.getPhotos.json
+++ b/src/flickr.people.getPhotos.json
@@ -1,130 +1,58 @@
 {
   "method": {
     "name": "flickr.people.getPhotos",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return photos from the given user's photostream. Only photos visible to the calling user will be returned. This method must be authenticated; to return public photos for a user, use <a href=\"/services/api/flickr.people.getPublicPhotos.html\">flickr.people.getPublicPhotos</a>."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the user who's photos to return. A value of \"me\" will return the calling user's photos."
+        "optional": "0"
       },
       {
         "name": "safe_search",
-        "optional": "1",
-        "_content": "Safe search setting:\r\n\r\n<ul>\r\n<li>1 for safe.</li>\r\n<li>2 for moderate.</li>\r\n<li>3 for restricted.</li>\r\n</ul>\r\n\r\n(Please note: Un-authed calls can only see Safe content.)"
+        "optional": "1"
       },
       {
         "name": "min_upload_date",
-        "optional": "1",
-        "_content": "Minimum upload date. Photos with an upload date greater than or equal to this value will be returned. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "max_upload_date",
-        "optional": "1",
-        "_content": "Maximum upload date. Photos with an upload date less than or equal to this value will be returned. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "min_taken_date",
-        "optional": "1",
-        "_content": "Minimum taken date. Photos with an taken date greater than or equal to this value will be returned. The date should be in the form of a mysql datetime."
+        "optional": "1"
       },
       {
         "name": "max_taken_date",
-        "optional": "1",
-        "_content": "Maximum taken date. Photos with an taken date less than or equal to this value will be returned. The date should be in the form of a mysql datetime."
+        "optional": "1"
       },
       {
         "name": "content_type",
-        "optional": "1",
-        "_content": "Content Type setting:\r\n<ul>\r\n<li>1 for photos only.</li>\r\n<li>2 for screenshots only.</li>\r\n<li>3 for 'other' only.</li>\r\n<li>4 for photos and screenshots.</li>\r\n<li>5 for screenshots and 'other'.</li>\r\n<li>6 for photos and 'other'.</li>\r\n<li>7 for photos, screenshots, and 'other' (all).</li>\r\n</ul>"
+        "optional": "1"
       },
       {
         "name": "privacy_filter",
-        "optional": "1",
-        "_content": "Return photos only matching a certain privacy level. This only applies when making an authenticated call to view photos you own. Valid values are:\r\n<ul>\r\n<li>1 public photos</li>\r\n<li>2 private photos visible to friends</li>\r\n<li>3 private photos visible to family</li>\r\n<li>4 private photos visible to friends & family</li>\r\n<li>5 completely private photos</li>\r\n</ul>"
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required arguments missing",
-        "_content": ""
-      },
-      {
-        "code": "2",
-        "message": "Unknown user",
-        "_content": "A user_id was passed which did not match a valid flickr user."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.people.getPhotosOf.json
+++ b/src/flickr.people.getPhotosOf.json
@@ -1,101 +1,34 @@
 {
   "method": {
     "name": "flickr.people.getPhotosOf",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns a list of photos containing a particular Flickr member."
-    },
-    "response": {
-      "_content": "<photos page=\"2\" has_next_page=\"1\" perpage=\"10\">\r\n\t<photo id=\"2636\" owner=\"47058503995@N01\" \r\n\t\tsecret=\"a123456\" server=\"2\" title=\"test_04\"\r\n\t\tispublic=\"1\" isfriend=\"0\" isfamily=\"0\" />\r\n\t<photo id=\"2635\" owner=\"47058503995@N01\"\r\n\t\tsecret=\"b123456\" server=\"2\" title=\"test_03\"\r\n\t\tispublic=\"0\" isfriend=\"1\" isfamily=\"1\" />\r\n\t<photo id=\"2633\" owner=\"47058503995@N01\"\r\n\t\tsecret=\"c123456\" server=\"2\" title=\"test_01\"\r\n\t\tispublic=\"1\" isfriend=\"0\" isfamily=\"0\" />\r\n\t<photo id=\"2610\" owner=\"12037949754@N01\"\r\n\t\tsecret=\"d123456\" server=\"2\" title=\"00_tall\"\r\n\t\tispublic=\"1\" isfriend=\"0\" isfamily=\"0\" />\r\n</photos>"
-    },
-    "explanation": {
-      "_content": "<p>This method returns a variant of the standard photo list xml.</p>\r\n\r\n<p>For queries about a member other than the currently authenticated one, pagination data (\"total\" and \"pages\" attributes) will not be available.</p>\r\n\r\n<p>Instead, the <photos> element will contain a boolean value 'has_next_page' which will tell you whether or not there are more photos to fetch.</p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the user you want to find photos of. A value of \"me\" will search against photos of the calling user, for authenticated calls."
+        "optional": "0"
       },
       {
         "name": "owner_id",
-        "optional": "1",
-        "_content": "An NSID of a Flickr member. This will restrict the list of photos to those taken by that member."
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>date_person_added</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found.",
-        "_content": "A user_id was passed which did not match a valid flickr user."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.people.getPublicGroups.json
+++ b/src/flickr.people.getPublicGroups.json
@@ -1,86 +1,22 @@
 {
   "method": {
     "name": "flickr.people.getPublicGroups",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the list of public groups a user is a member of."
-    },
-    "response": {
-      "_content": "<groups>\r\n\t<group nsid=\"34427469792@N01\" name=\"FlickrCentral\"\r\n\t\tadmin=\"0\" eighteenplus=\"0\" invitation_only=\"0\" /> \r\n\t<group nsid=\"37114057624@N01\" name=\"Cal's Test Group\"\r\n\t\tadmin=\"1\" eighteenplus=\"0\" invitation_only=\"1\" /> \r\n\t<group nsid=\"34955637532@N01\" name=\"18+ Group\"\r\n\t\tadmin=\"1\" eighteenplus=\"1\" invitation_only=\"0\" /> \r\n</groups>"
-    },
-    "explanation": {
-      "_content": "<p>The <code>admin</code> attribute indicates whether the user is an administrator of the group. The <code>eighteenplus</code> attribute indicates if the group is visible to members over 18 only. The <code>invite_only</code> attribute indicates whether a user can join the group without administrator approval.</p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the user to fetch groups for."
+        "optional": "0"
       },
       {
         "name": "invitation_only",
-        "optional": "1",
-        "_content": "Include public groups that require <a href=\"http://www.flickr.com/help/groups/#10\">an invitation</a> or administrator approval to join."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The user id passed did not match a Flickr user."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.people.getPublicPhotos.json
+++ b/src/flickr.people.getPublicPhotos.json
@@ -1,95 +1,34 @@
 {
   "method": {
     "name": "flickr.people.getPublicPhotos",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get a list of public photos for the given user."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the user who's photos to return."
+        "optional": "0"
       },
       {
         "name": "safe_search",
-        "optional": "1",
-        "_content": "Safe search setting:\r\n\r\n<ul>\r\n<li>1 for safe.</li>\r\n<li>2 for moderate.</li>\r\n<li>3 for restricted.</li>\r\n</ul>\r\n\r\n(Please note: Un-authed calls can only see Safe content.)"
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The user NSID passed was not a valid user NSID."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.people.getUploadStatus.json
+++ b/src/flickr.people.getUploadStatus.json
@@ -1,96 +1,14 @@
 {
   "method": {
     "name": "flickr.people.getUploadStatus",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns information for the calling user related to photo uploads."
-    },
-    "response": {
-      "_content": "<user id=\"12037949754@N01\" ispro=\"1\">\r\n\t<username>Bees</username> \r\n\t<bandwidth\r\n\t\tmaxbytes=\"2147483648\" maxkb=\"2097152\"\r\n\t\tusedbytes=\"383724\" usedkb=\"374\"\r\n\t\tremainingbytes=\"2147099924\" remainingkb=\"2096777\"\r\n\t /> \r\n\t<filesize\r\n\t\tmaxbytes=\"10485760\" maxkb=\"10240\"\r\n\t/> \r\n\t<sets\r\n\t\tcreated=\"27\"\r\n\t\tremaining=\"lots\"\r\n\t/>\r\n\t<videos\r\n\t\tuploaded=\"5\"\r\n\t\tremaining=\"lots\"\r\n\t/>\r\n</user>"
-    },
-    "explanation": {
-      "_content": "<p>Bandwidth and filesize numbers are provided in bytes and kilobytes. If you're using 32bit numbers, stick to using the kilobyte values - they shouldn't ever exceed 2/4 billion, while the byte values will.</p>\r\n\r\n<p>Bandwidth is specified in bytes/kb per month.</p>\r\n\r\n\r\n<p>All accounts display \"lots\" for the number of remaining sets, but remains in the response for backwards compatibility.</p>\r\n\r\n<p>Pro accounts display \"lots\" for the number of remaining videos, while free users will display 0, 1, or 2.</p>\r\n"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.addTags.json
+++ b/src/flickr.photos.addTags.json
@@ -1,110 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.addTags",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Add tags to a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to add tags to."
+        "optional": "0"
       },
       {
         "name": "tags",
-        "optional": "0",
-        "_content": "The tags to add to the photo."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not the id of a photo that the calling user can add tags to. It could be an invalid id, or the user may not have permission to add tags to it."
-      },
-      {
-        "code": "2",
-        "message": "Maximum number of tags reached",
-        "_content": "The maximum number of tags for the photo has been reached - no more tags can be added. If the current count is less than the maximum, but adding all of the tags for this request would go over the limit, the whole request is ignored. I.E. when you get this message, none of the requested tags have been added."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.comments.addComment.json
+++ b/src/flickr.photos.comments.addComment.json
@@ -1,118 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.comments.addComment",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Add comment to a photo as the currently authenticated user."
-    },
-    "response": {
-      "_content": "<comment id=\"97777-72057594037941949-72057594037942602\" />"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to add a comment to."
+        "optional": "0"
       },
       {
         "name": "comment_text",
-        "optional": "0",
-        "_content": "Text of the comment"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found.",
-        "_content": "The photo id passed was not a valid photo id"
-      },
-      {
-        "code": "8",
-        "message": "Blank comment.",
-        "_content": "Comment text can not be blank"
-      },
-      {
-        "code": "9",
-        "message": "User is posting comments too fast.",
-        "_content": "The user has reached the limit for number of comments posted during a specific time period.  Wait a bit and try again."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.comments.deleteComment.json
+++ b/src/flickr.photos.comments.deleteComment.json
@@ -1,105 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.comments.deleteComment",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Delete a comment as the currently authenticated user."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "comment_id",
-        "optional": "0",
-        "_content": "The id of the comment to edit."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found.",
-        "_content": "The requested comment is against a photo which no longer exists."
-      },
-      {
-        "code": "2",
-        "message": "Comment not found.",
-        "_content": "The comment id passed was not a valid comment id"
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.comments.editComment.json
+++ b/src/flickr.photos.comments.editComment.json
@@ -1,115 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.comments.editComment",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Edit the text of a comment as the currently authenticated user."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "comment_id",
-        "optional": "0",
-        "_content": "The id of the comment to edit."
+        "optional": "0"
       },
       {
         "name": "comment_text",
-        "optional": "0",
-        "_content": "Update the comment to this text."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found.",
-        "_content": "The requested comment is against a photo which no longer exists."
-      },
-      {
-        "code": "2",
-        "message": "Comment not found.",
-        "_content": "The comment id passed was not a valid comment id"
-      },
-      {
-        "code": "8",
-        "message": "Blank comment.",
-        "_content": "Comment text can not be blank"
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.comments.getList.json
+++ b/src/flickr.photos.comments.getList.json
@@ -1,88 +1,26 @@
 {
   "method": {
     "name": "flickr.photos.comments.getList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the comments for a photo"
-    },
-    "response": {
-      "_content": "<comments photo_id=\"109722179\">\r\n        <comment id=\"6065-109722179-72057594077818641\"\r\n         author=\"35468159852@N01\" authorname=\"Rev Dan Catt\" datecreate=\"1141841470\"\r\n         permalink=\"http://www.flickr.com/photos/straup/109722179/#comment72057594077818641\"\r\n         >Umm, I'm not sure, can I get back to you on that one?</comment>\r\n</comments>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to fetch comments for."
+        "optional": "0"
       },
       {
         "name": "min_comment_date",
-        "optional": "1",
-        "_content": "Minimum date that a a comment was added. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "max_comment_date",
-        "optional": "1",
-        "_content": "Maximum date that a comment was added. The date should be in the form of a unix timestamp."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id was either invalid or was for a photo not viewable by the calling user."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.comments.getRecentForContacts.json
+++ b/src/flickr.photos.comments.getRecentForContacts.json
@@ -1,115 +1,34 @@
 {
   "method": {
     "name": "flickr.photos.comments.getRecentForContacts",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Return the list of photos belonging to your contacts that have been commented on recently."
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date_lastcomment",
-        "optional": "1",
-        "_content": "Limits the resultset to photos that have been commented on since this date. The date should be in the form of a Unix timestamp.<br /><br />\r\nThe default, and maximum, offset is (1) hour.\r\n\r\n\r\n"
+        "optional": "1"
       },
       {
         "name": "contacts_filter",
-        "optional": "1",
-        "_content": "A comma-separated list of contact NSIDs to limit the scope of the query to."
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.delete.json
+++ b/src/flickr.photos.delete.json
@@ -1,100 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.delete",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "3",
-    "description": {
-      "_content": "Delete a photo from flickr."
-    }
+    "requiredperms": "3"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to delete."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id was not the id of a photo belonging to the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.geo.batchCorrectLocation.json
+++ b/src/flickr.photos.geo.batchCorrectLocation.json
@@ -1,145 +1,34 @@
 {
   "method": {
     "name": "flickr.photos.geo.batchCorrectLocation",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Correct the places hierarchy for all the photos for a user at a given latitude, longitude and accuracy.<br /><br />\r\n\r\nBatch corrections are processed in a delayed queue so it may take a few minutes before the changes are reflected in a user's photos."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "lat",
-        "optional": "0",
-        "_content": "The latitude of the photos to be update whose valid range is -90 to 90. Anything more than 6 decimal places will be truncated."
+        "optional": "0"
       },
       {
         "name": "lon",
-        "optional": "0",
-        "_content": "The longitude of the photos to be updated whose valid range is -180 to 180. Anything more than 6 decimal places will be truncated."
+        "optional": "0"
       },
       {
         "name": "accuracy",
-        "optional": "0",
-        "_content": "Recorded accuracy level of the photos to be updated. World level is 1, Country is ~3, Region ~6, City ~11, Street ~16. Current range is 1-16. Defaults to 16 if not specified."
+        "optional": "0"
       },
       {
         "name": "place_id",
-        "optional": "1",
-        "_content": "A Flickr Places ID. (While optional, you must pass either a valid Places ID or a WOE ID.)"
+        "optional": "1"
       },
       {
         "name": "woe_id",
-        "optional": "1",
-        "_content": "A Where On Earth (WOE) ID. (While optional, you must pass either a valid Places ID or a WOE ID.)"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required arguments missing",
-        "_content": "Some or all of the required arguments were not supplied."
-      },
-      {
-        "code": "2",
-        "message": "Not a valid latitude",
-        "_content": "The latitude argument failed validation."
-      },
-      {
-        "code": "3",
-        "message": "Not a valid longitude",
-        "_content": "The longitude argument failed validation."
-      },
-      {
-        "code": "4",
-        "message": "Not a valid accuracy",
-        "_content": "The accuracy argument failed validation."
-      },
-      {
-        "code": "5",
-        "message": "Not a valid Places ID",
-        "_content": "An invalid Places (or WOE) ID was passed with the API call."
-      },
-      {
-        "code": "6",
-        "message": "No photos geotagged at that location",
-        "_content": "There were no geotagged photos found for the authed user at the supplied latitude, longitude and accuracy."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.geo.correctLocation.json
+++ b/src/flickr.photos.geo.correctLocation.json
@@ -1,130 +1,30 @@
 {
   "method": {
     "name": "flickr.photos.geo.correctLocation",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": ""
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The ID of the photo whose WOE location is being corrected."
+        "optional": "0"
       },
       {
         "name": "place_id",
-        "optional": "1",
-        "_content": "A Flickr Places ID. (While optional, you must pass either a valid Places ID or a WOE ID.)"
+        "optional": "1"
       },
       {
         "name": "woe_id",
-        "optional": "1",
-        "_content": "A Where On Earth (WOE) ID. (While optional, you must pass either a valid Places ID or a WOE ID.)"
+        "optional": "1"
       },
       {
         "name": "foursquare_id",
-        "optional": "0",
-        "_content": "The venue ID for a Foursquare location. (If not passed in with correction, any existing foursquare venue will be removed)."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User has not configured default viewing settings for location data.",
-        "_content": "Before users may assign location data to a photo they must define who, by default, may view that information. Users can edit this preference at <a href=\"http://www.flickr.com/account/geo/privacy/\">http://www.flickr.com/account/geo/privacy/</a>"
-      },
-      {
-        "code": "2",
-        "message": "Missing place ID",
-        "_content": "No place ID was passed to the method"
-      },
-      {
-        "code": "3",
-        "message": "Not a valid place ID",
-        "_content": "The place ID passed to the method could not be identified"
-      },
-      {
-        "code": "4",
-        "message": "Server error correcting location.",
-        "_content": "There was an error trying to correct the location."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.geo.getLocation.json
+++ b/src/flickr.photos.geo.getLocation.json
@@ -1,88 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.geo.getLocation",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get the geo data (latitude and longitude and the accuracy level) for a photo."
-    },
-    "response": {
-      "_content": "<photo id=\"123\">\r\n        <location latitude=\"-17.685895\" longitude=\"-63.36914\" accuracy=\"6\" />\r\n</photo>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo you want to retrieve location data for."
+        "optional": "0"
       },
       {
         "name": "extras",
-        "optional": "1",
-        "_content": "Extra flags."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found.",
-        "_content": "The photo id was either invalid or was for a photo not viewable by the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Photo has no location information.",
-        "_content": "The photo requested has no location data or is not viewable by the calling user."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.geo.getPerms.json
+++ b/src/flickr.photos.geo.getPerms.json
@@ -1,108 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.geo.getPerms",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get permissions for who may view geo data for a photo."
-    },
-    "response": {
-      "_content": "<perms id=\"10592\" ispublic=\"0\" iscontact=\"0\" isfriend=\"0\" isfamily=\"1\" />"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to get permissions for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id was either invalid or was for a photo not viewable by the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Photo has no location information",
-        "_content": "The photo requested has no location data or is not viewable by the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.geo.photosForLocation.json
+++ b/src/flickr.photos.geo.photosForLocation.json
@@ -1,140 +1,38 @@
 {
   "method": {
     "name": "flickr.photos.geo.photosForLocation",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Return a list of photos for the calling user at a specific latitude, longitude and accuracy"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "lat",
-        "optional": "0",
-        "_content": "The latitude whose valid range is -90 to 90. Anything more than 6 decimal places will be truncated."
+        "optional": "0"
       },
       {
         "name": "lon",
-        "optional": "0",
-        "_content": "The longitude whose valid range is -180 to 180. Anything more than 6 decimal places will be truncated."
+        "optional": "0"
       },
       {
         "name": "accuracy",
-        "optional": "1",
-        "_content": "Recorded accuracy level of the location information. World level is 1, Country is ~3, Region ~6, City ~11, Street ~16. Current range is 1-16. Defaults to 16 if not specified."
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required arguments missing",
-        "_content": "One or more required arguments was missing from the method call."
-      },
-      {
-        "code": "2",
-        "message": "Not a valid latitude",
-        "_content": "The latitude argument failed validation."
-      },
-      {
-        "code": "3",
-        "message": "Not a valid longitude",
-        "_content": "The longitude argument failed validation."
-      },
-      {
-        "code": "4",
-        "message": "Not a valid accuracy",
-        "_content": "The accuracy argument failed validation."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.geo.removeLocation.json
+++ b/src/flickr.photos.geo.removeLocation.json
@@ -1,105 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.geo.removeLocation",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Removes the geo data associated with a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo you want to remove location data from."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id was either invalid or was for a photo not viewable by the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Photo has no location information",
-        "_content": "The specified photo has not been geotagged - there is nothing to remove."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.geo.setContext.json
+++ b/src/flickr.photos.geo.setContext.json
@@ -1,110 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.geo.setContext",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Indicate the state of a photo's geotagginess beyond latitude and longitude.<br /><br />\r\nNote : photos passed to this method must already be geotagged (using the <q>flickr.photos.geo.setLocation</q> method)."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to set context data for."
+        "optional": "0"
       },
       {
         "name": "context",
-        "optional": "0",
-        "_content": "Context is a numeric value representing the photo's geotagginess beyond latitude and longitude. For example, you may wish to indicate that a photo was taken \"indoors\" or \"outdoors\". <br /><br />\r\nThe current list of context IDs is :<br /><br/>\r\n<ul>\r\n<li><strong>0</strong>, not defined.</li>\r\n<li><strong>1</strong>, indoors.</li>\r\n<li><strong>2</strong>, outdoors.</li>\r\n</ul>"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id was either invalid or was for a photo not viewable by the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Not a valid context",
-        "_content": "The context ID passed to the method is invalid."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.geo.setLocation.json
+++ b/src/flickr.photos.geo.setLocation.json
@@ -1,150 +1,34 @@
 {
   "method": {
     "name": "flickr.photos.geo.setLocation",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Sets the geo data (latitude and longitude and, optionally, the accuracy level) for a photo.\r\n\r\nBefore users may assign location data to a photo they must define who, by default, may view that information. Users can edit this preference at <a href=\"http://www.flickr.com/account/geo/privacy/\">http://www.flickr.com/account/geo/privacy/</a>. If a user has not set this preference, the API method will return an error."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to set location data for."
+        "optional": "0"
       },
       {
         "name": "lat",
-        "optional": "0",
-        "_content": "The latitude whose valid range is -90 to 90. Anything more than 6 decimal places will be truncated."
+        "optional": "0"
       },
       {
         "name": "lon",
-        "optional": "0",
-        "_content": "The longitude whose valid range is -180 to 180. Anything more than 6 decimal places will be truncated."
+        "optional": "0"
       },
       {
         "name": "accuracy",
-        "optional": "1",
-        "_content": "Recorded accuracy level of the location information. World level is 1, Country is ~3, Region ~6, City ~11, Street ~16. Current range is 1-16. Defaults to 16 if not specified."
+        "optional": "1"
       },
       {
         "name": "context",
-        "optional": "1",
-        "_content": "Context is a numeric value representing the photo's geotagginess beyond latitude and longitude. For example, you may wish to indicate that a photo was taken \"indoors\" or \"outdoors\". <br /><br />\r\nThe current list of context IDs is :<br /><br/>\r\n<ul>\r\n<li><strong>0</strong>, not defined.</li>\r\n<li><strong>1</strong>, indoors.</li>\r\n<li><strong>2</strong>, outdoors.</li>\r\n</ul><br />\r\nThe default context for geotagged photos is 0, or \"not defined\"\r\n"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id was either invalid or was for a photo not viewable by the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Required arguments missing.",
-        "_content": "Some or all of the required arguments were not supplied."
-      },
-      {
-        "code": "3",
-        "message": "Not a valid latitude.",
-        "_content": "The latitude argument failed validation."
-      },
-      {
-        "code": "4",
-        "message": "Not a valid longitude.",
-        "_content": "The longitude argument failed validation."
-      },
-      {
-        "code": "5",
-        "message": "Not a valid accuracy.",
-        "_content": "The accuracy argument failed validation."
-      },
-      {
-        "code": "6",
-        "message": "Server error.",
-        "_content": "There was an unexpected problem setting location information to the photo."
-      },
-      {
-        "code": "7",
-        "message": "User has not configured default viewing settings for location data.",
-        "_content": "Before users may assign location data to a photo they must define who, by default, may view that information. Users can edit this preference at <a href=\"http://www.flickr.com/account/geo/privacy/\">http://www.flickr.com/account/geo/privacy/</a>"
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.geo.setPerms.json
+++ b/src/flickr.photos.geo.setPerms.json
@@ -1,130 +1,34 @@
 {
   "method": {
     "name": "flickr.photos.geo.setPerms",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Set the permission for who may view the geo data associated with a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "is_public",
-        "optional": "0",
-        "_content": "1 to set viewing permissions for the photo's location data to public, 0 to set it to private."
+        "optional": "0"
       },
       {
         "name": "is_contact",
-        "optional": "0",
-        "_content": "1 to set viewing permissions for the photo's location data to contacts, 0 to set it to private."
+        "optional": "0"
       },
       {
         "name": "is_friend",
-        "optional": "0",
-        "_content": "1 to set viewing permissions for the photo's location data to friends, 0 to set it to private."
+        "optional": "0"
       },
       {
         "name": "is_family",
-        "optional": "0",
-        "_content": "1 to set viewing permissions for the photo's location data to family, 0 to set it to private."
+        "optional": "0"
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to get permissions for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id was either invalid or was for a photo not viewable by the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Photo has no location information",
-        "_content": "The photo requested has no location data or is not viewable by the calling user."
-      },
-      {
-        "code": "3",
-        "message": "Required arguments missing.",
-        "_content": "Some or all of the required arguments were not supplied."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getAllContexts.json
+++ b/src/flickr.photos.getAllContexts.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.getAllContexts",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns all visible sets and pools the photo belongs to."
-    },
-    "response": {
-      "_content": "<set id=\"392\" title=\"记忆群组\" />\r\n<pool id=\"34427465471@N01\" title=\"FlickrDiscuss\" />"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The photo to return information for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not the id of a valid photo."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getContactsPhotos.json
+++ b/src/flickr.photos.getContactsPhotos.json
@@ -1,118 +1,34 @@
 {
   "method": {
     "name": "flickr.photos.getContactsPhotos",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Fetch a list of recent photos from the calling users' contacts."
-    },
-    "response": {
-      "_content": "<photos>\r\n\t<photo id=\"2801\" owner=\"12037949629@N01\"\r\n\t\tsecret=\"123456\" server=\"1\"\r\n\t\tusername=\"Eric is the best\" title=\"grease\" /> \r\n\t<photo id=\"2499\" owner=\"33853651809@N01\"\r\n\t\tsecret=\"123456\" server=\"1\"\r\n\t\tusername=\"cal18\" title=\"36679_o\" /> \r\n\t<photo id=\"2437\" owner=\"12037951898@N01\"\r\n\t\tsecret=\"123456\" server=\"1\"\r\n\t\tusername=\"georgie parker\" title=\"phoenix9_stewart\" /> \r\n</photos>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "count",
-        "optional": "1",
-        "_content": "Number of photos to return. Defaults to 10, maximum 50. This is only used if <code>single_photo</code> is not passed."
+        "optional": "1"
       },
       {
         "name": "just_friends",
-        "optional": "1",
-        "_content": "set as 1 to only show photos from friends and family (excluding regular contacts)."
+        "optional": "1"
       },
       {
         "name": "single_photo",
-        "optional": "1",
-        "_content": "Only fetch one photo (the latest) per contact, instead of all photos in chronological order."
+        "optional": "1"
       },
       {
         "name": "include_self",
-        "optional": "1",
-        "_content": "Set to 1 to include photos from the calling user."
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": "1",
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields include: license, date_upload, date_taken, owner_name, icon_server, original_format, last_update. For more information see extras under <a href=\"/services/api/flickr.photos.search.html\">flickr.photos.search</a>."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getContactsPublicPhotos.json
+++ b/src/flickr.photos.getContactsPublicPhotos.json
@@ -1,103 +1,38 @@
 {
   "method": {
     "name": "flickr.photos.getContactsPublicPhotos",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Fetch a list of recent public photos from a users' contacts."
-    },
-    "response": {
-      "_content": "<photos>\r\n\t<photo id=\"2801\" owner=\"12037949629@N01\"\r\n\t\tsecret=\"123456\" server=\"1\"\r\n\t\tusername=\"Eric is the best\" title=\"grease\" /> \r\n\t<photo id=\"2499\" owner=\"33853651809@N01\"\r\n\t\tsecret=\"123456\" server=\"1\"\r\n\t\tusername=\"cal18\" title=\"36679_o\" /> \r\n\t<photo id=\"2437\" owner=\"12037951898@N01\"\r\n\t\tsecret=\"123456\" server=\"1\"\r\n\t\tusername=\"georgie parker\" title=\"phoenix9_stewart\" /> \r\n</photos>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the user to fetch photos for."
+        "optional": "0"
       },
       {
         "name": "count",
-        "optional": "1",
-        "_content": "Number of photos to return. Defaults to 10, maximum 50. This is only used if <code>single_photo</code> is not passed."
+        "optional": "1"
       },
       {
         "name": "just_friends",
-        "optional": "1",
-        "_content": "set as 1 to only show photos from friends and family (excluding regular contacts)."
+        "optional": "1"
       },
       {
         "name": "single_photo",
-        "optional": "1",
-        "_content": "Only fetch one photo (the latest) per contact, instead of all photos in chronological order."
+        "optional": "1"
       },
       {
         "name": "include_self",
-        "optional": "1",
-        "_content": "Set to 1 to include photos from the user specified by user_id."
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": "1",
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: license, date_upload, date_taken, owner_name, icon_server, original_format, last_update."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The user NSID passed was not a valid user NSID."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getContext.json
+++ b/src/flickr.photos.getContext.json
@@ -1,81 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.getContext",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns next and previous photos for a photo in a photostream."
-    },
-    "response": {
-      "_content": "<prevphoto id=\"2980\" secret=\"973da1e709\"\r\n\ttitle=\"boo!\" url=\"/photos/bees/2980/\" /> \r\n<nextphoto id=\"2985\" secret=\"059b664012\"\r\n\ttitle=\"Amsterdam Amstel\" url=\"/photos/bees/2985/\" /> "
-    },
-    "explanation": {
-      "_content": "<p>When either the previous of next photo is unavailable, the element is still returned, but contains <code>id=\"0\"</code></p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to fetch the context for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id, or was the id of a photo that the calling user does not have permission to view."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getCounts.json
+++ b/src/flickr.photos.getCounts.json
@@ -1,108 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.getCounts",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Gets a list of photo counts for the given date ranges for the calling user."
-    },
-    "response": {
-      "_content": "<photocounts>\r\n\t<photocount count=\"4\" fromdate=\"1093566950\" todate=\"1093653350\" /> \r\n\t<photocount count=\"0\" fromdate=\"1093653350\" todate=\"1093739750\" /> \r\n\t<photocount count=\"0\" fromdate=\"1093739750\" todate=\"1093826150\" /> \r\n\t<photocount count=\"2\" fromdate=\"1093826150\" todate=\"1093912550\" /> \r\n\t<photocount count=\"0\" fromdate=\"1093912550\" todate=\"1093998950\" /> \r\n\t<photocount count=\"0\" fromdate=\"1093998950\" todate=\"1094085350\" /> \r\n\t<photocount count=\"0\" fromdate=\"1094085350\" todate=\"1094171750\" /> \r\n</photocounts>\r\n"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "dates",
-        "optional": "1",
-        "_content": "A comma delimited list of unix timestamps, denoting the periods to return counts for. They should be specified <b>smallest first</b>."
+        "optional": "1"
       },
       {
         "name": "taken_dates",
-        "optional": "1",
-        "_content": "A comma delimited list of mysql datetimes, denoting the periods to return counts for. They should be specified <b>smallest first</b>."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "No dates specified",
-        "_content": "Neither dates nor taken_dates were specified."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getExif.json
+++ b/src/flickr.photos.getExif.json
@@ -1,91 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.getExif",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Retrieves a list of EXIF/TIFF/GPS tags for a given photo. The calling user must have permission to view the photo."
-    },
-    "response": {
-      "_content": "<photo id=\"4424\" secret=\"06b8e43bc7\" server=\"2\">\r\n\t<exif tagspace=\"TIFF\" tagspaceid=\"1\" tag=\"271\" label=\"Manufacturer\">\r\n\t\t<raw>Canon</raw>\r\n\t</exif>\r\n\t<exif tagspace=\"EXIF\" tagspaceid=\"0\" tag=\"33437\" label=\"Aperture\">\r\n\t\t<raw>90/10</raw>\r\n\t\t<clean>f/9</clean>\r\n\t</exif>\r\n\t<exif tagspace=\"GPS\" tagspaceid=\"3\" tag=\"4\" label=\"Longitude\">\r\n\t\t<raw>64/1, 42/1, 4414/100</raw>\r\n\t\t<clean>64° 42' 44.14\"</clean>\r\n\t</exif>\r\n</photo>\r\n"
-    },
-    "explanation": {
-      "_content": "<p>The <code>&lt;clean&gt;</code> element contains a pretty-formatted version of the tag where availabale.</p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to fetch information for."
+        "optional": "0"
       },
       {
         "name": "secret",
-        "optional": "1",
-        "_content": "The secret for the photo. If the correct secret is passed then permissions checking is skipped. This enables the 'sharing' of individual photos by passing around the id and secret."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id was either invalid or was for a photo not viewable by the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Permission denied",
-        "_content": "The owner of the photo does not want to share EXIF data."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getFavorites.json
+++ b/src/flickr.photos.getFavorites.json
@@ -1,88 +1,26 @@
 {
   "method": {
     "name": "flickr.photos.getFavorites",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the list of people who have favorited a given photo."
-    },
-    "response": {
-      "_content": "<photo id=\"1253576\" secret=\"81b96be690\" server=\"1\" farm=\"1\"\r\n\tpage=\"1\" pages=\"3\" perpage=\"10\" total=\"27\">\r\n\t<person nsid=\"33939862@N00\" username=\"Dementation\" favedate=\"1166689690\"/>\r\n\t<person nsid=\"49485425@N00\" username=\"indigenous_prodigy\" favedate=\"1166573724\"/>\r\n\t<person nsid=\"46834205@N00\" username=\"smaaz\" favedate=\"1161874052\"/>\r\n\t<person nsid=\"95626108@N00\" username=\"chrome Foxpuppy\" favedate=\"1160528154\"/>\r\n\t<person nsid=\"44991966@N00\" username=\"getnoid\" favedate=\"1159828789\"/>\r\n\t<person nsid=\"92544710@N00\" username=\"miss_rogue\" favedate=\"1158034266\"/>\r\n\t<person nsid=\"50944224@N00\" username=\"Infollatus\" favedate=\"1155317436\"/>\r\n\t<person nsid=\"80544408@N00\" username=\"DafyddLlyr\" favedate=\"1148511763\"/>\r\n\t<person nsid=\"31154299@N00\" username=\"c r i s\" favedate=\"1143085224\"/>\r\n\t<person nsid=\"54309070@N00\" username=\"Shinayaker\" favedate=\"1142584219\"/>\r\n</photo>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The ID of the photo to fetch the favoriters list for."
+        "optional": "0"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of usres to return per page. If this argument is omitted, it defaults to 10. The maximum allowed value is 50."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The specified photo does not exist, or the calling user does not have permission to view it."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getInfo.json
+++ b/src/flickr.photos.getInfo.json
@@ -1,86 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.getInfo",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get information about a photo. The calling user must have permission to view the photo."
-    },
-    "response": {
-      "_content": "<photo id=\"2733\" secret=\"123456\" server=\"12\"\r\n\tisfavorite=\"0\" license=\"3\" rotation=\"90\" \r\n\toriginalsecret=\"1bc09ce34a\" originalformat=\"png\">\r\n\t<owner nsid=\"12037949754@N01\" username=\"Bees\"\r\n\t\trealname=\"Cal Henderson\" location=\"Bedford, UK\" />\r\n\t<title>orford_castle_taster</title>\r\n\t<description>hello!</description>\r\n\t<visibility ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" />\r\n\t<dates posted=\"1100897479\" taken=\"2004-11-19 12:51:19\"\r\n\t\ttakengranularity=\"0\" lastupdate=\"1093022469\" />\r\n\t<permissions permcomment=\"3\" permaddmeta=\"2\" />\r\n\t<editability cancomment=\"1\" canaddmeta=\"1\" />\r\n\t<comments>1</comments>\r\n\t<notes>\r\n\t\t<note id=\"313\" author=\"12037949754@N01\"\r\n\t\t\tauthorname=\"Bees\" x=\"10\" y=\"10\"\r\n\t\t\tw=\"50\" h=\"50\">foo</note>\r\n\t</notes>\r\n\t<tags>\r\n\t\t<tag id=\"1234\" author=\"12037949754@N01\" raw=\"woo yay\">wooyay</tag>\r\n\t\t<tag id=\"1235\" author=\"12037949754@N01\" raw=\"hoopla\">hoopla</tag>\r\n\t</tags>\r\n\t<urls>\r\n\t\t<url type=\"photopage\">http://www.flickr.com/photos/bees/2733/</url> \r\n\t</urls>\r\n</photo>"
-    },
-    "explanation": {
-      "_content": "<p>The <code>&lt;permissions&gt;</code> element is only returned for photos owned by the calling user. The <code>isfavorite</code> attribute only makes sense for logged in users who don't own the photo. The <code>rotation</code> attribute is the current clockwise rotation, in degrees, by which the smaller image sizes differ from the original image.</p>\r\n\r\n<p>The <code>&lt;date&gt;</code> element's <code>lastupdate</code> attribute is a Unix timestamp indicating the last time the photo, or any of its metadata (tags, comments, etc.) was modified.</p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to get information for."
+        "optional": "0"
       },
       {
         "name": "secret",
-        "optional": "1",
-        "_content": "The secret for the photo. If the correct secret is passed then permissions checking is skipped. This enables the 'sharing' of individual photos by passing around the id and secret."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found.",
-        "_content": "The photo id was either invalid or was for a photo not viewable by the calling user."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getNotInSet.json
+++ b/src/flickr.photos.getNotInSet.json
@@ -1,135 +1,50 @@
 {
   "method": {
     "name": "flickr.photos.getNotInSet",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns a list of your photos that are not part of any sets."
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "max_upload_date",
-        "optional": "1",
-        "_content": "Maximum upload date. Photos with an upload date less than or equal to this value will be returned. The date can be in the form of a unix timestamp or mysql datetime."
+        "optional": "1"
       },
       {
         "name": "min_taken_date",
-        "optional": "1",
-        "_content": "Minimum taken date. Photos with an taken date greater than or equal to this value will be returned. The date can be in the form of a mysql datetime or unix timestamp."
+        "optional": "1"
       },
       {
         "name": "max_taken_date",
-        "optional": "1",
-        "_content": "Maximum taken date. Photos with an taken date less than or equal to this value will be returned. The date can be in the form of a mysql datetime or unix timestamp."
+        "optional": "1"
       },
       {
         "name": "privacy_filter",
-        "optional": "1",
-        "_content": "Return photos only matching a certain privacy level. Valid values are:\r\n<ul>\r\n<li>1 public photos</li>\r\n<li>2 private photos visible to friends</li>\r\n<li>3 private photos visible to family</li>\r\n<li>4 private photos visible to friends &amp; family</li>\r\n<li>5 completely private photos</li>\r\n</ul>\r\n"
+        "optional": "1"
       },
       {
         "name": "media",
-        "optional": "1",
-        "_content": "Filter results by media type. Possible values are <code>all</code> (default), <code>photos</code> or <code>videos</code>"
+        "optional": "1"
       },
       {
         "name": "min_upload_date",
-        "optional": "1",
-        "_content": "Minimum upload date. Photos with an upload date greater than or equal to this value will be returned. The date can be in the form of a unix timestamp or mysql datetime."
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getPerms.json
+++ b/src/flickr.photos.getPerms.json
@@ -1,103 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.getPerms",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get permissions for a photo."
-    },
-    "response": {
-      "_content": "<perms id=\"2733\" ispublic=\"1\" isfriend=\"1\" isfamily=\"0\" permcomment=\"0\" permaddmeta=\"1\" /> "
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to get permissions for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id of a photo belonging to the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getPopular.json
+++ b/src/flickr.photos.getPopular.json
@@ -1,100 +1,34 @@
 {
   "method": {
     "name": "flickr.photos.getPopular",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns a list of popular photos"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "1",
-        "_content": "The NSID of the user to get a galleries list for. If none is specified, the calling user is assumed."
+        "optional": "1"
       },
       {
         "name": "sort",
-        "optional": "1",
-        "_content": "The sort order. One of <code>faves</code>, <code>views</code>, <code>comments</code> or <code>interesting</code>. Deafults to <code>interesting</code>."
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid user id",
-        "_content": "An invalid NSID was passed"
-      },
-      {
-        "code": "2",
-        "message": "Popular photos disabled by user",
-        "_content": ""
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getRecent.json
+++ b/src/flickr.photos.getRecent.json
@@ -1,85 +1,26 @@
 {
   "method": {
     "name": "flickr.photos.getRecent",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns a list of the latest public photos uploaded to flickr."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "bad value for jump_to, must be valid photo id.",
-        "_content": ""
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getSizes.json
+++ b/src/flickr.photos.getSizes.json
@@ -1,83 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.getSizes",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the available sizes for a photo.  The calling user must have permission to view the photo."
-    },
-    "response": {
-      "_content": "<sizes canblog=\"1\" canprint=\"1\" candownload=\"1\">\r\n    <size label=\"Square\" width=\"75\" height=\"75\" source=\"http://farm2.staticflickr.com/1103/567229075_2cf8456f01_s.jpg\" url=\"http://www.flickr.com/photos/stewart/567229075/sizes/sq/\" media=\"photo\" />\r\n    <size label=\"Large Square\" width=\"150\" height=\"150\" source=\"http://farm2.staticflickr.com/1103/567229075_2cf8456f01_q.jpg\" url=\"http://www.flickr.com/photos/stewart/567229075/sizes/q/\" media=\"photo\" />\r\n    <size label=\"Thumbnail\" width=\"100\" height=\"75\" source=\"http://farm2.staticflickr.com/1103/567229075_2cf8456f01_t.jpg\" url=\"http://www.flickr.com/photos/stewart/567229075/sizes/t/\" media=\"photo\" />\r\n    <size label=\"Small\" width=\"240\" height=\"180\" source=\"http://farm2.staticflickr.com/1103/567229075_2cf8456f01_m.jpg\" url=\"http://www.flickr.com/photos/stewart/567229075/sizes/s/\" media=\"photo\" />\r\n    <size label=\"Small 320\" width=\"320\" height=\"240\" source=\"http://farm2.staticflickr.com/1103/567229075_2cf8456f01_n.jpg\" url=\"http://www.flickr.com/photos/stewart/567229075/sizes/n/\" media=\"photo\" />\r\n    <size label=\"Medium\" width=\"500\" height=\"375\" source=\"http://farm2.staticflickr.com/1103/567229075_2cf8456f01.jpg\" url=\"http://www.flickr.com/photos/stewart/567229075/sizes/m/\" media=\"photo\" />\r\n    <size label=\"Medium 640\" width=\"640\" height=\"480\" source=\"http://farm2.staticflickr.com/1103/567229075_2cf8456f01_z.jpg?zz=1\" url=\"http://www.flickr.com/photos/stewart/567229075/sizes/z/\" media=\"photo\" />\r\n    <size label=\"Medium 800\" width=\"800\" height=\"600\" source=\"http://farm2.staticflickr.com/1103/567229075_2cf8456f01_c.jpg\" url=\"http://www.flickr.com/photos/stewart/567229075/sizes/c/\" media=\"photo\" />\r\n    <size label=\"Large\" width=\"1024\" height=\"768\" source=\"http://farm2.staticflickr.com/1103/567229075_2cf8456f01_b.jpg\" url=\"http://www.flickr.com/photos/stewart/567229075/sizes/l/\" media=\"photo\" />\r\n    <size label=\"Original\" width=\"2400\" height=\"1800\" source=\"http://farm2.staticflickr.com/1103/567229075_6dc09dc6da_o.jpg\" url=\"http://www.flickr.com/photos/stewart/567229075/sizes/o/\" media=\"photo\" />\r\n</sizes>\r\n"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to fetch size information for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id."
-      },
-      {
-        "code": "2",
-        "message": "Permission denied",
-        "_content": "The calling user does not have permission to view the photo."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getUntagged.json
+++ b/src/flickr.photos.getUntagged.json
@@ -1,135 +1,50 @@
 {
   "method": {
     "name": "flickr.photos.getUntagged",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns a list of your photos with no tags."
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "min_upload_date",
-        "optional": "1",
-        "_content": "Minimum upload date. Photos with an upload date greater than or equal to this value will be returned. The date can be in the form of a unix timestamp or mysql datetime."
+        "optional": "1"
       },
       {
         "name": "max_upload_date",
-        "optional": "1",
-        "_content": "Maximum upload date. Photos with an upload date less than or equal to this value will be returned. The date can be in the form of a unix timestamp or mysql datetime."
+        "optional": "1"
       },
       {
         "name": "min_taken_date",
-        "optional": "1",
-        "_content": "Minimum taken date. Photos with an taken date greater than or equal to this value will be returned. The date should be in the form of a mysql datetime or unix timestamp."
+        "optional": "1"
       },
       {
         "name": "max_taken_date",
-        "optional": "1",
-        "_content": "Maximum taken date. Photos with an taken date less than or equal to this value will be returned. The date can be in the form of a mysql datetime or unix timestamp."
+        "optional": "1"
       },
       {
         "name": "privacy_filter",
-        "optional": "1",
-        "_content": "Return photos only matching a certain privacy level. Valid values are:\r\n<ul>\r\n<li>1 public photos</li>\r\n<li>2 private photos visible to friends</li>\r\n<li>3 private photos visible to family</li>\r\n<li>4 private photos visible to friends &amp; family</li>\r\n<li>5 completely private photos</li>\r\n</ul>\r\n"
+        "optional": "1"
       },
       {
         "name": "media",
-        "optional": "1",
-        "_content": "Filter results by media type. Possible values are <code>all</code> (default), <code>photos</code> or <code>videos</code>"
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getWithGeoData.json
+++ b/src/flickr.photos.getWithGeoData.json
@@ -1,140 +1,54 @@
 {
   "method": {
     "name": "flickr.photos.getWithGeoData",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns a list of your geo-tagged photos."
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "min_upload_date",
-        "optional": "1",
-        "_content": "Minimum upload date. Photos with an upload date greater than or equal to this value will be returned. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "max_upload_date",
-        "optional": "1",
-        "_content": "Maximum upload date. Photos with an upload date less than or equal to this value will be returned. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "min_taken_date",
-        "optional": "1",
-        "_content": "Minimum taken date. Photos with an taken date greater than or equal to this value will be returned. The date should be in the form of a mysql datetime."
+        "optional": "1"
       },
       {
         "name": "max_taken_date",
-        "optional": "1",
-        "_content": "Maximum taken date. Photos with an taken date less than or equal to this value will be returned. The date should be in the form of a mysql datetime."
+        "optional": "1"
       },
       {
         "name": "privacy_filter",
-        "optional": "1",
-        "_content": "Return photos only matching a certain privacy level. Valid values are:\r\n<ul>\r\n<li>1 public photos</li>\r\n<li>2 private photos visible to friends</li>\r\n<li>3 private photos visible to family</li>\r\n<li>4 private photos visible to friends & family</li>\r\n<li>5 completely private photos</li>\r\n</ul>\r\n"
+        "optional": "1"
       },
       {
         "name": "sort",
-        "optional": "1",
-        "_content": "The order in which to sort returned photos. Deafults to date-posted-desc. The possible values are: date-posted-asc, date-posted-desc, date-taken-asc, date-taken-desc, interestingness-desc, and interestingness-asc."
+        "optional": "1"
       },
       {
         "name": "media",
-        "optional": "1",
-        "_content": "Filter results by media type. Possible values are <code>all</code> (default), <code>photos</code> or <code>videos</code>"
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.getWithoutGeoData.json
+++ b/src/flickr.photos.getWithoutGeoData.json
@@ -1,140 +1,54 @@
 {
   "method": {
     "name": "flickr.photos.getWithoutGeoData",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns a list of your photos which haven't been geo-tagged."
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "max_upload_date",
-        "optional": "1",
-        "_content": "Maximum upload date. Photos with an upload date less than or equal to this value will be returned. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "min_taken_date",
-        "optional": "1",
-        "_content": "Minimum taken date. Photos with an taken date greater than or equal to this value will be returned. The date can be in the form of a mysql datetime or unix timestamp."
+        "optional": "1"
       },
       {
         "name": "max_taken_date",
-        "optional": "1",
-        "_content": "Maximum taken date. Photos with an taken date less than or equal to this value will be returned. The date can be in the form of a mysql datetime or unix timestamp."
+        "optional": "1"
       },
       {
         "name": "privacy_filter",
-        "optional": "1",
-        "_content": "Return photos only matching a certain privacy level. Valid values are:\r\n<ul>\r\n<li>1 public photos</li>\r\n<li>2 private photos visible to friends</li>\r\n<li>3 private photos visible to family</li>\r\n<li>4 private photos visible to friends &amp; family</li>\r\n<li>5 completely private photos</li>\r\n</ul>\r\n"
+        "optional": "1"
       },
       {
         "name": "sort",
-        "optional": "1",
-        "_content": "The order in which to sort returned photos. Deafults to date-posted-desc. The possible values are: date-posted-asc, date-posted-desc, date-taken-asc, date-taken-desc, interestingness-desc, and interestingness-asc."
+        "optional": "1"
       },
       {
         "name": "media",
-        "optional": "1",
-        "_content": "Filter results by media type. Possible values are <code>all</code> (default), <code>photos</code> or <code>videos</code>"
+        "optional": "1"
       },
       {
         "name": "min_upload_date",
-        "optional": "1",
-        "_content": "Minimum upload date. Photos with an upload date greater than or equal to this value will be returned. The date can be in the form of a unix timestamp or mysql datetime."
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.licenses.getInfo.json
+++ b/src/flickr.photos.licenses.getInfo.json
@@ -1,68 +1,14 @@
 {
   "method": {
     "name": "flickr.photos.licenses.getInfo",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Fetches a list of available photo licenses for Flickr."
-    },
-    "response": {
-      "_content": "<licenses>\r\n        <license id=\"0\" name=\"All Rights Reserved\" url=\"\" />\r\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"\r\n\t\turl=\"http://creativecommons.org/licenses/by-nc-sa/2.0/\" /> \r\n\t<license id=\"2\" name=\"Attribution-NonCommercial License\"\r\n\t\turl=\"http://creativecommons.org/licenses/by-nc/2.0/\" /> \r\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"\r\n\t\turl=\"http://creativecommons.org/licenses/by-nc-nd/2.0/\" /> \r\n\t<license id=\"4\" name=\"Attribution License\"\r\n\t\turl=\"http://creativecommons.org/licenses/by/2.0/\" /> \r\n\t<license id=\"5\" name=\"Attribution-ShareAlike License\"\r\n\t\turl=\"http://creativecommons.org/licenses/by-sa/2.0/\" /> \r\n\t<license id=\"6\" name=\"Attribution-NoDerivs License\"\r\n\t\turl=\"http://creativecommons.org/licenses/by-nd/2.0/\" /> \r\n\t<license id=\"7\" name=\"No known copyright restrictions\"\r\n\t\turl=\"http://flickr.com/commons/usage/\" />\r\n        <license id=\"8\" name=\"United States Government Work\"\r\n                url=\"http://www.usa.gov/copyright.shtml\" />\r\n</licenses>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.licenses.setLicense.json
+++ b/src/flickr.photos.licenses.setLicense.json
@@ -1,110 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.licenses.setLicense",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Sets the license for a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The photo to update the license for."
+        "optional": "0"
       },
       {
         "name": "license_id",
-        "optional": "0",
-        "_content": "The license to apply, or 0 (zero) to remove the current license. Note : as of this writing the \"no known copyright restrictions\" license (7) is not a valid argument."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The specified id was not the id of a valif photo owner by the calling user."
-      },
-      {
-        "code": "2",
-        "message": "License not found",
-        "_content": "The license id was not valid."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.notes.add.json
+++ b/src/flickr.photos.notes.add.json
@@ -1,143 +1,38 @@
 {
   "method": {
     "name": "flickr.photos.notes.add",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Add a note to a photo. Coordinates and sizes are in pixels, based on the 500px image size shown on individual photo pages."
-    },
-    "response": {
-      "_content": "<note id=\"1234\" />"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to add a note to"
+        "optional": "0"
       },
       {
         "name": "note_x",
-        "optional": "0",
-        "_content": "The left coordinate of the note"
+        "optional": "0"
       },
       {
         "name": "note_y",
-        "optional": "0",
-        "_content": "The top coordinate of the note"
+        "optional": "0"
       },
       {
         "name": "note_w",
-        "optional": "0",
-        "_content": "The width of the note"
+        "optional": "0"
       },
       {
         "name": "note_h",
-        "optional": "0",
-        "_content": "The height of the note"
+        "optional": "0"
       },
       {
         "name": "note_text",
-        "optional": "0",
-        "_content": "The description of the note"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id"
-      },
-      {
-        "code": "2",
-        "message": "User cannot add notes",
-        "_content": "The calling user does not have permission to add a note to this photo"
-      },
-      {
-        "code": "3",
-        "message": "Missing required arguments",
-        "_content": "One or more of the required arguments were not supplied."
-      },
-      {
-        "code": "4",
-        "message": "Maximum number of notes reached",
-        "_content": "The maximum number of notes for the photo has been reached."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.notes.delete.json
+++ b/src/flickr.photos.notes.delete.json
@@ -1,105 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.notes.delete",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Delete a note from a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "note_id",
-        "optional": "0",
-        "_content": "The id of the note to delete"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Note not found",
-        "_content": "The note id passed was not a valid note id"
-      },
-      {
-        "code": "2",
-        "message": "User cannot delete note",
-        "_content": "The calling user does not have permission to delete the specified note"
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.notes.edit.json
+++ b/src/flickr.photos.notes.edit.json
@@ -1,135 +1,38 @@
 {
   "method": {
     "name": "flickr.photos.notes.edit",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Edit a note on a photo. Coordinates and sizes are in pixels, based on the 500px image size shown on individual photo pages.\r\n"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "note_id",
-        "optional": "0",
-        "_content": "The id of the note to edit"
+        "optional": "0"
       },
       {
         "name": "note_x",
-        "optional": "0",
-        "_content": "The left coordinate of the note"
+        "optional": "0"
       },
       {
         "name": "note_y",
-        "optional": "0",
-        "_content": "The top coordinate of the note"
+        "optional": "0"
       },
       {
         "name": "note_w",
-        "optional": "0",
-        "_content": "The width of the note"
+        "optional": "0"
       },
       {
         "name": "note_h",
-        "optional": "0",
-        "_content": "The height of the note"
+        "optional": "0"
       },
       {
         "name": "note_text",
-        "optional": "0",
-        "_content": "The description of the note"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Note not found",
-        "_content": "The note id passed was not a valid note id"
-      },
-      {
-        "code": "2",
-        "message": "User cannot edit note",
-        "_content": "The calling user does not have permission to edit the specified note"
-      },
-      {
-        "code": "3",
-        "message": "Missing required arguments",
-        "_content": "One or more of the required arguments were not supplied."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.people.add.json
+++ b/src/flickr.photos.people.add.json
@@ -1,160 +1,38 @@
 {
   "method": {
     "name": "flickr.photos.people.add",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Add a person to a photo. Coordinates and sizes of boxes are optional; they are measured in pixels, based on the 500px image size shown on individual photo pages."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to add a person to."
+        "optional": "0"
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the user to add to the photo."
+        "optional": "0"
       },
       {
         "name": "person_x",
-        "optional": "1",
-        "_content": "The left-most pixel co-ordinate of the box around the person."
+        "optional": "1"
       },
       {
         "name": "person_y",
-        "optional": "1",
-        "_content": "The top-most pixel co-ordinate of the box around the person."
+        "optional": "1"
       },
       {
         "name": "person_w",
-        "optional": "1",
-        "_content": "The width (in pixels) of the box around the person."
+        "optional": "1"
       },
       {
         "name": "person_h",
-        "optional": "1",
-        "_content": "The height (in pixels) of the box around the person."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Person not found",
-        "_content": "The NSID passed was not a valid user id."
-      },
-      {
-        "code": "2",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id."
-      },
-      {
-        "code": "3",
-        "message": "User cannot add this person to photos",
-        "_content": "The person being added to the photo does not allow the calling user to add them."
-      },
-      {
-        "code": "4",
-        "message": "User cannot add people to that photo",
-        "_content": "The owner of the photo doesn't allow the calling user to add people to their photos."
-      },
-      {
-        "code": "5",
-        "message": "Person can't be tagged in that photo",
-        "_content": "The person being added to the photo does not want to be identified in this photo."
-      },
-      {
-        "code": "6",
-        "message": "Some co-ordinate paramters were blank",
-        "_content": "Not all of the co-ordinate parameters (person_x, person_y, person_w, person_h) were passed with valid values."
-      },
-      {
-        "code": "7",
-        "message": "Can't add that person to a non-public photo",
-        "_content": "You can only add yourself to another member's non-public photos."
-      },
-      {
-        "code": "8",
-        "message": "Too many people in that photo",
-        "_content": "The maximum number of people has already been added to the photo."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.people.delete.json
+++ b/src/flickr.photos.people.delete.json
@@ -1,115 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.people.delete",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Remove a person from a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to remove a person from."
+        "optional": "0"
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the person to remove from the photo."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Person not found",
-        "_content": "The NSID passed was not a valid user id."
-      },
-      {
-        "code": "2",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id."
-      },
-      {
-        "code": "3",
-        "message": "User cannot remove that person",
-        "_content": "The calling user did not have permission to remove this person from this photo."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.people.deleteCoords.json
+++ b/src/flickr.photos.people.deleteCoords.json
@@ -1,115 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.people.deleteCoords",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Remove the bounding box from a person in a photo"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to edit a person in."
+        "optional": "0"
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the person whose bounding box you want to remove."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Person not found",
-        "_content": "The NSID passed was not a valid user id."
-      },
-      {
-        "code": "2",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id."
-      },
-      {
-        "code": "3",
-        "message": "User cannot edit that person in that photo",
-        "_content": "The calling user is neither the person depicted in the photo nor the person who added the bounding box."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.people.editCoords.json
+++ b/src/flickr.photos.people.editCoords.json
@@ -1,145 +1,38 @@
 {
   "method": {
     "name": "flickr.photos.people.editCoords",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Edit the bounding box of an existing person on a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to edit a person in."
+        "optional": "0"
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the person to edit in a photo."
+        "optional": "0"
       },
       {
         "name": "person_x",
-        "optional": "0",
-        "_content": "The left-most pixel co-ordinate of the box around the person."
+        "optional": "0"
       },
       {
         "name": "person_y",
-        "optional": "0",
-        "_content": "The top-most pixel co-ordinate of the box around the person."
+        "optional": "0"
       },
       {
         "name": "person_w",
-        "optional": "0",
-        "_content": "The width (in pixels) of the box around the person."
+        "optional": "0"
       },
       {
         "name": "person_h",
-        "optional": "0",
-        "_content": "The height (in pixels) of the box around the person."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Person not found",
-        "_content": "The NSID passed was not a valid user id."
-      },
-      {
-        "code": "2",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id."
-      },
-      {
-        "code": "3",
-        "message": "User cannot edit that person in that photo",
-        "_content": "The calling user did not originally add this person to the photo, and is not the person in question."
-      },
-      {
-        "code": "4",
-        "message": "Some co-ordinate paramters were blank",
-        "_content": "Not all of the co-ordinate parameters (person_x, person_y, person_w, person_h) were passed with valid values."
-      },
-      {
-        "code": "5",
-        "message": "No co-ordinates given",
-        "_content": "None of the co-ordinate parameters were valid."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.people.getList.json
+++ b/src/flickr.photos.people.getList.json
@@ -1,81 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.people.getList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get a list of people in a given photo."
-    },
-    "response": {
-      "_content": "<people total=\"1\">\r\n  <person nsid=\"87944415@N00\" username=\"hitherto\" iconserver=\"1\" iconfarm=\"1\"\r\n          realname=\"Simon Batistoni\" added_by=\"12037949754@N01\" x=\"50\" y=\"50\"\r\n          w=\"100\" h=\"100\"/>\r\n</people>"
-    },
-    "explanation": {
-      "_content": "x, y, w and h correspond to the coordinates of the \"bounding box\" around a person in a photo. Since these co-ordinates are optional, these elements may not be present for every person."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to get a list of people for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.recentlyUpdated.json
+++ b/src/flickr.photos.recentlyUpdated.json
@@ -1,126 +1,30 @@
 {
   "method": {
     "name": "flickr.photos.recentlyUpdated",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "<p>Return a list of your photos that have been recently created or which have been recently modified.</p>\r\n\r\n<p>Recently modified may mean that the photo's metadata (title, description, tags) may have been changed or a comment has been added (or just modified somehow :-)</p>"
-    },
-    "response": {
-      "_content": "<photos page=\"1\" pages=\"1\" perpage=\"100\" total=\"2\">\r\n        <photo id=\"169885459\" owner=\"35034348999@N01\" \r\n               secret=\"c85114c195\" server=\"46\" title=\"Doubting Michael\"\r\n               ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" lastupdate=\"1150755888\" />\r\n        <photo id=\"85022332\" owner=\"35034348999@N01\"\r\n               secret=\"23de6de0c0\" server=\"41\"\r\n               title=\"&quot;Do you think we're allowed to tape stuff to the walls?&quot;\"\r\n               ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" lastupdate=\"1150564974\" />\r\n</photos>"
-    },
-    "explanation": {
-      "_content": "<p>Photos are sorted by their date updated timestamp, in descending order.</p>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "min_date",
-        "optional": "0",
-        "_content": "A Unix timestamp or any English textual datetime description indicating the date from which modifications should be compared."
+        "optional": "0"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required argument missing.",
-        "_content": "Some or all of the required arguments were not supplied."
-      },
-      {
-        "code": "2",
-        "message": "Not a valid date",
-        "_content": "The date argument did not pass validation."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.removeTag.json
+++ b/src/flickr.photos.removeTag.json
@@ -1,100 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.removeTag",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Remove a tag from a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "tag_id",
-        "optional": "0",
-        "_content": "The tag to remove from the photo. This parameter should contain a tag id, as returned by <a href=\"/services/api/flickr.photos.getInfo.html\">flickr.photos.getInfo</a>."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Tag not found",
-        "_content": "The calling user doesn't have permission to delete the specified tag. This could mean it belongs to someone else, or doesn't exist."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.search.json
+++ b/src/flickr.photos.search.json
@@ -1,313 +1,150 @@
 {
   "method": {
     "name": "flickr.photos.search",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a list of photos matching some criteria. Only photos visible to the calling user will be returned. To return private or semi-private photos, the caller must be authenticated with 'read' permissions, and have permission to view the photos. Unauthenticated calls will only return public photos."
-    },
-    "explanation": {
-      "_content": "Please note that Flickr will return at most the first 4,000 results for any given search query.  If this is an issue, we recommend trying a more specific query."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "1",
-        "_content": "The NSID of the user who's photo to search. If this parameter isn't passed then everybody's public photos will be searched. A value of \"me\" will search against the calling user's photos for authenticated calls."
+        "optional": "1"
       },
       {
         "name": "tags",
-        "optional": "1",
-        "_content": "A comma-delimited list of tags. Photos with one or more of the tags listed will be returned. You can exclude results that match a term by prepending it with a - character."
+        "optional": "1"
       },
       {
         "name": "tag_mode",
-        "optional": "1",
-        "_content": "Either 'any' for an OR combination of tags, or 'all' for an AND combination. Defaults to 'any' if not specified."
+        "optional": "1"
       },
       {
         "name": "text",
-        "optional": "1",
-        "_content": "A free text search. Photos who's title, description or tags contain the text will be returned. You can exclude results that match a term by prepending it with a - character."
+        "optional": "1"
       },
       {
         "name": "min_upload_date",
-        "optional": "1",
-        "_content": "Minimum upload date. Photos with an upload date greater than or equal to this value will be returned. The date can be in the form of a unix timestamp or mysql datetime."
+        "optional": "1"
       },
       {
         "name": "max_upload_date",
-        "optional": "1",
-        "_content": "Maximum upload date. Photos with an upload date less than or equal to this value will be returned. The date can be in the form of a unix timestamp or mysql datetime."
+        "optional": "1"
       },
       {
         "name": "min_taken_date",
-        "optional": "1",
-        "_content": "Minimum taken date. Photos with an taken date greater than or equal to this value will be returned. The date can be in the form of a mysql datetime or unix timestamp."
+        "optional": "1"
       },
       {
         "name": "max_taken_date",
-        "optional": "1",
-        "_content": "Maximum taken date. Photos with an taken date less than or equal to this value will be returned. The date can be in the form of a mysql datetime or unix timestamp."
+        "optional": "1"
       },
       {
         "name": "license",
-        "optional": "1",
-        "_content": "The license id for photos (for possible values see the flickr.photos.licenses.getInfo method). Multiple licenses may be comma-separated."
+        "optional": "1"
       },
       {
         "name": "sort",
-        "optional": "1",
-        "_content": "The order in which to sort returned photos. Deafults to date-posted-desc (unless you are doing a radial geo query, in which case the default sorting is by ascending distance from the point specified). The possible values are: date-posted-asc, date-posted-desc, date-taken-asc, date-taken-desc, interestingness-desc, interestingness-asc, and relevance."
+        "optional": "1"
       },
       {
         "name": "privacy_filter",
-        "optional": "1",
-        "_content": "Return photos only matching a certain privacy level. This only applies when making an authenticated call to view photos you own. Valid values are:\r\n<ul>\r\n<li>1 public photos</li>\r\n<li>2 private photos visible to friends</li>\r\n<li>3 private photos visible to family</li>\r\n<li>4 private photos visible to friends & family</li>\r\n<li>5 completely private photos</li>\r\n</ul>\r\n"
+        "optional": "1"
       },
       {
         "name": "bbox",
-        "optional": "1",
-        "_content": "A comma-delimited list of 4 values defining the Bounding Box of the area that will be searched.\r\n<br /><br />\r\nThe 4 values represent the bottom-left corner of the box and the top-right corner, minimum_longitude, minimum_latitude, maximum_longitude, maximum_latitude.\r\n<br /><br />\r\nLongitude has a range of -180 to 180 , latitude of -90 to 90. Defaults to -180, -90, 180, 90 if not specified.\r\n<br /><br />\r\nUnlike standard photo queries, geo (or bounding box) queries will only return 250 results per page.\r\n<br /><br />\r\nGeo queries require some sort of limiting agent in order to prevent the database from crying. This is basically like the check against \"parameterless searches\" for queries without a geo component.\r\n<br /><br />\r\nA tag, for instance, is considered a limiting agent as are user defined min_date_taken and min_date_upload parameters &#8212; If no limiting factor is passed we return only photos added in the last 12 hours (though we may extend the limit in the future)."
+        "optional": "1"
       },
       {
         "name": "accuracy",
-        "optional": "1",
-        "_content": "Recorded accuracy level of the location information.  Current range is 1-16 : \r\n\r\n<ul>\r\n<li>World level is 1</li>\r\n<li>Country is ~3</li>\r\n<li>Region is ~6</li>\r\n<li>City is ~11</li>\r\n<li>Street is ~16</li>\r\n</ul>\r\n\r\nDefaults to maximum value if not specified."
+        "optional": "1"
       },
       {
         "name": "safe_search",
-        "optional": "1",
-        "_content": "Safe search setting:\r\n\r\n<ul>\r\n<li>1 for safe.</li>\r\n<li>2 for moderate.</li>\r\n<li>3 for restricted.</li>\r\n</ul>\r\n\r\n(Please note: Un-authed calls can only see Safe content.)"
+        "optional": "1"
       },
       {
         "name": "content_type",
-        "optional": "1",
-        "_content": "Content Type setting:\r\n<ul>\r\n<li>1 for photos only.</li>\r\n<li>2 for screenshots only.</li>\r\n<li>3 for 'other' only.</li>\r\n<li>4 for photos and screenshots.</li>\r\n<li>5 for screenshots and 'other'.</li>\r\n<li>6 for photos and 'other'.</li>\r\n<li>7 for photos, screenshots, and 'other' (all).</li>\r\n</ul>"
+        "optional": "1"
       },
       {
         "name": "machine_tags",
-        "optional": "1",
-        "_content": "Aside from passing in a fully formed machine tag, there is a special syntax for searching on specific properties :\r\n\r\n<ul>\r\n  <li>Find photos using the 'dc' namespace :    <code>\"machine_tags\" => \"dc:\"</code></li>\r\n\r\n  <li> Find photos with a title in the 'dc' namespace : <code>\"machine_tags\" => \"dc:title=\"</code></li>\r\n\r\n  <li>Find photos titled \"mr. camera\" in the 'dc' namespace : <code>\"machine_tags\" => \"dc:title=\\\"mr. camera\\\"</code></li>\r\n\r\n  <li>Find photos whose value is \"mr. camera\" : <code>\"machine_tags\" => \"*:*=\\\"mr. camera\\\"\"</code></li>\r\n\r\n  <li>Find photos that have a title, in any namespace : <code>\"machine_tags\" => \"*:title=\"</code></li>\r\n\r\n  <li>Find photos that have a title, in any namespace, whose value is \"mr. camera\" : <code>\"machine_tags\" => \"*:title=\\\"mr. camera\\\"\"</code></li>\r\n\r\n  <li>Find photos, in the 'dc' namespace whose value is \"mr. camera\" : <code>\"machine_tags\" => \"dc:*=\\\"mr. camera\\\"\"</code></li>\r\n\r\n </ul>\r\n\r\nMultiple machine tags may be queried by passing a comma-separated list. The number of machine tags you can pass in a single query depends on the tag mode (AND or OR) that you are querying with. \"AND\" queries are limited to (16) machine tags. \"OR\" queries are limited\r\nto (8)."
+        "optional": "1"
       },
       {
         "name": "machine_tag_mode",
-        "optional": "1",
-        "_content": "Either 'any' for an OR combination of tags, or 'all' for an AND combination. Defaults to 'any' if not specified."
+        "optional": "1"
       },
       {
         "name": "group_id",
-        "optional": "1",
-        "_content": "The id of a group who's pool to search.  If specified, only matching photos posted to the group's pool will be returned."
+        "optional": "1"
       },
       {
         "name": "contacts",
-        "optional": "1",
-        "_content": "Search your contacts. Either 'all' or 'ff' for just friends and family. (Experimental)"
+        "optional": "1"
       },
       {
         "name": "woe_id",
-        "optional": "1",
-        "_content": "A 32-bit identifier that uniquely represents spatial entities. (not used if bbox argument is present). \r\n<br /><br />\r\nGeo queries require some sort of limiting agent in order to prevent the database from crying. This is basically like the check against \"parameterless searches\" for queries without a geo component.\r\n<br /><br />\r\nA tag, for instance, is considered a limiting agent as are user defined min_date_taken and min_date_upload parameters &mdash; If no limiting factor is passed we return only photos added in the last 12 hours (though we may extend the limit in the future)."
+        "optional": "1"
       },
       {
         "name": "place_id",
-        "optional": "1",
-        "_content": "A Flickr place id.  (not used if bbox argument is present).\r\n<br /><br />\r\nGeo queries require some sort of limiting agent in order to prevent the database from crying. This is basically like the check against \"parameterless searches\" for queries without a geo component.\r\n<br /><br />\r\nA tag, for instance, is considered a limiting agent as are user defined min_date_taken and min_date_upload parameters &mdash; If no limiting factor is passed we return only photos added in the last 12 hours (though we may extend the limit in the future)."
+        "optional": "1"
       },
       {
         "name": "media",
-        "optional": "1",
-        "_content": "Filter results by media type. Possible values are <code>all</code> (default), <code>photos</code> or <code>videos</code>"
+        "optional": "1"
       },
       {
         "name": "has_geo",
-        "optional": "1",
-        "_content": "Any photo that has been geotagged, or if the value is \"0\" any photo that has <i>not</i> been geotagged.\r\n<br /><br />\r\nGeo queries require some sort of limiting agent in order to prevent the database from crying. This is basically like the check against \"parameterless searches\" for queries without a geo component.\r\n<br /><br />\r\nA tag, for instance, is considered a limiting agent as are user defined min_date_taken and min_date_upload parameters &mdash; If no limiting factor is passed we return only photos added in the last 12 hours (though we may extend the limit in the future)."
+        "optional": "1"
       },
       {
         "name": "geo_context",
-        "optional": "1",
-        "_content": "Geo context is a numeric value representing the photo's geotagginess beyond latitude and longitude. For example, you may wish to search for photos that were taken \"indoors\" or \"outdoors\". <br /><br />\r\nThe current list of context IDs is :<br /><br/>\r\n<ul>\r\n<li><strong>0</strong>, not defined.</li>\r\n<li><strong>1</strong>, indoors.</li>\r\n<li><strong>2</strong>, outdoors.</li>\r\n</ul>\r\n<br /><br />\r\nGeo queries require some sort of limiting agent in order to prevent the database from crying. This is basically like the check against \"parameterless searches\" for queries without a geo component.\r\n<br /><br />\r\nA tag, for instance, is considered a limiting agent as are user defined min_date_taken and min_date_upload parameters &mdash; If no limiting factor is passed we return only photos added in the last 12 hours (though we may extend the limit in the future)."
+        "optional": "1"
       },
       {
         "name": "lat",
-        "optional": "1",
-        "_content": "A valid latitude, in decimal format, for doing radial geo queries.\r\n<br /><br />\r\nGeo queries require some sort of limiting agent in order to prevent the database from crying. This is basically like the check against \"parameterless searches\" for queries without a geo component.\r\n<br /><br />\r\nA tag, for instance, is considered a limiting agent as are user defined min_date_taken and min_date_upload parameters &mdash; If no limiting factor is passed we return only photos added in the last 12 hours (though we may extend the limit in the future)."
+        "optional": "1"
       },
       {
         "name": "lon",
-        "optional": "1",
-        "_content": "A valid longitude, in decimal format, for doing radial geo queries.\r\n<br /><br />\r\nGeo queries require some sort of limiting agent in order to prevent the database from crying. This is basically like the check against \"parameterless searches\" for queries without a geo component.\r\n<br /><br />\r\nA tag, for instance, is considered a limiting agent as are user defined min_date_taken and min_date_upload parameters &mdash; If no limiting factor is passed we return only photos added in the last 12 hours (though we may extend the limit in the future)."
+        "optional": "1"
       },
       {
         "name": "radius",
-        "optional": "1",
-        "_content": "A valid radius used for geo queries, greater than zero and less than 20 miles (or 32 kilometers), for use with point-based geo queries. The default value is 5 (km)."
+        "optional": "1"
       },
       {
         "name": "radius_units",
-        "optional": "1",
-        "_content": "The unit of measure when doing radial geo queries. Valid options are \"mi\" (miles) and \"km\" (kilometers). The default is \"km\"."
+        "optional": "1"
       },
       {
         "name": "is_commons",
-        "optional": "1",
-        "_content": "Limit the scope of the search to only photos that are part of the <a href=\"http://flickr.com/commons\">Flickr Commons project</a>. Default is false."
+        "optional": "1"
       },
       {
         "name": "in_gallery",
-        "optional": "1",
-        "_content": "Limit the scope of the search to only photos that are in a <a href=\"http://www.flickr.com/help/galleries/\">gallery</a>?  Default is false, search all photos."
+        "optional": "1"
       },
       {
         "name": "is_getty",
-        "optional": "1",
-        "_content": "Limit the scope of the search to only photos that are for sale on Getty. Default is false."
+        "optional": "1"
       },
       {
         "name": "extras",
-        "optional": 1,
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: <code>description</code>, <code>license</code>, <code>date_upload</code>, <code>date_taken</code>, <code>owner_name</code>, <code>icon_server</code>, <code>original_format</code>, <code>last_update</code>, <code>geo</code>, <code>tags</code>, <code>machine_tags</code>, <code>o_dims</code>, <code>views</code>, <code>media</code>, <code>path_alias</code>, <code>url_sq</code>, <code>url_t</code>, <code>url_s</code>, <code>url_q</code>, <code>url_m</code>, <code>url_n</code>, <code>url_z</code>, <code>url_c</code>, <code>url_l</code>, <code>url_o</code>"
+        "optional": 1
       },
       {
         "name": "per_page",
-        "optional": 1,
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 100. The maximum allowed value is 500."
+        "optional": 1
       },
       {
         "name": "page",
-        "optional": 1,
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": 1
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Too many tags in ALL query",
-        "_content": "When performing an 'all tags' search, you may not specify more than 20 tags to join together."
-      },
-      {
-        "code": "2",
-        "message": "Unknown user",
-        "_content": "A user_id was passed which did not match a valid flickr user."
-      },
-      {
-        "code": "3",
-        "message": "Parameterless searches have been disabled",
-        "_content": "To perform a search with no parameters (to get the latest public photos, please use flickr.photos.getRecent instead)."
-      },
-      {
-        "code": "4",
-        "message": "You don't have permission to view this pool",
-        "_content": "The logged in user (if any) does not have permission to view the pool for this group."
-      },
-      {
-        "code": "10",
-        "message": "Sorry, the Flickr search API is not currently available.",
-        "_content": "The Flickr API search databases are temporarily unavailable."
-      },
-      {
-        "code": "11",
-        "message": "No valid machine tags",
-        "_content": "The query styntax for the machine_tags argument did not validate."
-      },
-      {
-        "code": "12",
-        "message": "Exceeded maximum allowable machine tags",
-        "_content": "The maximum number of machine tags in a single query was exceeded."
-      },
-      {
-        "code": "13",
-        "message": "jump_to not avaiable for this query",
-        "_content": "jump_to only supported for some query types."
-      },
-      {
-        "code": "14",
-        "message": "Bad value for jump_to",
-        "_content": "jump_to must be valid photo ID."
-      },
-      {
-        "code": "15",
-        "message": "Photo not found",
-        "_content": ""
-      },
-      {
-        "code": "16",
-        "message": "You can only search within your own favorites",
-        "_content": ""
-      },
-      {
-        "code": "17",
-        "message": "You can only search within your own contacts",
-        "_content": "The call tried to use the contacts parameter with no user ID or a user ID other than that of the authenticated user."
-      },
-      {
-        "code": "18",
-        "message": "Illogical arguments",
-        "_content": "The request contained contradictory arguments."
-      },
-      {
-        "code": "19",
-        "message": "Similarity search invalid.",
-        "_content": "The similarity_id param contains an invalid photo id or the viewer does not have permission to view the photo."
-      },
-      {
-        "code": "20",
-        "message": "Excessive photo offset in search",
-        "_content": "The search requested photos beyond an allowable offset. Reduce the page number or number of results per page for this search."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.setContentType.json
+++ b/src/flickr.photos.setContentType.json
@@ -1,118 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.setContentType",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Set the content type of a photo."
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n<photo id=\"14814\" content_type=\"3\"/>\r\n</rsp>"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to set the adultness of."
+        "optional": "0"
       },
       {
         "name": "content_type",
-        "optional": "0",
-        "_content": "The content type of the photo. Must be one of: 1 for Photo, 2 for Screenshot, and 3 for Other."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id of a photo belonging to the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Required arguments missing",
-        "_content": "Some or all of the required arguments were not supplied."
-      },
-      {
-        "code": "3",
-        "message": "Change not allowed",
-        "_content": "Changing the content type of this photo is not allowed."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.setDates.json
+++ b/src/flickr.photos.setDates.json
@@ -1,140 +1,30 @@
 {
   "method": {
     "name": "flickr.photos.setDates",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Set one or both of the dates for a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to edit dates for."
+        "optional": "0"
       },
       {
         "name": "date_posted",
-        "optional": "1",
-        "_content": "The date the photo was uploaded to flickr (see the <a href=\"/services/api/misc.dates.html\">dates documentation</a>)"
+        "optional": "1"
       },
       {
         "name": "date_taken",
-        "optional": "1",
-        "_content": "The date the photo was taken (see the <a href=\"/services/api/misc.dates.html\">dates documentation</a>)"
+        "optional": "1"
       },
       {
         "name": "date_taken_granularity",
-        "optional": "1",
-        "_content": "The granularity of the date the photo was taken (see the <a href=\"/services/api/misc.dates.html\">dates documentation</a>)"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id was not the id of a valid photo belonging to the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Not enough arguments",
-        "_content": "No dates were specified to be changed."
-      },
-      {
-        "code": "3",
-        "message": "Invalid granularity",
-        "_content": "The value passed for 'granularity' was not a valid flickr date granularity."
-      },
-      {
-        "code": "4",
-        "message": "Invalid date_posted",
-        "_content": "The date posted is invalid, its in the past."
-      },
-      {
-        "code": "5",
-        "message": "Invalid Date Taken Format",
-        "_content": "The date taken is not in the format that we support."
-      },
-      {
-        "code": "6",
-        "message": "Invalid Date Taken",
-        "_content": "The date taken passed is invalid. It may be in the future or way in the past. "
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.setMeta.json
+++ b/src/flickr.photos.setMeta.json
@@ -1,115 +1,26 @@
 {
   "method": {
     "name": "flickr.photos.setMeta",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Set the meta information for a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to set information for."
+        "optional": "0"
       },
       {
         "name": "title",
-        "optional": "1",
-        "_content": "The title for the photo. At least one of title or description must be set."
+        "optional": "1"
       },
       {
         "name": "description",
-        "optional": "1",
-        "_content": "The description for the photo. At least one of title or description must be set."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not the id of a photo belonging to the calling user. It might be an invalid id, or the photo might be owned by another user. "
-      },
-      {
-        "code": "2",
-        "message": "At least one of title or description must be set",
-        "_content": "Since title and description is now optional, at least one of them must be sent. "
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.setPerms.json
+++ b/src/flickr.photos.setPerms.json
@@ -1,133 +1,38 @@
 {
   "method": {
     "name": "flickr.photos.setPerms",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Set permissions for a photo."
-    },
-    "response": {
-      "_content": "<photoid secret=\"abcdef\" originalsecret=\"abcdef\">1234</photoid>"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to set permissions for."
+        "optional": "0"
       },
       {
         "name": "is_public",
-        "optional": "0",
-        "_content": "1 to set the photo to public, 0 to set it to private."
+        "optional": "0"
       },
       {
         "name": "is_friend",
-        "optional": "0",
-        "_content": "1 to make the photo visible to friends when private, 0 to not."
+        "optional": "0"
       },
       {
         "name": "is_family",
-        "optional": "0",
-        "_content": "1 to make the photo visible to family when private, 0 to not."
+        "optional": "0"
       },
       {
         "name": "perm_comment",
-        "optional": "1",
-        "_content": "who can add comments to the photo and it's notes. one of:<br />\r\n<code>0</code>: nobody<br />\r\n<code>1</code>: friends &amp; family<br />\r\n<code>2</code>: contacts<br />\r\n<code>3</code>: everybody"
+        "optional": "1"
       },
       {
         "name": "perm_addmeta",
-        "optional": "1",
-        "_content": "who can add notes and tags to the photo. one of:<br />\r\n<code>0</code>: nobody / just the owner<br />\r\n<code>1</code>: friends &amp; family<br />\r\n<code>2</code>: contacts<br />\r\n<code>3</code>: everybody\r\n"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id of a photo belonging to the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Required arguments missing",
-        "_content": "Some or all of the required arguments were not supplied."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.setSafetyLevel.json
+++ b/src/flickr.photos.setSafetyLevel.json
@@ -1,123 +1,26 @@
 {
   "method": {
     "name": "flickr.photos.setSafetyLevel",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Set the safety level of a photo."
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n<photo id=\"14814\" safety_level=\"2\" hidden=\"0\"/>\r\n</rsp>"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to set the adultness of."
+        "optional": "0"
       },
       {
         "name": "safety_level",
-        "optional": "1",
-        "_content": "The safety level of the photo.  Must be one of:\r\n\r\n1 for Safe, 2 for Moderate, and 3 for Restricted."
+        "optional": "1"
       },
       {
         "name": "hidden",
-        "optional": "1",
-        "_content": "Whether or not to additionally hide the photo from public searches.  Must be either 1 for Yes or 0 for No."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id of a photo belonging to the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Invalid or missing arguments",
-        "_content": "Neither a valid safety level nor a hidden value were passed."
-      },
-      {
-        "code": "3",
-        "message": "Change not allowed",
-        "_content": "Changing the safety level of this photo is not allowed."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.setTags.json
+++ b/src/flickr.photos.setTags.json
@@ -1,110 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.setTags",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Set the tags for a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to set tags for.\r\n"
+        "optional": "0"
       },
       {
         "name": "tags",
-        "optional": "0",
-        "_content": "All tags for the photo (as a single space-delimited string)."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not the id of a photo belonging to the calling user. It might be an invalid id, or the photo might be owned by another user. "
-      },
-      {
-        "code": "2",
-        "message": "Maximum number of tags reached",
-        "_content": "The number of tags specified exceeds the limit for the photo. No tags were modified."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.suggestions.approveSuggestion.json
+++ b/src/flickr.photos.suggestions.approveSuggestion.json
@@ -1,95 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.suggestions.approveSuggestion",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Approve a suggestion for a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "suggestion_id",
-        "optional": "0",
-        "_content": "The unique ID for the location suggestion to approve."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.suggestions.getList.json
+++ b/src/flickr.photos.suggestions.getList.json
@@ -1,100 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.suggestions.getList",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Return a list of suggestions for a user that are pending approval."
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "1",
-        "_content": "Only show suggestions for a single photo."
+        "optional": "1"
       },
       {
         "name": "status_id",
-        "optional": "1",
-        "_content": "Only show suggestions with a given status.\r\n\r\n<ul>\r\n<li><strong>0</strong>, pending</li>\r\n<li><strong>1</strong>, approved</li>\r\n<li><strong>2</strong>, rejected</li>\r\n</ul>\r\n\r\nThe default is pending (or \"0\")."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.suggestions.rejectSuggestion.json
+++ b/src/flickr.photos.suggestions.rejectSuggestion.json
@@ -1,95 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.suggestions.rejectSuggestion",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Reject a suggestion for a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "suggestion_id",
-        "optional": "0",
-        "_content": "The unique ID of the suggestion to reject."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.suggestions.removeSuggestion.json
+++ b/src/flickr.photos.suggestions.removeSuggestion.json
@@ -1,95 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.suggestions.removeSuggestion",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Remove a suggestion, made by the calling user, from a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "suggestion_id",
-        "optional": "0",
-        "_content": "The unique ID for the location suggestion to approve."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.suggestions.suggestLocation.json
+++ b/src/flickr.photos.suggestions.suggestLocation.json
@@ -1,125 +1,42 @@
 {
   "method": {
     "name": "flickr.photos.suggestions.suggestLocation",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Suggest a geotagged location for a photo."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The photo whose location you are suggesting."
+        "optional": "0"
       },
       {
         "name": "lat",
-        "optional": "0",
-        "_content": "The latitude whose valid range is -90 to 90. Anything more than 6 decimal places will be truncated."
+        "optional": "0"
       },
       {
         "name": "lon",
-        "optional": "0",
-        "_content": "The longitude whose valid range is -180 to 180. Anything more than 6 decimal places will be truncated."
+        "optional": "0"
       },
       {
         "name": "accuracy",
-        "optional": "1",
-        "_content": "Recorded accuracy level of the location information. World level is 1, Country is ~3, Region ~6, City ~11, Street ~16. Current range is 1-16. Defaults to 16 if not specified."
+        "optional": "1"
       },
       {
         "name": "woe_id",
-        "optional": "1",
-        "_content": "The WOE ID of the location used to build the location hierarchy for the photo."
+        "optional": "1"
       },
       {
         "name": "place_id",
-        "optional": "1",
-        "_content": "The Flickr Places ID of the location used to build the location hierarchy for the photo."
+        "optional": "1"
       },
       {
         "name": "note",
-        "optional": "1",
-        "_content": "A short note or history to include with the suggestion."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.transform.rotate.json
+++ b/src/flickr.photos.transform.rotate.json
@@ -1,123 +1,22 @@
 {
   "method": {
     "name": "flickr.photos.transform.rotate",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Rotate a photo."
-    },
-    "response": {
-      "_content": "<photoid secret=\"abcdef\" originalsecret=\"abcdef\">1234</photoid>"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to rotate."
+        "optional": "0"
       },
       {
         "name": "degrees",
-        "optional": "0",
-        "_content": "The amount of degrees by which to rotate the photo (clockwise) from it's current orientation. Valid values are 90, 180 and 270."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id was invalid or did not belong to the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Invalid rotation",
-        "_content": "The rotation degrees were an invalid value."
-      },
-      {
-        "code": "3",
-        "message": "Temporary failure",
-        "_content": "There was a problem either rotating the image or storing the rotated versions."
-      },
-      {
-        "code": "4",
-        "message": "Rotation disabled",
-        "_content": "The rotation service is currently disabled."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photos.upload.checkTickets.json
+++ b/src/flickr.photos.upload.checkTickets.json
@@ -1,76 +1,18 @@
 {
   "method": {
     "name": "flickr.photos.upload.checkTickets",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Checks the status of one or more asynchronous photo upload tickets."
-    },
-    "response": {
-      "_content": "<uploader>\r\n\t<ticket id=\"128\" complete=\"1\" photoid=\"2995\" />\r\n\t<ticket id=\"129\" complete=\"0\" />\r\n\t<ticket id=\"130\" complete=\"2\" />\r\n\t<ticket id=\"131\" invalid=\"1\" />\r\n</uploader>\r\n"
-    },
-    "explanation": {
-      "_content": "<p>There is one <code>&lt;ticket&gt;</code> element for each ticket id supplied. The <code>id</code> attribute contains the corresponding ticket id. If the ticket wasn't found, the <code>invalid</code> attribute is set. The status of the ticket is passed in the <code>status</code> attribute; 0 means not completed, 1 means completed and 2 means the ticket failed (indicating there was a problem converting the file). When the status is 1, the photo id is passed in the <code>photoid</code> attribute. The photo id can then be used as with the <a href=\"/services/api/upload.api.html\">synchronous upload API</a>."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "tickets",
-        "optional": "0",
-        "_content": "A comma-delimited list of ticket ids"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.addPhoto.json
+++ b/src/flickr.photosets.addPhoto.json
@@ -1,120 +1,22 @@
 {
   "method": {
     "name": "flickr.photosets.addPhoto",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Add a photo to the end of an existing photoset."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The id of the photoset to add a photo to."
+        "optional": "0"
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to add to the set."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photoset not found",
-        "_content": "The photoset id passed was not the id of avalid photoset owned by the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not the id of a valid photo owned by the calling user."
-      },
-      {
-        "code": "3",
-        "message": "Photo already in set",
-        "_content": "The photo is already a member of the photoset."
-      },
-      {
-        "code": "10",
-        "message": "Maximum number of photos in set",
-        "_content": "A set has reached the upper limit for the number of photos allowed."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.comments.addComment.json
+++ b/src/flickr.photosets.comments.addComment.json
@@ -1,118 +1,22 @@
 {
   "method": {
     "name": "flickr.photosets.comments.addComment",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Add a comment to a photoset."
-    },
-    "response": {
-      "_content": "<comment id=\"97777-12492-72057594037942601\" />"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The id of the photoset to add a comment to."
+        "optional": "0"
       },
       {
         "name": "comment_text",
-        "optional": "0",
-        "_content": "Text of the comment"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photoset not found",
-        "_content": ""
-      },
-      {
-        "code": "8",
-        "message": "Blank comment",
-        "_content": ""
-      },
-      {
-        "code": "9",
-        "message": "User is posting comments too fast.",
-        "_content": "The user has reached the limit for number of comments posted during a specific time period. Wait a bit and try again."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.comments.deleteComment.json
+++ b/src/flickr.photosets.comments.deleteComment.json
@@ -1,100 +1,18 @@
 {
   "method": {
     "name": "flickr.photosets.comments.deleteComment",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Delete a photoset comment as the currently authenticated user."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "comment_id",
-        "optional": "0",
-        "_content": "The id of the comment to delete from a photoset."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "2",
-        "message": "Comment not found.",
-        "_content": "The comment id passed was not a valid comment id"
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.comments.editComment.json
+++ b/src/flickr.photosets.comments.editComment.json
@@ -1,110 +1,22 @@
 {
   "method": {
     "name": "flickr.photosets.comments.editComment",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Edit the text of a comment as the currently authenticated user."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "comment_id",
-        "optional": "0",
-        "_content": "The id of the comment to edit."
+        "optional": "0"
       },
       {
         "name": "comment_text",
-        "optional": "0",
-        "_content": "Update the comment to this text."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "2",
-        "message": "Comment not found.",
-        "_content": "The comment id passed was not a valid comment id."
-      },
-      {
-        "code": "8",
-        "message": "Blank comment.",
-        "_content": "Comment text can't be blank."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.comments.getList.json
+++ b/src/flickr.photosets.comments.getList.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.photosets.comments.getList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the comments for a photoset."
-    },
-    "response": {
-      "_content": "<comments photoset_id=\"109722179\">\r\n    <comment id=\"6065-109722179-72057594077818641\"\r\n         author=\"35468159852@N01\" authorname=\"Rev Dan Catt\" date_create=\"1141841470\"\r\n         permalink=\"http://www.flickr.com/photos/straup/109722179/#comment72057594077818641\"\r\n         >Umm, I'm not sure, can I get back to you on that one?</comment>\r\n</comments>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The id of the photoset to fetch comments for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photoset not found.",
-        "_content": "The photoset id was invalid."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.create.json
+++ b/src/flickr.photosets.create.json
@@ -1,126 +1,26 @@
 {
   "method": {
     "name": "flickr.photosets.create",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Create a new photoset for the calling user."
-    },
-    "response": {
-      "_content": "<photoset id=\"1234\" url=\"http://www.flickr.com/photos/bees/sets/1234/\" />"
-    },
-    "explanation": {
-      "_content": "<p>New photosets are automatically put first in the photoset ordering for the user. Use <a href=\"/services/api/flickr.photosets.orderSets.html\">flickr.photosets.orderSets</a> if you don't want the new set to appear first on the user's photoset list.</p>"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "title",
-        "optional": "0",
-        "_content": "A title for the photoset."
+        "optional": "0"
       },
       {
         "name": "description",
-        "optional": "1",
-        "_content": "A description of the photoset. May contain limited html."
+        "optional": "1"
       },
       {
         "name": "primary_photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to represent this set. The photo must belong to the calling user."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "No title specified",
-        "_content": "No title parameter was passed in the request."
-      },
-      {
-        "code": "2",
-        "message": "Photo not found",
-        "_content": "The primary photo id passed was not a valid photo id or does not belong to the calling user."
-      },
-      {
-        "code": "3",
-        "message": "Can't create any more sets",
-        "_content": "The user has reached their maximum number of photosets limit."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.delete.json
+++ b/src/flickr.photosets.delete.json
@@ -1,100 +1,18 @@
 {
   "method": {
     "name": "flickr.photosets.delete",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Delete a photoset."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The id of the photoset to delete. It must be owned by the calling user."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photoset not found",
-        "_content": "The photoset id passed was not a valid photoset id or did not belong to the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.editMeta.json
+++ b/src/flickr.photosets.editMeta.json
@@ -1,115 +1,26 @@
 {
   "method": {
     "name": "flickr.photosets.editMeta",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Modify the meta-data for a photoset."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The id of the photoset to modify."
+        "optional": "0"
       },
       {
         "name": "title",
-        "optional": "0",
-        "_content": "The new title for the photoset."
+        "optional": "0"
       },
       {
         "name": "description",
-        "optional": "1",
-        "_content": "A description of the photoset. May contain limited html."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photoset not found",
-        "_content": "The photoset id passed was not a valid photoset id or did not belong to the calling user."
-      },
-      {
-        "code": "2",
-        "message": "No title specified",
-        "_content": "No title parameter was passed in the request. "
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.editPhotos.json
+++ b/src/flickr.photosets.editPhotos.json
@@ -1,130 +1,26 @@
 {
   "method": {
     "name": "flickr.photosets.editPhotos",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Modify the photos in a photoset. Use this method to add, remove and re-order photos."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The id of the photoset to modify. The photoset must belong to the calling user."
+        "optional": "0"
       },
       {
         "name": "primary_photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to use as the 'primary' photo for the set. This id must also be passed along in photo_ids list argument."
+        "optional": "0"
       },
       {
         "name": "photo_ids",
-        "optional": "0",
-        "_content": "A comma-delimited list of photo ids to include in the set. They will appear in the set in the order sent. This list <b>must</b> contain the primary photo id. All photos must belong to the owner of the set. This list of photos replaces the existing list. Call flickr.photosets.addPhoto to append a photo to a set."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photoset not found",
-        "_content": "The photoset id passed was not a valid photoset id or did not belong to the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Photo not found",
-        "_content": "One or more of the photo ids passed was not a valid photo id or does not belong to the calling user."
-      },
-      {
-        "code": "3",
-        "message": "Primary photo not found",
-        "_content": "The primary photo id passed was not a valid photo id or does not belong to the calling user."
-      },
-      {
-        "code": "4",
-        "message": "Primary photo not in list",
-        "_content": "The primary photo id passed did not appear in the photo id list."
-      },
-      {
-        "code": "5",
-        "message": "Empty photos list",
-        "_content": "No photo ids were passed."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.getContext.json
+++ b/src/flickr.photosets.getContext.json
@@ -1,91 +1,22 @@
 {
   "method": {
     "name": "flickr.photosets.getContext",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns next and previous photos for a photo in a set."
-    },
-    "response": {
-      "_content": "<prevphoto id=\"2980\" secret=\"973da1e709\"\r\n\ttitle=\"boo!\" url=\"/photos/bees/2980/\" /> \r\n<nextphoto id=\"2985\" secret=\"059b664012\"\r\n\ttitle=\"Amsterdam Amstel\" url=\"/photos/bees/2985/\" /> "
-    },
-    "explanation": {
-      "_content": "<p>See <a href=\"/services/api/flickr.photos.getContext.html\">flickr.photos.getContext</a></p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to fetch the context for."
+        "optional": "0"
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The id of the photoset for which to fetch the photo's context."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id, or was the id of a photo that the calling user does not have permission to view."
-      },
-      {
-        "code": "2",
-        "message": "Photo not in set",
-        "_content": "The specified photo is not in the specified set."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.getInfo.json
+++ b/src/flickr.photosets.getInfo.json
@@ -1,88 +1,22 @@
 {
   "method": {
     "name": "flickr.photosets.getInfo",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Gets information about a photoset."
-    },
-    "response": {
-      "_content": "<photoset id=\"72157624618609504\" owner=\"34427469121@N01\" primary=\"4847770787\" secret=\"6abd09a292\" server=\"4153\" farm=\"5\" photos=\"55\" count_views=\"523\" count_comments=\"1\" count_photos=\"43\" count_videos=\"12\" can_comment=\"1\" date_create=\"1280530593\" date_update=\"1308091378\">\r\n    <title>Mah Kittehs</title>\r\n    <description>Sixty and Niner. Born on the 3rd of May, 2010, or thereabouts. Came to my place on Thursday, July 29, 2010.</description>\r\n</photoset>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The ID of the photoset to fetch information for."
+        "optional": "0"
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The user_id here is the owner of the set passed in photoset_id. This is optional, but passing this gives better performance. "
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photoset not found",
-        "_content": "The photoset id was not valid."
-      },
-      {
-        "code": "2",
-        "message": "User not found",
-        "_content": ""
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.getList.json
+++ b/src/flickr.photosets.getList.json
@@ -1,96 +1,30 @@
 {
   "method": {
     "name": "flickr.photosets.getList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the photosets belonging to the specified user."
-    },
-    "response": {
-      "_content": "<photosets page=\"1\" pages=\"1\" perpage=\"30\" total=\"2\" cancreate=\"1\">\r\n    <photoset id=\"72157626216528324\" primary=\"5504567858\" secret=\"017804c585\" server=\"5174\" farm=\"6\" photos=\"22\" videos=\"0\" count_views=\"137\" count_comments=\"0\" can_comment=\"1\" date_create=\"1299514498\" date_update=\"1300335009\">\r\n      <title>Avis Blanche</title>\r\n      <description>My Grandma's Recipe File.</description>\r\n    </photoset>\r\n    <photoset id=\"72157624618609504\" primary=\"4847770787\" secret=\"6abd09a292\" server=\"4153\" farm=\"5\" photos=\"43\" videos=\"12\" count_views=\"523\" count_comments=\"1\" can_comment=\"1\" date_create=\"1280530593\" date_update=\"1308091378\">\r\n      <title>Mah Kittehs</title>\r\n      <description>Sixty and Niner. Born on the 3rd of May, 2010, or thereabouts. Came to my place on Thursday, July 29, 2010.</description>\r\n    </photoset>\r\n</photosets>"
-    },
-    "explanation": {
-      "_content": "<p>Photosets are returned in the user's specified order, which may not mean the newest set is first. Applications displaying photosets should respect the user's ordering.</p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "1",
-        "_content": "The NSID of the user to get a photoset list for. If none is specified, the calling user is assumed."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to get. Currently, if this is not provided, all sets are returned, but this behaviour may change in future."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "The number of sets to get per page. If paging is enabled, the maximum number of sets per page is 500."
+        "optional": "1"
       },
       {
         "name": "primary_photo_extras",
-        "optional": "1",
-        "_content": "A comma-delimited list of extra information to fetch for the primary photo. Currently supported fields are: license, date_upload, date_taken, owner_name, icon_server, original_format, last_update, geo, tags, machine_tags, o_dims, views, media, path_alias, url_sq, url_t, url_s, url_m, url_o"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The user NSID passed was not a valid user NSID and the calling user was not logged in.\r\n"
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.getPhotos.json
+++ b/src/flickr.photosets.getPhotos.json
@@ -1,113 +1,42 @@
 {
   "method": {
     "name": "flickr.photosets.getPhotos",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get the list of photos in a set."
-    },
-    "response": {
-      "_content": "<photoset id=\"4\" primary=\"2483\" page=\"1\" perpage=\"500\" pages=\"1\" total=\"2\">\r\n\t<photo id=\"2484\" secret=\"123456\" server=\"1\"\r\n\t\ttitle=\"my photo\" isprimary=\"0\" /> \r\n\t<photo id=\"2483\" secret=\"123456\" server=\"1\"\r\n\t\ttitle=\"flickr rocks\" isprimary=\"1\" /> \r\n</photoset>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The id of the photoset to return the photos for."
+        "optional": "0"
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The user_id here is the owner of the set passed in photoset_id. This is optional, but passing this gives better performance. "
+        "optional": "0"
       },
       {
         "name": "extras",
-        "optional": "1",
-        "_content": "A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: license, date_upload, date_taken, owner_name, icon_server, original_format, last_update, geo, tags, machine_tags, o_dims, views, media, path_alias, url_sq, url_t, url_s, url_m, url_o"
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of photos to return per page. If this argument is omitted, it defaults to 500. The maximum allowed value is 500."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       },
       {
         "name": "privacy_filter",
-        "optional": "1",
-        "_content": "Return photos only matching a certain privacy level. This only applies when making an authenticated call to view a photoset you own. Valid values are:\r\n<ul>\r\n<li>1 public photos</li>\r\n<li>2 private photos visible to friends</li>\r\n<li>3 private photos visible to family</li>\r\n<li>4 private photos visible to friends &amp; family</li>\r\n<li>5 completely private photos</li>\r\n</ul>\r\n"
+        "optional": "1"
       },
       {
         "name": "media",
-        "optional": "1",
-        "_content": "Filter results by media type. Possible values are <code>all</code> (default), <code>photos</code> or <code>videos</code>"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photoset not found",
-        "_content": "The photoset id passed was not a valid photoset id."
-      },
-      {
-        "code": "2",
-        "message": "User not found",
-        "_content": ""
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.orderSets.json
+++ b/src/flickr.photosets.orderSets.json
@@ -1,100 +1,18 @@
 {
   "method": {
     "name": "flickr.photosets.orderSets",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Set the order of photosets for the calling user."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photoset_ids",
-        "optional": "0",
-        "_content": "A comma delimited list of photoset IDs, ordered with the set to show first, first in the list. Any set IDs not given in the list will be set to appear at the end of the list, ordered by their IDs."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Set not found",
-        "_content": "One of the photoset ids passed was not the id of a valid photoset belonging to the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.removePhoto.json
+++ b/src/flickr.photosets.removePhoto.json
@@ -1,115 +1,22 @@
 {
   "method": {
     "name": "flickr.photosets.removePhoto",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Remove a photo from a photoset."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The id of the photoset to remove a photo from."
+        "optional": "0"
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to remove from the set."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photoset not found",
-        "_content": "The photoset id passed was not the id of avalid photoset owned by the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not the id of a valid photo belonging to the calling user."
-      },
-      {
-        "code": "3",
-        "message": "Photo not in set",
-        "_content": "The photo is not a member of the photoset."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.removePhotos.json
+++ b/src/flickr.photosets.removePhotos.json
@@ -1,110 +1,22 @@
 {
   "method": {
     "name": "flickr.photosets.removePhotos",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Remove multiple photos from a photoset."
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The id of the photoset to remove photos from."
+        "optional": "0"
       },
       {
         "name": "photo_ids",
-        "optional": "0",
-        "_content": "Comma-delimited list of photo ids to remove from the photoset."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photoset not found",
-        "_content": "The photoset id passed was not the id of available photosets owned by the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not the id of a valid photo belonging to the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.reorderPhotos.json
+++ b/src/flickr.photosets.reorderPhotos.json
@@ -1,110 +1,22 @@
 {
   "method": {
     "name": "flickr.photosets.reorderPhotos",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": ""
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The id of the photoset to reorder. The photoset must belong to the calling user."
+        "optional": "0"
       },
       {
         "name": "photo_ids",
-        "optional": "0",
-        "_content": "Ordered, comma-delimited list of photo ids. Photos that are not in the list will keep their original order"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photoset not found",
-        "_content": "The photoset id passed was not a valid photoset id or did not belong to the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Photo not found",
-        "_content": "One or more of the photo ids passed was not a valid photo id or does not belong to the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.photosets.setPrimaryPhoto.json
+++ b/src/flickr.photosets.setPrimaryPhoto.json
@@ -1,110 +1,22 @@
 {
   "method": {
     "name": "flickr.photosets.setPrimaryPhoto",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Set photoset primary photo"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The id of the photoset to set primary photo to."
+        "optional": "0"
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to set as primary."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photoset not found",
-        "_content": "The photoset id passed was not the id of avalid photoset owned by the calling user."
-      },
-      {
-        "code": "2",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not the id of a valid photo owned by the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.find.json
+++ b/src/flickr.places.find.json
@@ -1,81 +1,18 @@
 {
   "method": {
     "name": "flickr.places.find",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a list of place IDs for a query string.<br /><br />\r\nThe flickr.places.find method is <b>not</b> a geocoder. It will round <q>up</q> to the nearest place type to which place IDs apply. For example, if you pass it a street level address it will return the city that contains the address rather than the street, or building, itself."
-    },
-    "response": {
-      "_content": "<places query=\"Alabama\" total=\"3\">\r\n   <place place_id=\"VrrjuESbApjeFS4.\" woeid=\"2347559\"\r\n               latitude=\"32.614\" longitude=\"-86.680\"\r\n               place_url=\"/United+States/Alabama\"\r\n               place_type=\"region\">Alabama, Alabama, United States</place>\r\n   <place place_id=\"cGHuc0mbApmzEHoP\" woeid=\"2352520\"\r\n               latitude=\"43.096\" longitude=\"-78.389\"\r\n               place_url=\"/United+States/New+York/Alabama\"\r\n               place_type=\"locality\">Alabama, New York, United States</place>\r\n   <place place_id=\"o4yVPEqYBJvFMP8Q\" woeid=\"1579389\"\r\n               latitude=\"-26.866\" longitude=\"26.583\"\r\n               place_url=\"/South+Africa/North+West/Alabama\"\r\n               place_type=\"locality\">Alabama, North West, South Africa</place>\r\n</places>"
-    },
-    "explanation": {
-      "_content": "Each place returned will contain its place ID, corresponding URL (underneath www.flickr.com/places) and place type for disambiguating different locations with the same name."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "query",
-        "optional": "0",
-        "_content": "The query string to use for place ID lookups"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required parameter missing",
-        "_content": "One or more required parameters was not included with the API call."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.findByLatLon.json
+++ b/src/flickr.places.findByLatLon.json
@@ -1,103 +1,26 @@
 {
   "method": {
     "name": "flickr.places.findByLatLon",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a place ID for a latitude, longitude and accuracy triple.<br /><br />\r\nThe flickr.places.findByLatLon method is not meant to be a (reverse) geocoder in the traditional sense. It is designed to allow users to find photos for \"places\" and will round up to the nearest place type to which corresponding place IDs apply.<br /><br />\r\nFor example, if you pass it a street level coordinate it will return the city that contains the point rather than the street, or building, itself.<br /><br />\r\nIt will also truncate latitudes and longitudes to three decimal points.\r\n\r\n"
-    },
-    "response": {
-      "_content": "<places latitude=\"37.76513627957266\" longitude=\"-122.42020770907402\" accuracy=\"16\" total=\"1\">\r\n   <place place_id=\"Y12JWsKbApmnSQpbQg\" woeid=\"23512048\"\r\n      latitude=\"37.765\" longitude=\"-122.424\" \r\n      place_url=\"/United+States/California/San+Francisco/Mission+Dolores\"\r\n      place_type=\"neighbourhood\" place_type_id=\"22\" \r\n      timezone=\"America/Los_Angeles\"\r\n      name=\"Mission Dolores, San Francisco, CA, US, United States\"/>\r\n</places>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "lat",
-        "optional": "0",
-        "_content": "The latitude whose valid range is -90 to 90. Anything more than 4 decimal places will be truncated."
+        "optional": "0"
       },
       {
         "name": "lon",
-        "optional": "0",
-        "_content": "The longitude whose valid range is -180 to 180. Anything more than 4 decimal places will be truncated."
+        "optional": "0"
       },
       {
         "name": "accuracy",
-        "optional": "1",
-        "_content": "Recorded accuracy level of the location information. World level is 1, Country is ~3, Region ~6, City ~11, Street ~16. Current range is 1-16. The default is 16."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required arguments missing",
-        "_content": "One or more required parameters was not included with the API request."
-      },
-      {
-        "code": "2",
-        "message": "Not a valid latitude",
-        "_content": "The latitude argument failed validation."
-      },
-      {
-        "code": "3",
-        "message": "Not a valid longitude",
-        "_content": "The longitude argument failed validation."
-      },
-      {
-        "code": "4",
-        "message": "Not a valid accuracy",
-        "_content": "The accuracy argument failed validation."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.getChildrenWithPhotosPublic.json
+++ b/src/flickr.places.getChildrenWithPhotosPublic.json
@@ -1,93 +1,22 @@
 {
   "method": {
     "name": "flickr.places.getChildrenWithPhotosPublic",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a list of locations with public photos that are parented by a Where on Earth (WOE) or Places ID."
-    },
-    "response": {
-      "_content": "<places total=\"79\">\r\n   <place place_id=\"HznQfdKbB58biy8sdA\" woeid=\"26332794\"\r\n      latitude=\"45.498\" longitude=\"-73.575\"\r\n      place_url=\"/Canada/Quebec/Montreal  /Montreal+Golden+Square+Mile\"\r\n      place_type=\"neighbourhood\" photo_count=\"2717\">\r\n      Montreal Golden Square Mile, Montreal, QC, CA, Canada\r\n   </place>\r\n   <place place_id=\"K1rYWmGbB59rwn7lOA\" woeid=\"26332799\"\r\n      latitude=\"45.502\" longitude=\"-73.578\"\r\n      place_url=\"/Canada/Quebec/Montreal/Downtown+Montr%C3%A9al\"\r\n      place_type=\"neighbourhood\" photo_count=\"2317\">\r\n      Downtown Montréal, Montreal, QC, CA, Canada\r\n  </place>\r\n\r\n   <!-- and so on... -->\r\n\r\n</places>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "place_id",
-        "optional": "1",
-        "_content": "A Flickr Places ID. (While optional, you must pass either a valid Places ID or a WOE ID.)"
+        "optional": "1"
       },
       {
         "name": "woe_id",
-        "optional": "1",
-        "_content": "A Where On Earth (WOE) ID. (While optional, you must pass either a valid Places ID or a WOE ID.)"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required parameter missing",
-        "_content": "One or more required parameter is missing from the API call."
-      },
-      {
-        "code": "2",
-        "message": "Not a valid Places ID",
-        "_content": "An invalid Places (or WOE) ID was passed with the API call."
-      },
-      {
-        "code": "3",
-        "message": "Place not found",
-        "_content": "No place could be found for the Places (or WOE) ID passed to the API call."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.getInfo.json
+++ b/src/flickr.places.getInfo.json
@@ -1,96 +1,22 @@
 {
   "method": {
     "name": "flickr.places.getInfo",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get informations about a place."
-    },
-    "response": {
-      "_content": "<place place_id=\"4hLQygSaBJ92\" woeid=\"3534\"\r\n   latitude=\"45.512\" longitude=\"-73.554\"\r\n   place_url=\"/Canada/Quebec/Montreal\" place_type=\"locality\"\r\n   has_shapedata=\"1\" timezone=\"America/Toronto\">\r\n   <locality place_id=\"4hLQygSaBJ92\" woeid=\"3534\"\r\n      latitude=\"45.512\" longitude=\"-73.554\"\r\n      place_url=\"/Canada/Quebec/Montreal\">Montreal</locality>\r\n   <county place_id=\"cFBi9x6bCJ8D5rba1g\" woeid=\"29375198\"\r\n      latitude=\"45.551\" longitude=\"-73.600\" \r\n      place_url=\"/cFBi9x6bCJ8D5rba1g\">Montréal</county>\r\n   <region place_id=\"CrZUvXebApjI0.72\" woeid=\"2344924\" \r\n      latitude=\"53.890\" longitude=\"-68.429\"\r\n      place_url=\"/Canada/Quebec\">Quebec</region>\r\n   <country place_id=\"EESRy8qbApgaeIkbsA\" woeid=\"23424775\"\r\n      latitude=\"62.358\" longitude=\"-96.582\" \r\n      place_url=\"/Canada\">Canada</country>\r\n   <shapedata created=\"1223513357\" alpha=\"0.012359619140625\"\r\n      count_points=\"34778\" count_edges=\"52\"\r\n      has_donuthole=\"1\" is_donuthole=\"1\">\r\n      <polylines>\r\n         <polyline>\r\n            45.427627563477,-73.589645385742 45.428966522217,-73.587898254395, etc...\r\n         </polyline>\r\n      </polylines>\r\n      <urls>\r\n         <shapefile>\r\n         http://farm4.static.flickr.com/3228/shapefiles/3534_20081111_0a8afe03c5.tar.gz\r\n         </shapefile>\r\n      </urls>\r\n   </shapedata>\r\n</place>"
-    },
-    "explanation": {
-      "_content": "  "
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "place_id",
-        "optional": "1",
-        "_content": "A Flickr Places ID. <span style=\"font-style:italic;\">(While optional, you must pass either a valid Places ID or a WOE ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "woe_id",
-        "optional": "1",
-        "_content": "A Where On Earth (WOE) ID. <span style=\"font-style:italic;\">(While optional, you must pass either a valid Places ID or a WOE ID.)</span>"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required parameter missing",
-        "_content": "One or more required parameter is missing from the API call."
-      },
-      {
-        "code": "2",
-        "message": "Not a valid Places ID",
-        "_content": "An invalid Places (or WOE) ID was passed with the API call."
-      },
-      {
-        "code": "3",
-        "message": "Place not found",
-        "_content": "No place could be found for the Places (or WOE) ID passed to the API call."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.getInfoByUrl.json
+++ b/src/flickr.places.getInfoByUrl.json
@@ -1,83 +1,18 @@
 {
   "method": {
     "name": "flickr.places.getInfoByUrl",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Lookup information about a place, by its flickr.com/places URL."
-    },
-    "response": {
-      "_content": "<place place_id=\"4hLQygSaBJ92\" woeid=\"3534\"\r\n   latitude=\"45.512\" longitude=\"-73.554\"\r\n   place_url=\"/Canada/Quebec/Montreal\" place_type=\"locality\"\r\n   has_shapedata=\"1\">\r\n   <locality place_id=\"4hLQygSaBJ92\" woeid=\"3534\"\r\n      latitude=\"45.512\" longitude=\"-73.554\"\r\n      place_url=\"/Canada/Quebec/Montreal\">Montreal</locality>\r\n   <county place_id=\"cFBi9x6bCJ8D5rba1g\" woeid=\"29375198\"\r\n      latitude=\"45.551\" longitude=\"-73.600\" \r\n      place_url=\"/cFBi9x6bCJ8D5rba1g\">Montréal</county>\r\n   <region place_id=\"CrZUvXebApjI0.72\" woeid=\"2344924\" \r\n      latitude=\"53.890\" longitude=\"-68.429\"\r\n      place_url=\"/Canada/Quebec\">Quebec</region>\r\n   <country place_id=\"EESRy8qbApgaeIkbsA\" woeid=\"23424775\"\r\n      latitude=\"62.358\" longitude=\"-96.582\" \r\n      place_url=\"/Canada\">Canada</country>\r\n   <shapedata created=\"1223513357\" alpha=\"0.012359619140625\"\r\n      count_points=\"34778\" count_edges=\"52\">\r\n      <polylines>\r\n         <polyline>\r\n            45.427627563477,-73.589645385742 45.428966522217,-73.587898254395, etc...\r\n         </polyline>\r\n      </polylines>\r\n   </shapedata>\r\n</place>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "url",
-        "optional": "0",
-        "_content": "A flickr.com/places URL in the form of /country/region/city. For example: /Canada/Quebec/Montreal"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "2",
-        "message": "Place URL required.",
-        "_content": "The flickr.com/places URL was not passed with the API method."
-      },
-      {
-        "code": "3",
-        "message": "Place not found.",
-        "_content": "Unable to find a valid place for the places URL."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.getPlaceTypes.json
+++ b/src/flickr.places.getPlaceTypes.json
@@ -1,68 +1,14 @@
 {
   "method": {
     "name": "flickr.places.getPlaceTypes",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Fetches a list of available place types for Flickr."
-    },
-    "response": {
-      "_content": "<place_types>\r\n   <place_type place_type_id=\"22\">neighbourhood</place_type>\r\n   <place_type place_type_id=\"7\">locality</place_type>\r\n   <place_type place_type_id=\"9\">county</place_type>\r\n   <place_type place_type_id=\"8\">region</place_type>\r\n   <place_type place_type_id=\"12\">country</place_type>\r\n   <place_type place_type_id=\"29\">continent</place_type>\r\n</place_types>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.getShapeHistory.json
+++ b/src/flickr.places.getShapeHistory.json
@@ -1,93 +1,22 @@
 {
   "method": {
     "name": "flickr.places.getShapeHistory",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return an historical list of all the shape data generated for a Places or Where on Earth (WOE) ID."
-    },
-    "response": {
-      "_content": "<shapes total=\"2\" woe_id=\"3534\" place_id=\"4hLQygSaBJ92\" place_type=\"locality\" place_type_id=\"7\">\r\n   <shapedata created=\"1223513357\" alpha=\"0.012359619140625\"\r\n      count_points=\"34778\" count_edges=\"52\" is_donuthole=\"0\">\r\n      <polylines>\r\n         <polyline>\r\n            45.427627563477,-73.589645385742 45.428966522217,-73.587898254395, etc...\r\n         </polyline>\r\n      </polylines>\r\n      <urls>\r\n         <shapefile>\r\n         http://farm4.static.flickr.com/3228/shapefiles/3534_20081111_0a8afe03c5.tar.gz\r\n         </shapefile>\r\n      </urls>\r\n   </shapedata>\r\n   <!-- and so on... -->\r\n</shapes>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "place_id",
-        "optional": "1",
-        "_content": "A Flickr Places ID. <span style=\"font-style:italic;\">(While optional, you must pass either a valid Places ID or a WOE ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "woe_id",
-        "optional": "1",
-        "_content": "A Where On Earth (WOE) ID. <span style=\"font-style:italic;\">(While optional, you must pass either a valid Places ID or a WOE ID.)</span>"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required parameter missing",
-        "_content": "One or more required parameter is missing from the API call."
-      },
-      {
-        "code": "2",
-        "message": "Not a valid Places ID",
-        "_content": "An invalid Places (or WOE) ID was passed with the API call."
-      },
-      {
-        "code": "3",
-        "message": "Place not found",
-        "_content": "No place could be found for the Places (or WOE) ID passed to the API call."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.getTopPlacesList.json
+++ b/src/flickr.places.getTopPlacesList.json
@@ -1,108 +1,30 @@
 {
   "method": {
     "name": "flickr.places.getTopPlacesList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return the top 100 most geotagged places for a day."
-    },
-    "response": {
-      "_content": "<places total=\"100\" date_start=\"1246320000\" date_stop=\"1246406399\">\r\n   <place place_id=\"4KO02SibApitvSBieQ\" woeid=\"23424977\"\r\n       latitude=\"48.890\" longitude=\"-116.982\" \r\n       place_url=\"/United+States\" place_type=\"country\" \r\n       place_type_id=\"12\" photo_count=\"23371\">United States</place>\r\n   <!-- and so on... -->\r\n</places>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "place_type_id",
-        "optional": "0",
-        "_content": "The numeric ID for a specific place type to cluster photos by. <br /><br />\r\n\r\nValid place type IDs are :\r\n\r\n<ul>\r\n<li><strong>22</strong>: neighbourhood</li>\r\n<li><strong>7</strong>: locality</li>\r\n<li><strong>8</strong>: region</li>\r\n<li><strong>12</strong>: country</li>\r\n<li><strong>29</strong>: continent</li>\r\n</ul>"
+        "optional": "0"
       },
       {
         "name": "date",
-        "optional": "1",
-        "_content": "A valid date in YYYY-MM-DD format. The default is yesterday."
+        "optional": "1"
       },
       {
         "name": "woe_id",
-        "optional": "1",
-        "_content": "Limit your query to only those top places belonging to a specific Where on Earth (WOE) identifier."
+        "optional": "1"
       },
       {
         "name": "place_id",
-        "optional": "1",
-        "_content": "Limit your query to only those top places belonging to a specific Flickr Places identifier."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required parameter missing",
-        "_content": "One or more required parameters with missing from your request."
-      },
-      {
-        "code": "2",
-        "message": "Not a valid place type.",
-        "_content": "An unknown or unsupported place type ID was passed with your request."
-      },
-      {
-        "code": "3",
-        "message": "Not a valid date.",
-        "_content": "The date argument passed with your request is invalid."
-      },
-      {
-        "code": "4",
-        "message": "Not a valid Place ID",
-        "_content": "An invalid Places (or WOE) identifier was included with your request."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.placesForBoundingBox.json
+++ b/src/flickr.places.placesForBoundingBox.json
@@ -1,103 +1,26 @@
 {
   "method": {
     "name": "flickr.places.placesForBoundingBox",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return all the locations of a matching place type for a bounding box.<br /><br />\r\n\r\nThe maximum allowable size of a bounding box (the distance between the SW and NE corners) is governed by the place type you are requesting. Allowable sizes are as follows:\r\n\r\n<ul>\r\n<li><strong>neighbourhood</strong>: 3km (1.8mi)</li>\r\n<li><strong>locality</strong>: 7km (4.3mi)</li>\r\n<li><strong>county</strong>: 50km (31mi)</li>\r\n<li><strong>region</strong>: 200km (124mi)</li>\r\n<li><strong>country</strong>: 500km (310mi)</li>\r\n<li><strong>continent</strong>: 1500km (932mi)</li>\r\n</ul>"
-    },
-    "response": {
-      "_content": "<places place_type=\"neighbourhood\" total=\"21\"\r\n   pages=\"1\" page=\"1\" \r\n   bbox=\"-122.42307100000001,37.773779,-122.381071,37.815779\">\r\n   <place place_id=\".aaSwYSbApnq6seyGw\" woeid=\"23512025\"\r\n      latitude=\"37.788\" longitude=\"-122.412\" \r\n      place_url=\"/United+States/California/San+Francisco/Downtown\"\r\n      place_type=\"neighbourhood\">\r\n      Downtown, San Francisco, CA, US, United States\r\n   </place>\r\n   <place place_id=\"3KymK1GbCZ41eBVBxg\" woeid=\"28288707\"\r\n      latitude=\"37.776\" longitude=\"-122.417\" \r\n      place_url=\"/United+States/California/San+Francisco/Civic+Center\"\r\n      place_type=\"neighbourhood\">\r\n      Civic Center, San Francisco, CA, US, United States\r\n   </place>\r\n   <place place_id=\"9xdhxY.bAptvBjHo\" woeid=\"2379855\"   \r\n      latitude=\"37.796\" longitude=\"-122.407\" \r\n      place_url=\"/United+States/California/San+Francisco/Chinatown\"\r\n      place_type=\"neighbourhood\">\r\n      Chinatown, San Francisco, CA, US, United States\r\n   </place>\r\n   <!-- and so on -->\r\n</places>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "bbox",
-        "optional": "0",
-        "_content": "A comma-delimited list of 4 values defining the Bounding Box of the area that will be searched. The 4 values represent the bottom-left corner of the box and the top-right corner, minimum_longitude, minimum_latitude, maximum_longitude, maximum_latitude."
+        "optional": "0"
       },
       {
         "name": "place_type",
-        "optional": "1",
-        "_content": "The name of place type to using as the starting point to search for places in a bounding box. Valid placetypes are:\r\n\r\n<ul>\r\n<li>neighbourhood</li>\r\n<li>locality</li>\r\n<li>county</li>\r\n<li>region</li>\r\n<li>country</li>\r\n<li>continent</li>\r\n</ul>\r\n<br />\r\n<span style=\"font-style:italic;\">The \"place_type\" argument has been deprecated in favor of the \"place_type_id\" argument. It won't go away but it will not be added to new methods. A complete list of place type IDs is available using the <a href=\"http://www.flickr.com/services/api/flickr.places.getPlaceTypes.html\">flickr.places.getPlaceTypes</a> method. (While optional, you must pass either a valid place type or place type ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "place_type_id",
-        "optional": "1",
-        "_content": "The numeric ID for a specific place type to cluster photos by. <br /><br />\r\n\r\nValid place type IDs are :\r\n\r\n<ul>\r\n<li><strong>22</strong>: neighbourhood</li>\r\n<li><strong>7</strong>: locality</li>\r\n<li><strong>8</strong>: region</li>\r\n<li><strong>12</strong>: country</li>\r\n<li><strong>29</strong>: continent</li>\r\n</ul>\r\n<br /><span style=\"font-style:italic;\">(While optional, you must pass either a valid place type or place type ID.)</span>\r\n"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required parameters missing",
-        "_content": "One or more required parameter is missing from the API call."
-      },
-      {
-        "code": "2",
-        "message": "Not a valid bbox",
-        "_content": "The bbox argument was incomplete or incorrectly formatted"
-      },
-      {
-        "code": "3",
-        "message": "Not a valid place type",
-        "_content": "An invalid place type was included with your request."
-      },
-      {
-        "code": "4",
-        "message": "Bounding box exceeds maximum allowable size for place type",
-        "_content": "The bounding box passed along with your request was too large for the request place type."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.placesForContacts.json
+++ b/src/flickr.places.placesForContacts.json
@@ -1,173 +1,54 @@
 {
   "method": {
     "name": "flickr.places.placesForContacts",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Return a list of the top 100 unique places clustered by a given placetype for a user's contacts. "
-    },
-    "response": {
-      "_content": "<places total=\"1\">\r\n   <place place_id=\"kH8dLOubBZRvX_YZ\" woeid=\"2487956\"\r\n               latitude=\"37.779\" longitude=\"-122.420\"\r\n               place_url=\"/United+States/California/San+Francisco\"\r\n               place_type=\"locality\"\r\n               photo_count=\"156\">San Francisco, California</place>\r\n</places>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "place_type",
-        "optional": "1",
-        "_content": "A specific place type to cluster photos by. <br /><br />\r\n\r\nValid place types are :\r\n\r\n<ul>\r\n<li><strong>neighbourhood</strong> (and neighborhood)</li>\r\n<li><strong>locality</strong></li>\r\n<li><strong>region</strong></li>\r\n<li><strong>country</strong></li>\r\n<li><strong>continent</strong></li>\r\n</ul>\r\n<br />\r\n<span style=\"font-style:italic;\">The \"place_type\" argument has been deprecated in favor of the \"place_type_id\" argument. It won't go away but it will not be added to new methods. A complete list of place type IDs is available using the <a href=\"http://www.flickr.com/services/api/flickr.places.getPlaceTypes.html\">flickr.places.getPlaceTypes</a> method. (While optional, you must pass either a valid place type or place type ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "place_type_id",
-        "optional": "1",
-        "_content": "The numeric ID for a specific place type to cluster photos by. <br /><br />\r\n\r\nValid place type IDs are :\r\n\r\n<ul>\r\n<li><strong>22</strong>: neighbourhood</li>\r\n<li><strong>7</strong>: locality</li>\r\n<li><strong>8</strong>: region</li>\r\n<li><strong>12</strong>: country</li>\r\n<li><strong>29</strong>: continent</li>\r\n</ul>\r\n<br /><span style=\"font-style:italic;\">(While optional, you must pass either a valid place type or place type ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "woe_id",
-        "optional": "1",
-        "_content": "A Where on Earth identifier to use to filter photo clusters. For example all the photos clustered by <strong>locality</strong> in the United States (WOE ID <strong>23424977</strong>).<br /><br />\r\n<span style=\"font-style:italic;\">(While optional, you must pass either a valid Places ID or a WOE ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "place_id",
-        "optional": "1",
-        "_content": "A Flickr Places identifier to use to filter photo clusters. For example all the photos clustered by <strong>locality</strong> in the United States (Place ID <strong>4KO02SibApitvSBieQ</strong>).\r\n<br /><br />\r\n<span style=\"font-style:italic;\">(While optional, you must pass either a valid Places ID or a WOE ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "threshold",
-        "optional": "1",
-        "_content": "The minimum number of photos that a place type must have to be included. If the number of photos is lowered then the parent place type for that place will be used.<br /><br />\r\n\r\nFor example if your contacts only have <strong>3</strong> photos taken in the locality of Montreal</strong> (WOE ID 3534) but your threshold is set to <strong>5</strong> then those photos will be \"rolled up\" and included instead with a place record for the region of Quebec (WOE ID 2344924)."
+        "optional": "1"
       },
       {
         "name": "contacts",
-        "optional": "1",
-        "_content": "Search your contacts. Either 'all' or 'ff' for just friends and family. (Default is all)"
+        "optional": "1"
       },
       {
         "name": "min_upload_date",
-        "optional": "1",
-        "_content": "Minimum upload date. Photos with an upload date greater than or equal to this value will be returned. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "max_upload_date",
-        "optional": "1",
-        "_content": "Maximum upload date. Photos with an upload date less than or equal to this value will be returned. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "min_taken_date",
-        "optional": "1",
-        "_content": "Minimum taken date. Photos with an taken date greater than or equal to this value will be returned. The date should be in the form of a mysql datetime."
+        "optional": "1"
       },
       {
         "name": "max_taken_date",
-        "optional": "1",
-        "_content": "Maximum taken date. Photos with an taken date less than or equal to this value will be returned. The date should be in the form of a mysql datetime."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Places for contacts are not available at this time",
-        "_content": "Places for contacts have been disabled or are otherwise not available."
-      },
-      {
-        "code": "2",
-        "message": "Required parameter missing",
-        "_content": "One or more of the required parameters was not included with your request."
-      },
-      {
-        "code": "3",
-        "message": "Not a valid place type.",
-        "_content": "An invalid place type was included with your request."
-      },
-      {
-        "code": "4",
-        "message": "Not a valid Place ID",
-        "_content": "An invalid Places (or WOE) identifier was included with your request."
-      },
-      {
-        "code": "5",
-        "message": "Not a valid threshold",
-        "_content": "The threshold passed was invalid. "
-      },
-      {
-        "code": "6",
-        "message": "Not a valid contacts type",
-        "_content": "Contacts must be either \"all\" or \"ff\" (friends and family)."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.placesForTags.json
+++ b/src/flickr.places.placesForTags.json
@@ -1,128 +1,62 @@
 {
   "method": {
     "name": "flickr.places.placesForTags",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a list of the top 100 unique places clustered by a given placetype for set of tags or machine tags. "
-    },
-    "response": {
-      "_content": "<places total=\"1\">\r\n   <place place_id=\"kH8dLOubBZRvX_YZ\" woeid=\"2487956\"\r\n               latitude=\"37.779\" longitude=\"-122.420\"\r\n               place_url=\"/United+States/California/San+Francisco\"\r\n               place_type=\"locality\"\r\n               photo_count=\"156\">San Francisco, California</place>\r\n</places>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "place_type_id",
-        "optional": "0",
-        "_content": "The numeric ID for a specific place type to cluster photos by. <br /><br />\r\n\r\nValid place type IDs are :\r\n\r\n<ul>\r\n<li><strong>22</strong>: neighbourhood</li>\r\n<li><strong>7</strong>: locality</li>\r\n<li><strong>8</strong>: region</li>\r\n<li><strong>12</strong>: country</li>\r\n<li><strong>29</strong>: continent</li>\r\n</ul>"
+        "optional": "0"
       },
       {
         "name": "woe_id",
-        "optional": "1",
-        "_content": "A Where on Earth identifier to use to filter photo clusters. For example all the photos clustered by <strong>locality</strong> in the United States (WOE ID <strong>23424977</strong>).\r\n<br /><br />\r\n<span style=\"font-style:italic;\">(While optional, you must pass either a valid Places ID or a WOE ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "place_id",
-        "optional": "1",
-        "_content": "A Flickr Places identifier to use to filter photo clusters. For example all the photos clustered by <strong>locality</strong> in the United States (Place ID <strong>4KO02SibApitvSBieQ</strong>).\r\n<br /><br />\r\n<span style=\"font-style:italic;\">(While optional, you must pass either a valid Places ID or a WOE ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "threshold",
-        "optional": "1",
-        "_content": "The minimum number of photos that a place type must have to be included. If the number of photos is lowered then the parent place type for that place will be used.<br /><br />\r\n\r\nFor example if you only have <strong>3</strong> photos taken in the locality of Montreal</strong> (WOE ID 3534) but your threshold is set to <strong>5</strong> then those photos will be \"rolled up\" and included instead with a place record for the region of Quebec (WOE ID 2344924)."
+        "optional": "1"
       },
       {
         "name": "tags",
-        "optional": "1",
-        "_content": "A comma-delimited list of tags. Photos with one or more of the tags listed will be returned.\r\n<br /><br />\r\n<span style=\"font-style:italic;\">(While optional, you must pass either a valid tag or machine_tag</span>"
+        "optional": "1"
       },
       {
         "name": "tag_mode",
-        "optional": "1",
-        "_content": "Either 'any' for an OR combination of tags, or 'all' for an AND combination. Defaults to 'any' if not specified."
+        "optional": "1"
       },
       {
         "name": "machine_tags",
-        "optional": "1",
-        "_content": "Aside from passing in a fully formed machine tag, there is a special syntax for searching on specific properties :\r\n\r\n<ul>\r\n  <li>Find photos using the 'dc' namespace :    <code>\"machine_tags\" => \"dc:\"</code></li>\r\n\r\n  <li> Find photos with a title in the 'dc' namespace : <code>\"machine_tags\" => \"dc:title=\"</code></li>\r\n\r\n  <li>Find photos titled \"mr. camera\" in the 'dc' namespace : <code>\"machine_tags\" => \"dc:title=\\\"mr. camera\\\"</code></li>\r\n\r\n  <li>Find photos whose value is \"mr. camera\" : <code>\"machine_tags\" => \"*:*=\\\"mr. camera\\\"\"</code></li>\r\n\r\n  <li>Find photos that have a title, in any namespace : <code>\"machine_tags\" => \"*:title=\"</code></li>\r\n\r\n  <li>Find photos that have a title, in any namespace, whose value is \"mr. camera\" : <code>\"machine_tags\" => \"*:title=\\\"mr. camera\\\"\"</code></li>\r\n\r\n  <li>Find photos, in the 'dc' namespace whose value is \"mr. camera\" : <code>\"machine_tags\" => \"dc:*=\\\"mr. camera\\\"\"</code></li>\r\n\r\n </ul>\r\n\r\nMultiple machine tags may be queried by passing a comma-separated list. The number of machine tags you can pass in a single query depends on the tag mode (AND or OR) that you are querying with. \"AND\" queries are limited to (16) machine tags. \"OR\" queries are limited\r\nto (8).\r\n<br /><br />\r\n<span style=\"font-style:italic;\">(While optional, you must pass either a valid tag or machine_tag)</span>"
+        "optional": "1"
       },
       {
         "name": "machine_tag_mode",
-        "optional": "1",
-        "_content": "Either 'any' for an OR combination of tags, or 'all' for an AND combination. Defaults to 'any' if not specified."
+        "optional": "1"
       },
       {
         "name": "min_upload_date",
-        "optional": "1",
-        "_content": "Minimum upload date. Photos with an upload date greater than or equal to this value will be returned. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "max_upload_date",
-        "optional": "1",
-        "_content": "Maximum upload date. Photos with an upload date less than or equal to this value will be returned. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "min_taken_date",
-        "optional": "1",
-        "_content": "Minimum taken date. Photos with an taken date greater than or equal to this value will be returned. The date should be in the form of a mysql datetime."
+        "optional": "1"
       },
       {
         "name": "max_taken_date",
-        "optional": "1",
-        "_content": "Maximum taken date. Photos with an taken date less than or equal to this value will be returned. The date should be in the form of a mysql datetime."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.placesForUser.json
+++ b/src/flickr.places.placesForUser.json
@@ -1,163 +1,50 @@
 {
   "method": {
     "name": "flickr.places.placesForUser",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Return a list of the top 100 unique places clustered by a given placetype for a user. "
-    },
-    "response": {
-      "_content": "<places total=\"1\">\r\n   <place place_id=\"kH8dLOubBZRvX_YZ\" woeid=\"2487956\"\r\n               latitude=\"37.779\" longitude=\"-122.420\"\r\n               place_url=\"/United+States/California/San+Francisco\"\r\n               place_type=\"locality\"\r\n               photo_count=\"156\">San Francisco, California</place>\r\n</places>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "place_type_id",
-        "optional": "1",
-        "_content": "The numeric ID for a specific place type to cluster photos by. <br /><br />\r\n\r\nValid place type IDs are :\r\n\r\n<ul>\r\n<li><strong>22</strong>: neighbourhood</li>\r\n<li><strong>7</strong>: locality</li>\r\n<li><strong>8</strong>: region</li>\r\n<li><strong>12</strong>: country</li>\r\n<li><strong>29</strong>: continent</li>\r\n</ul>\r\n<br />\r\n<span style=\"font-style:italic;\">The \"place_type\" argument has been deprecated in favor of the \"place_type_id\" argument. It won't go away but it will not be added to new methods. A complete list of place type IDs is available using the <a href=\"http://www.flickr.com/services/api/flickr.places.getPlaceTypes.html\">flickr.places.getPlaceTypes</a> method. (While optional, you must pass either a valid place type or place type ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "place_type",
-        "optional": "1",
-        "_content": "A specific place type to cluster photos by. <br /><br />\r\n\r\nValid place types are :\r\n\r\n<ul>\r\n<li><strong>neighbourhood</strong> (and neighborhood)</li>\r\n<li><strong>locality</strong></li>\r\n<li><strong>region</strong></li>\r\n<li><strong>country</strong></li>\r\n<li><strong>continent</strong></li>\r\n</ul>\r\n<br /><span style=\"font-style:italic;\">(While optional, you must pass either a valid place type or place type ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "woe_id",
-        "optional": "1",
-        "_content": "A Where on Earth identifier to use to filter photo clusters. For example all the photos clustered by <strong>locality</strong> in the United States (WOE ID <strong>23424977</strong>).<br /><br />\r\n<span style=\"font-style:italic;\">(While optional, you must pass either a valid Places ID or a WOE ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "place_id",
-        "optional": "1",
-        "_content": "A Flickr Places identifier to use to filter photo clusters. For example all the photos clustered by <strong>locality</strong> in the United States (Place ID <strong>4KO02SibApitvSBieQ</strong>).<br /><br />\r\n<span style=\"font-style:italic;\">(While optional, you must pass either a valid Places ID or a WOE ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "threshold",
-        "optional": "1",
-        "_content": "The minimum number of photos that a place type must have to be included. If the number of photos is lowered then the parent place type for that place will be used.<br /><br />\r\n\r\nFor example if you only have <strong>3</strong> photos taken in the locality of Montreal</strong> (WOE ID 3534) but your threshold is set to <strong>5</strong> then those photos will be \"rolled up\" and included instead with a place record for the region of Quebec (WOE ID 2344924)."
+        "optional": "1"
       },
       {
         "name": "min_upload_date",
-        "optional": "1",
-        "_content": "Minimum upload date. Photos with an upload date greater than or equal to this value will be returned. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "max_upload_date",
-        "optional": "1",
-        "_content": "Maximum upload date. Photos with an upload date less than or equal to this value will be returned. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "min_taken_date",
-        "optional": "1",
-        "_content": "Minimum taken date. Photos with an taken date greater than or equal to this value will be returned. The date should be in the form of a mysql datetime."
+        "optional": "1"
       },
       {
         "name": "max_taken_date",
-        "optional": "1",
-        "_content": "Maximum taken date. Photos with an taken date less than or equal to this value will be returned. The date should be in the form of a mysql datetime."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Places for user are not available at this time",
-        "_content": "Places for user have been disabled or are otherwise not available."
-      },
-      {
-        "code": "2",
-        "message": "Required parameter missing",
-        "_content": "One or more of the required parameters was not included with your request."
-      },
-      {
-        "code": "3",
-        "message": "Not a valid place type",
-        "_content": "An invalid place type was included with your request."
-      },
-      {
-        "code": "4",
-        "message": "Not a valid Place ID",
-        "_content": "An invalid Places (or WOE) identifier was included with your request."
-      },
-      {
-        "code": "5",
-        "message": "Not a valid threshold",
-        "_content": "The threshold passed was invalid. "
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.resolvePlaceId.json
+++ b/src/flickr.places.resolvePlaceId.json
@@ -1,83 +1,18 @@
 {
   "method": {
     "name": "flickr.places.resolvePlaceId",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Find Flickr Places information by Place ID.<br /><br />\r\nThis method has been deprecated. It won't be removed but you should use <a href=\"/services/api/flickr.places.getInfo.html\">flickr.places.getInfo</a> instead."
-    },
-    "response": {
-      "_content": "<location place_id=\"kH8dLOubBZRvX_YZ\" woeid=\"2487956\" \r\n                latitude=\"37.779\" longitude=\"-122.420\"\r\n                place_url=\"/United+States/California/San+Francisco\"\r\n                place_type=\"locality\">\r\n   <locality place_id=\"kH8dLOubBZRvX_YZ\" woeid=\"2487956\"\r\n                 latitude=\"37.779\" longitude=\"-122.420\" \r\n                 place_url=\"/United+States/California/San+Francisco\">San Francisco</locality>\r\n   <county place_id=\"hCca8XSYA5nn0X1Sfw\" woeid=\"12587707\"\r\n                 latitude=\"37.759\" longitude=\"-122.435\" \r\n                 place_url=\"/hCca8XSYA5nn0X1Sfw\">San Francisco</county>\r\n   <region place_id=\"SVrAMtCbAphCLAtP\" woeid=\"2347563\" \r\n                latitude=\"37.271\" longitude=\"-119.270\" \r\n                place_url=\"/United+States/California\">California</region>\r\n   <country place_id=\"4KO02SibApitvSBieQ\" woeid=\"23424977\"\r\n                  latitude=\"48.890\" longitude=\"-116.982\" \r\n                  place_url=\"/United+States\">United States</country>\r\n</location>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "place_id",
-        "optional": "0",
-        "_content": "A Flickr Places ID"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "2",
-        "message": "Place ID required.",
-        "_content": ""
-      },
-      {
-        "code": "3",
-        "message": "Place not found.",
-        "_content": ""
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.resolvePlaceURL.json
+++ b/src/flickr.places.resolvePlaceURL.json
@@ -1,83 +1,18 @@
 {
   "method": {
     "name": "flickr.places.resolvePlaceURL",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Find Flickr Places information by Place URL.<br /><br />\r\nThis method has been deprecated. It won't be removed but you should use <a href=\"/services/api/flickr.places.getInfoByUrl.html\">flickr.places.getInfoByUrl</a> instead.\r\n"
-    },
-    "response": {
-      "_content": "<location place_id=\"kH8dLOubBZRvX_YZ\" woeid=\"2487956\" \r\n                latitude=\"37.779\" longitude=\"-122.420\"\r\n                place_url=\"/United+States/California/San+Francisco\"\r\n                place_type=\"locality\">\r\n   <locality place_id=\"kH8dLOubBZRvX_YZ\" woeid=\"2487956\"\r\n                 latitude=\"37.779\" longitude=\"-122.420\" \r\n                 place_url=\"/United+States/California/San+Francisco\">San Francisco</locality>\r\n   <county place_id=\"hCca8XSYA5nn0X1Sfw\" woeid=\"12587707\"\r\n                 latitude=\"37.759\" longitude=\"-122.435\" \r\n                 place_url=\"/hCca8XSYA5nn0X1Sfw\">San Francisco</county>\r\n   <region place_id=\"SVrAMtCbAphCLAtP\" woeid=\"2347563\" \r\n                latitude=\"37.271\" longitude=\"-119.270\" \r\n                place_url=\"/United+States/California\">California</region>\r\n   <country place_id=\"4KO02SibApitvSBieQ\" woeid=\"23424977\"\r\n                  latitude=\"48.890\" longitude=\"-116.982\" \r\n                  place_url=\"/United+States\">United States</country>\r\n</location>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "url",
-        "optional": "0",
-        "_content": "A Flickr Places URL.  \r\n<br /><br />\r\nFlickr Place URLs are of the form /country/region/city"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "2",
-        "message": "Place URL required.",
-        "_content": ""
-      },
-      {
-        "code": "3",
-        "message": "Place not found.",
-        "_content": ""
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.places.tagsForPlace.json
+++ b/src/flickr.places.tagsForPlace.json
@@ -1,113 +1,38 @@
 {
   "method": {
     "name": "flickr.places.tagsForPlace",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Return a list of the top 100 unique tags for a Flickr Places or Where on Earth (WOE) ID"
-    },
-    "response": {
-      "_content": "<tags total=\"100\">\r\n   <tag count=\"31775\">montreal</tag>\r\n   <tag count=\"20585\">canada</tag>\r\n   <tag count=\"12319\">montréal</tag>\r\n   <tag count=\"12154\">quebec</tag>\r\n   <tag count=\"6471\">québec</tag>\r\n   <tag count=\"2173\">sylvainmichaud</tag>\r\n   <tag count=\"2091\">nikon</tag>\r\n   <tag count=\"1541\">lucbus</tag>\r\n   <tag count=\"1539\">music</tag>\r\n   <tag count=\"1479\">urban</tag>\r\n   <tag count=\"1425\">lucbussieres</tag>\r\n   <tag count=\"1419\">festival</tag>\r\n   <!-- and so on -->\r\n</tags>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "woe_id",
-        "optional": "1",
-        "_content": "A Where on Earth identifier to use to filter photo clusters.<br /><br />\r\n<span style=\"font-style:italic;\">(While optional, you must pass either a valid Places ID or a WOE ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "place_id",
-        "optional": "1",
-        "_content": "A Flickr Places identifier to use to filter photo clusters.<br /><br />\r\n<span style=\"font-style:italic;\">(While optional, you must pass either a valid Places ID or a WOE ID.)</span>"
+        "optional": "1"
       },
       {
         "name": "min_upload_date",
-        "optional": "1",
-        "_content": "Minimum upload date. Photos with an upload date greater than or equal to this value will be returned. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "max_upload_date",
-        "optional": "1",
-        "_content": "Maximum upload date. Photos with an upload date less than or equal to this value will be returned. The date should be in the form of a unix timestamp."
+        "optional": "1"
       },
       {
         "name": "min_taken_date",
-        "optional": "1",
-        "_content": "Minimum taken date. Photos with an taken date greater than or equal to this value will be returned. The date should be in the form of a mysql datetime."
+        "optional": "1"
       },
       {
         "name": "max_taken_date",
-        "optional": "1",
-        "_content": "Maximum taken date. Photos with an taken date less than or equal to this value will be returned. The date should be in the form of a mysql datetime."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required parameter missing",
-        "_content": "One or more parameters was not included with the API request"
-      },
-      {
-        "code": "2",
-        "message": "Not a valid Places ID",
-        "_content": "An invalid Places (or WOE) identifier was included with your request."
-      },
-      {
-        "code": "3",
-        "message": "Place not found",
-        "_content": "An invalid Places (or WOE) identifier was included with your request."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.prefs.getContentType.json
+++ b/src/flickr.prefs.getContentType.json
@@ -1,93 +1,14 @@
 {
   "method": {
     "name": "flickr.prefs.getContentType",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns the default content type preference for the user."
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n<person nsid=\"12037949754@N01\" content_type=\"1\" />\r\n</rsp>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.prefs.getGeoPerms.json
+++ b/src/flickr.prefs.getGeoPerms.json
@@ -1,93 +1,14 @@
 {
   "method": {
     "name": "flickr.prefs.getGeoPerms",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns the default privacy level for geographic information attached to the user's photos and whether or not the user has chosen to use geo-related EXIF information to automatically geotag their photos.\r\n\r\nPossible values, for viewing geotagged photos, are:\r\n\r\n<ul>\r\n<li>0 : <i>No default set</i></li>\r\n<li>1 : Public</li>\r\n<li>2 : Contacts only</li>\r\n<li>3 : Friends and Family only</li>\r\n<li>4 : Friends only</li>\r\n<li>5 : Family only</li>\r\n<li>6 : Private</li>\r\n</ul>\r\n\r\nUsers can edit this preference at <a href=\"http://www.flickr.com/account/geo/privacy/\">http://www.flickr.com/account/geo/privacy/</a>.\r\n<br /><br />\r\nPossible values for whether or not geo-related EXIF information will be used to geotag a photo are:\r\n\r\n<ul>\r\n<li>0: Geo-related EXIF information will be ignored</li>\r\n<li>1: Geo-related EXIF information will be used to try and geotag photos on upload</li>\r\n</ul>\r\n\r\nUsers can edit this preference at <a href=\"http://www.flickr.com/account/geo/exif/?from=privacy\">http://www.flickr.com/account/geo/exif/?from=privacy</a>"
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n<person nsid=\"12037949754@N01\" geoperms=\"1\" importgeoexif=\"0\" />\r\n</rsp>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.prefs.getHidden.json
+++ b/src/flickr.prefs.getHidden.json
@@ -1,93 +1,14 @@
 {
   "method": {
     "name": "flickr.prefs.getHidden",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns the default hidden preference for the user."
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n<person nsid=\"12037949754@N01\" hidden=\"1\" />\r\n</rsp>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.prefs.getPrivacy.json
+++ b/src/flickr.prefs.getPrivacy.json
@@ -1,93 +1,14 @@
 {
   "method": {
     "name": "flickr.prefs.getPrivacy",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns the default privacy level preference for the user.\r\n\r\nPossible values are:\r\n<ul>\r\n<li>1 : Public</li>\r\n<li>2 : Friends only</li>\r\n<li>3 : Family only</li>\r\n<li>4 : Friends and Family</li>\r\n<li>5 : Private</li>\r\n</ul>"
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n<person nsid=\"12037949754@N01\" privacy=\"1\" />\r\n</rsp>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.prefs.getSafetyLevel.json
+++ b/src/flickr.prefs.getSafetyLevel.json
@@ -1,93 +1,14 @@
 {
   "method": {
     "name": "flickr.prefs.getSafetyLevel",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns the default safety level preference for the user."
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n<person nsid=\"12037949754@N01\" safety_level=\"1\" />\r\n</rsp>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.profile.getProfile.json
+++ b/src/flickr.profile.getProfile.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.profile.getProfile",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns specified user's profile info, respecting profile privacy settings"
-    },
-    "response": {
-      "_content": "<profile\r\n    id=\"85826296@N00\"\r\n    nsid=\"85826296@N00\"\r\n    showcase_set=\"12357488850955295\"\r\n    first_name=\"Hal\"\r\n    last_name=\"Cenderson\"\r\n    description=\"This is me, this is my story\"\r\n    website=\"http://example.org\"\r\n    occupation=\"Super Conductor\"\r\n    hometown=\"Melbourne, Australia\"\r\n    city=\"San Francisco\"\r\n    country=\"USA\"\r\n/>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the user to fetch profile information for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid NSID provided",
-        "_content": "An invalid NSID was passed"
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.push.getSubscriptions.json
+++ b/src/flickr.push.getSubscriptions.json
@@ -1,98 +1,14 @@
 {
   "method": {
     "name": "flickr.push.getSubscriptions",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns a list of the subscriptions for the logged-in user.\r\n<br><br>\r\n<i>(this method is experimental and may change)</i>"
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n  <subscriptions>\r\n    <subscription topic=\"contacts_photos\" callback=\"http://example.com/contacts_photos_endpoint?user=12345\" pending=\"0\" date_create=\"1309293755\" lease_seconds=\"0\" expiry=\"1309380155\" verify_attempts=\"0\" />\r\n    <subscription topic=\"contacts_faves\" callback=\"http://example.com/contacts_faves_endpoint?user=12345\" pending=\"0\" date_create=\"1309293785\" lease_seconds=\"0\" expiry=\"1309380185\" verify_attempts=\"0\" />\r\n  </subscriptions>\r\n</rsp>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "5",
-        "message": "Service currently available only to pro accounts",
-        "_content": "PuSH subscriptions are currently restricted to Pro account holders."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.push.getTopics.json
+++ b/src/flickr.push.getTopics.json
@@ -1,68 +1,14 @@
 {
   "method": {
     "name": "flickr.push.getTopics",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "All the different flavours of anteater.\r\n<br><br>\r\n<i>(this method is experimental and may change)</i>"
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n  <topics>\r\n    <topic name=\"contacts_photos\" />\r\n    <topic name=\"contacts_faves\" />\r\n  </topics>\r\n</rsp>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.push.subscribe.json
+++ b/src/flickr.push.subscribe.json
@@ -1,190 +1,70 @@
 {
   "method": {
     "name": "flickr.push.subscribe",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "In ur pandas, tickling ur unicorn\r\n<br><br>\r\n<i>(this method is experimental and may change)</i>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "topic",
-        "optional": "0",
-        "_content": "The type of subscription. See <a href=\"http://www.flickr.com/services/api/flickr.push.getTopics.htm\">flickr.push.getTopics</a>."
+        "optional": "0"
       },
       {
         "name": "callback",
-        "optional": "0",
-        "_content": "The url for the subscription endpoint. Limited to 255 bytes, and must be unique for this user, i.e. no two subscriptions for a given user may use the same callback url."
+        "optional": "0"
       },
       {
         "name": "verify",
-        "optional": "0",
-        "_content": "The verification mode, either <code>sync</code> or <code>async</code>. See the <a href=\"http://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.3.html#subscribingl\">Google PubSubHubbub spec</a> for details."
+        "optional": "0"
       },
       {
         "name": "verify_token",
-        "optional": "1",
-        "_content": "The verification token to be echoed back to the subscriber during the verification callback, as per the <a href=\"http://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.3.html#subscribing\">Google PubSubHubbub spec</a>. Limited to 200 bytes."
+        "optional": "1"
       },
       {
         "name": "lease_seconds",
-        "optional": "1",
-        "_content": "Number of seconds for which the subscription will be valid. Legal values are 60 to 86400 (1 minute to 1 day). If not present, the subscription will be auto-renewing."
+        "optional": "1"
       },
       {
         "name": "woe_ids",
-        "optional": "1",
-        "_content": "A 32-bit integer for a <a href=\"http://developer.yahoo.com/geo/geoplanet/\">Where on Earth ID</a>. Only valid if <code>topic</code> is <code>geo</code>.\r\n<br/><br/>\r\nThe order of precedence for geo subscriptions is : woe ids, place ids, radial i.e. the <code>lat, lon</code> parameters will be ignored if <code>place_ids</code> is present, which will be ignored if <code>woe_ids</code> is present."
+        "optional": "1"
       },
       {
         "name": "place_ids",
-        "optional": "1",
-        "_content": "A comma-separated list of Flickr place IDs. Only valid if <code>topic</code> is <code>geo</code>.\r\n<br/><br/>\r\nThe order of precedence for geo subscriptions is : woe ids, place ids, radial i.e. the <code>lat, lon</code> parameters will be ignored if <code>place_ids</code> is present, which will be ignored if <code>woe_ids</code> is present."
+        "optional": "1"
       },
       {
         "name": "lat",
-        "optional": "1",
-        "_content": "A latitude value, in decimal format. Only valid if <code>topic</code> is <code>geo</code>. Defines the latitude for a radial query centered around (lat, lon).\r\n<br/><br/>\r\nThe order of precedence for geo subscriptions is : woe ids, place ids, radial i.e. the <code>lat, lon</code> parameters will be ignored if <code>place_ids</code> is present, which will be ignored if <code>woe_ids</code> is present."
+        "optional": "1"
       },
       {
         "name": "lon",
-        "optional": "1",
-        "_content": "A longitude value, in decimal format. Only valid if <code>topic</code> is <code>geo</code>. Defines the longitude for a radial query centered around (lat, lon).\r\n<br/><br/>\r\nThe order of precedence for geo subscriptions is : woe ids, place ids, radial i.e. the <code>lat, lon</code> parameters will be ignored if <code>place_ids</code> is present, which will be ignored if <code>woe_ids</code> is present."
+        "optional": "1"
       },
       {
         "name": "radius",
-        "optional": "1",
-        "_content": "A radius value, in the units defined by radius_units. Only valid if <code>topic</code> is <code>geo</code>. Defines the radius of a circle for a radial query centered around (lat, lon). Default is 5 km.\r\n<br/><br/>\r\nThe order of precedence for geo subscriptions is : woe ids, place ids, radial i.e. the <code>lat, lon</code> parameters will be ignored if <code>place_ids</code> is present, which will be ignored if <code>woe_ids</code> is present."
+        "optional": "1"
       },
       {
         "name": "radius_units",
-        "optional": "1",
-        "_content": "Defines the units for the radius parameter. Only valid if <code>topic</code> is <code>geo</code>. Options are <code>mi</code> and <code>km</code>. Default is <code>km</code>.\r\n<br/><br/>\r\nThe order of precedence for geo subscriptions is : woe ids, place ids, radial i.e. the <code>lat, lon</code> parameters will be ignored if <code>place_ids</code> is present, which will be ignored if <code>woe_ids</code> is present."
+        "optional": "1"
       },
       {
         "name": "accuracy",
-        "optional": "1",
-        "_content": "Defines the minimum accuracy required for photos to be included in a subscription. Only valid if <code>topic</code> is <code>geo</code> Legal values are 1-16, default is 1 (i.e. any accuracy level).\r\n<ul>\r\n<li>World level is 1</li>\r\n<li>Country is ~3</li>\r\n<li>Region is ~6</li>\r\n<li>City is ~11</li>\r\n<li>Street is ~16</li>\r\n</ul>"
+        "optional": "1"
       },
       {
         "name": "nsids",
-        "optional": "1",
-        "_content": "A comma-separated list of nsids representing Flickr Commons institutions (see <a href=\"http://www.flickr.com/services/api/flickr.commons.getInstitutions.html\">flickr.commons.getInstitutions</a>). Only valid if <code>topic</code> is <code>commons</code>. If not present this argument defaults to all Flickr Commons institutions."
+        "optional": "1"
       },
       {
         "name": "tags",
-        "optional": "1",
-        "_content": "A comma-separated list of strings to be used for tag subscriptions. Photos with one or more of the tags listed will be included in the subscription. Only valid if the <code>topic</code> is <code>tags</code>."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required parameter missing",
-        "_content": "One of the required arguments for the method was not provided."
-      },
-      {
-        "code": "2",
-        "message": "Invalid parameter value",
-        "_content": "One of the arguments was specified with an illegal value."
-      },
-      {
-        "code": "3",
-        "message": "Callback URL already in use for a different subscription",
-        "_content": "A different subscription already exists that uses the same callback URL."
-      },
-      {
-        "code": "4",
-        "message": "Callback failed or invalid response",
-        "_content": "The verification callback failed, or failed to return the expected response to confirm the subscription."
-      },
-      {
-        "code": "5",
-        "message": "Service currently available only to pro accounts",
-        "_content": "PuSH subscriptions are currently restricted to Pro account holders."
-      },
-      {
-        "code": "6",
-        "message": "Subscription awaiting verification callback response - try again later",
-        "_content": "A subscription with those details exists already, but it is in a pending (non-verified) state. Please wait a bit for the verification callback to complete before attempting to update the subscription."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.push.unsubscribe.json
+++ b/src/flickr.push.unsubscribe.json
@@ -1,135 +1,30 @@
 {
   "method": {
     "name": "flickr.push.unsubscribe",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Why would you want to do this?\r\n<br><br>\r\n<i>(this method is experimental and may change)</i>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "topic",
-        "optional": "0",
-        "_content": "The type of subscription. See <a href=\"http://www.flickr.com/services/api/flickr.push.getTopics.htm\">flickr.push.getTopics</a>."
+        "optional": "0"
       },
       {
         "name": "callback",
-        "optional": "0",
-        "_content": "The url for the subscription endpoint (must be the same url as was used when creating the subscription)."
+        "optional": "0"
       },
       {
         "name": "verify",
-        "optional": "0",
-        "_content": "The verification mode, either 'sync' or 'async'. See the <a href=\"http://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.3.html#subscribingl\">Google PubSubHubbub spec</a> for details."
+        "optional": "0"
       },
       {
         "name": "verify_token",
-        "optional": "1",
-        "_content": "The verification token to be echoed back to the subscriber during the verification callback, as per the <a href=\"http://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.3.html#subscribing\">Google PubSubHubbub spec</a>. Limited to 200 bytes."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Required parameter missing",
-        "_content": "One of the required arguments for the method was not provided."
-      },
-      {
-        "code": "2",
-        "message": "Invalid parameter value",
-        "_content": "One of the arguments was specified with an illegal value."
-      },
-      {
-        "code": "4",
-        "message": "Callback failed or invalid response",
-        "_content": "The verification callback failed, or failed to return the expected response to confirm the un-subscription."
-      },
-      {
-        "code": "6",
-        "message": "Subscription awaiting verification callback response - try again later",
-        "_content": "A subscription with those details exists already, but it is in a pending (non-verified) state. Please wait a bit for the verification callback to complete before attempting to update the subscription."
-      },
-      {
-        "code": "7",
-        "message": "Subscription not found",
-        "_content": "No subscription matching the provided details for this user could be found."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.reflection.getMethodInfo.json
+++ b/src/flickr.reflection.getMethodInfo.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.reflection.getMethodInfo",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns information for a given flickr API method."
-    },
-    "response": {
-      "_content": "<method name=\"flickr.fakeMethod\" needslogin=\"1\">\r\n\t<description>A fake method</description> \r\n\t<response>xml-response-example</response> \r\n\t<explanation>explanation of example response</explanation> \r\n\t<arguments>\r\n\t\t<argument name=\"api_key\" optional=\"0\">\r\n\t\t\tYou API application key.</argument> \r\n\t\t<argument name=\"color\" optional=\"1\">\r\n\t\t\tYour favorite color.</argument> \r\n\t</arguments>\r\n\t<errors>\r\n\t\t<error code=\"1\" message=\"Photo not found\">\r\n\t\t\tFull explanation...</error> \r\n\t\t<error code=\"100\" message=\"Invalid API Key\">\r\n\t\t\tFull explanation...</error> \r\n\t</errors>\r\n</method>\r\n"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "method_name",
-        "optional": "0",
-        "_content": "The name of the method to fetch information for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Method not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.reflection.getMethods.json
+++ b/src/flickr.reflection.getMethods.json
@@ -1,68 +1,14 @@
 {
   "method": {
     "name": "flickr.reflection.getMethods",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns a list of available flickr API methods."
-    },
-    "response": {
-      "_content": "<methods>\r\n\t<method>flickr.blogs.getList</method>\r\n\t<method>flickr.blogs.postPhoto</method>\r\n\t<method>flickr.contacts.getList</method>\r\n\t<method>flickr.contacts.getPublicList</method>\r\n</methods>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getCSVFiles.json
+++ b/src/flickr.stats.getCSVFiles.json
@@ -1,93 +1,14 @@
 {
   "method": {
     "name": "flickr.stats.getCSVFiles",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns a list of URLs for text files containing <i>all</i> your stats data (from November 26th 2007 onwards) for the currently auth'd user.\r\n\r\n<b>Please note, these files will only be available until June 1, 2010 Noon PDT.</b> \r\nFor more information <a href=\"/help/stats/#1369409\">please check out this FAQ</a>, or just <a href=\"/photos/me/stats/downloads/\">go download your files</a>."
-    },
-    "response": {
-      "_content": "<stats> \r\n   <csvfiles> \r\n      <csv href=\"http://farm4.static.flickr.com/3496/stats/72157623902771865_faaa.csv\" type=\"daily\" date=\"2010-04-01\" /> \r\n      <csv href=\"http://farm4.static.flickr.com/3376/stats/72157624027152370_fbbb.csv\" type=\"monthly\" date=\"2010-04-01\" /> \r\n      <csv href=\"http://farm5.static.flickr.com/4006/stats/72157623627769689_fccc.csv\" type=\"daily\" date=\"2010-03-01\" /> \r\n      ....\r\n    </csvfiles> \r\n</stats>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getCollectionDomains.json
+++ b/src/flickr.stats.getCollectionDomains.json
@@ -1,136 +1,30 @@
 {
   "method": {
     "name": "flickr.stats.getCollectionDomains",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get a list of referring domains for a collection"
-    },
-    "response": {
-      "_content": "<domains page=\"1\" perpage=\"25\" pages=\"1\" total=\"3\">\r\n\t<domain name=\"images.search.yahoo.com\" views=\"127\" />\r\n\t<domain name=\"flickr.com\" views=\"122\" />\r\n\t<domain name=\"images.google.com\" views=\"70\" />\r\n</domains>\r\n"
-    },
-    "explanation": {
-      "_content": "<p>There is one <code>&lt;domain&gt;</code> element for each referring domain, with attributes for the domain name and the number of views.</p>\r\n\r\n<p>For details on the referrers coming from each domain listed you can call <a href=\"/services/api/flickr.stats.getCollectionReferrers.html\">flickr.stats.getCollectionReferrers</a></p>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "0",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format.\r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day."
+        "optional": "0"
       },
       {
         "name": "collection_id",
-        "optional": "1",
-        "_content": "The id of the collection to get stats for. If not provided, stats for all collections will be returned."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of domains to return per page. If this argument is omitted, it defaults to 25. The maximum allowed value is 100."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": "4",
-        "message": "Collection not found",
-        "_content": "The collection id was either invalid or was for a collection not owned by the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getCollectionReferrers.json
+++ b/src/flickr.stats.getCollectionReferrers.json
@@ -1,146 +1,34 @@
 {
   "method": {
     "name": "flickr.stats.getCollectionReferrers",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get a list of referrers from a given domain to a collection"
-    },
-    "response": {
-      "_content": "<domain page=\"1\" perpage=\"25\" pages=\"1\" total=\"3\" name=\"flickr.com\">\r\n\t<referrer url=\"http://flickr.com/\" views=\"11\"/>\r\n\t<referrer url=\"http://flickr.com/photos/friends/\" views=\"8\"/>\r\n\t<referrer url=\"http://flickr.com/search/?q=stats+api\" views=\"2\" searchterm=\"stats api\"/>\r\n</domain>\r\n"
-    },
-    "explanation": {
-      "_content": "<p>There is one <code>&lt;referrer&gt;</code> element for each referring page, with attributes for the url and the number of views.</p>\r\n\r\n<p>Where the referring page is a search engine and we have identified the search term it will be given in the searchterm attribute.</p>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "0",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format. \r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day."
+        "optional": "0"
       },
       {
         "name": "domain",
-        "optional": "0",
-        "_content": "The domain to return referrers for. This should be a hostname (eg: \"flickr.com\") with no protocol or pathname."
+        "optional": "0"
       },
       {
         "name": "collection_id",
-        "optional": "1",
-        "_content": "The id of the collection to get stats for. If not provided, stats for all collections will be returned."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of referrers to return per page. If this argument is omitted, it defaults to 25. The maximum allowed value is 100."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": "4",
-        "message": "Collection not found",
-        "_content": "The collection id was either invalid or was for a collection not owned by the calling user."
-      },
-      {
-        "code": "5",
-        "message": "Invalid domain",
-        "_content": "The domain provided is not in the expected format."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getCollectionStats.json
+++ b/src/flickr.stats.getCollectionStats.json
@@ -1,123 +1,22 @@
 {
   "method": {
     "name": "flickr.stats.getCollectionStats",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get the number of views on a collection for a given date."
-    },
-    "response": {
-      "_content": "<stats views=\"24\" />"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "0",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format.\r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day."
+        "optional": "0"
       },
       {
         "name": "collection_id",
-        "optional": "0",
-        "_content": "The id of the collection to get stats for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": "4",
-        "message": "Collection not found",
-        "_content": "The collection id was either invalid or was for a collection not owned by the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getPhotoDomains.json
+++ b/src/flickr.stats.getPhotoDomains.json
@@ -1,136 +1,30 @@
 {
   "method": {
     "name": "flickr.stats.getPhotoDomains",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get a list of referring domains for a photo"
-    },
-    "response": {
-      "_content": "<domains page=\"1\" perpage=\"25\" pages=\"1\" total=\"3\">\r\n\t<domain name=\"images.search.yahoo.com\" views=\"127\" />\r\n\t<domain name=\"flickr.com\" views=\"122\" />\r\n\t<domain name=\"images.google.com\" views=\"70\" />\r\n</domains>\r\n"
-    },
-    "explanation": {
-      "_content": "<p>There is one <code>&lt;domain&gt;</code> element for each referring domain, with attributes for the domain name and the number of views.</p>\r\n\r\n<p>For details on the referrers coming from each domain listed you can call <a href=\"/services/api/flickr.stats.getPhotoReferrers.html\">flickr.stats.getPhotoReferrers</a></p>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "0",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format.\r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day."
+        "optional": "0"
       },
       {
         "name": "photo_id",
-        "optional": "1",
-        "_content": "The id of the photo to get stats for. If not provided, stats for all photos will be returned."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of domains to return per page. If this argument is omitted, it defaults to 25. The maximum allowed value is 100."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": "4",
-        "message": "Photo not found",
-        "_content": "The photo id was either invalid or was for a photo not owned by the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getPhotoReferrers.json
+++ b/src/flickr.stats.getPhotoReferrers.json
@@ -1,146 +1,34 @@
 {
   "method": {
     "name": "flickr.stats.getPhotoReferrers",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get a list of referrers from a given domain to a photo"
-    },
-    "response": {
-      "_content": "<domain page=\"1\" perpage=\"25\" pages=\"1\" total=\"3\" name=\"flickr.com\">\r\n\t<referrer url=\"http://flickr.com/\" views=\"11\"/>\r\n\t<referrer url=\"http://flickr.com/photos/friends/\" views=\"8\"/>\r\n\t<referrer url=\"http://flickr.com/search/?q=stats+api\" views=\"2\" searchterm=\"stats api\"/>\r\n</domain>"
-    },
-    "explanation": {
-      "_content": "<p>There is one <code>&lt;referrer&gt;</code> element for each referring page, with attributes for the url and the number of views.</p>\r\n\r\n<p>Where the referring page is a search engine and we have identified the search term it will be given in the searchterm attribute.</p>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "0",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format.\r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day."
+        "optional": "0"
       },
       {
         "name": "domain",
-        "optional": "0",
-        "_content": "The domain to return referrers for. This should be a hostname (eg: \"flickr.com\") with no protocol or pathname."
+        "optional": "0"
       },
       {
         "name": "photo_id",
-        "optional": "1",
-        "_content": "The id of the photo to get stats for. If not provided, stats for all photos will be returned."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of referrers to return per page. If this argument is omitted, it defaults to 25. The maximum allowed value is 100."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": "4",
-        "message": "Photo not found",
-        "_content": "The photo id was either invalid or was for a photo not owned by the calling user."
-      },
-      {
-        "code": "5",
-        "message": "Invalid domain",
-        "_content": "The domain provided is not in the expected format."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getPhotoStats.json
+++ b/src/flickr.stats.getPhotoStats.json
@@ -1,123 +1,22 @@
 {
   "method": {
     "name": "flickr.stats.getPhotoStats",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get the number of views, comments and favorites on a photo for a given date."
-    },
-    "response": {
-      "_content": "<stats views=\"24\" comments=\"4\" favorites=\"1\"/>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "0",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format.\r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day."
+        "optional": "0"
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to get stats for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": "4",
-        "message": "Photo not found",
-        "_content": "The photo id was either invalid or was for a photo not owned by the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getPhotosetDomains.json
+++ b/src/flickr.stats.getPhotosetDomains.json
@@ -1,136 +1,30 @@
 {
   "method": {
     "name": "flickr.stats.getPhotosetDomains",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get a list of referring domains for a photoset"
-    },
-    "response": {
-      "_content": "<domains page=\"1\" perpage=\"25\" pages=\"1\" total=\"3\">\r\n\t<domain name=\"images.search.yahoo.com\" views=\"127\" />\r\n\t<domain name=\"flickr.com\" views=\"122\" />\r\n\t<domain name=\"images.google.com\" views=\"70\" />\r\n</domains>\r\n"
-    },
-    "explanation": {
-      "_content": "<p>There is one <code>&lt;domain&gt;</code> element for each referring domain, with attributes for the domain name and the number of views.</p>\r\n\r\n<p>For details on the referrers coming from each domain listed you can call <a href=\"/services/api/flickr.stats.getPhotosetReferrers.html\">flickr.stats.getPhotosetReferrers</a></p>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "0",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format.\r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day."
+        "optional": "0"
       },
       {
         "name": "photoset_id",
-        "optional": "1",
-        "_content": "The id of the photoset to get stats for. If not provided, stats for all sets will be returned."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of domains to return per page. If this argument is omitted, it defaults to 25. The maximum allowed value is 100."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": "4",
-        "message": "Photoset not found",
-        "_content": "The photoset id was either invalid or was for a set not owned by the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getPhotosetReferrers.json
+++ b/src/flickr.stats.getPhotosetReferrers.json
@@ -1,146 +1,34 @@
 {
   "method": {
     "name": "flickr.stats.getPhotosetReferrers",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get a list of referrers from a given domain to a photoset"
-    },
-    "response": {
-      "_content": "<domain page=\"1\" perpage=\"25\" pages=\"1\" total=\"3\" name=\"flickr.com\">\r\n\t<referrer url=\"http://flickr.com/\" views=\"11\"/>\r\n\t<referrer url=\"http://flickr.com/photos/friends/\" views=\"8\"/>\r\n\t<referrer url=\"http://flickr.com/search/?q=stats+api\" views=\"2\" searchterm=\"stats api\"/>\r\n</domain>"
-    },
-    "explanation": {
-      "_content": "<p>There is one <code>&lt;referrer&gt;</code> element for each referring page, with attributes for the url and the number of views.</p>\r\n\r\n<p>Where the referring page is a search engine and we have identified the search term it will be given in the searchterm attribute.</p>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "0",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format. \r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day."
+        "optional": "0"
       },
       {
         "name": "domain",
-        "optional": "0",
-        "_content": "The domain to return referrers for. This should be a hostname (eg: \"flickr.com\") with no protocol or pathname."
+        "optional": "0"
       },
       {
         "name": "photoset_id",
-        "optional": "1",
-        "_content": "The id of the photoset to get stats for. If not provided, stats for all sets will be returned."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of referrers to return per page. If this argument is omitted, it defaults to 25. The maximum allowed value is 100."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": "4",
-        "message": "Photoset not found",
-        "_content": "The photoset id was either invalid or was for a set not owned by the calling user."
-      },
-      {
-        "code": "5",
-        "message": "Invalid domain",
-        "_content": "The domain provided is not in the expected format."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getPhotosetStats.json
+++ b/src/flickr.stats.getPhotosetStats.json
@@ -1,123 +1,22 @@
 {
   "method": {
     "name": "flickr.stats.getPhotosetStats",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get the number of views on a photoset for a given date."
-    },
-    "response": {
-      "_content": "<stats views=\"24\" comments=\"1\" />"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "0",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format.\r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day."
+        "optional": "0"
       },
       {
         "name": "photoset_id",
-        "optional": "0",
-        "_content": "The id of the photoset to get stats for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": "4",
-        "message": "Photoset not found",
-        "_content": "The photoset id was either invalid or was for a set not owned by the calling user."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getPhotostreamDomains.json
+++ b/src/flickr.stats.getPhotostreamDomains.json
@@ -1,126 +1,26 @@
 {
   "method": {
     "name": "flickr.stats.getPhotostreamDomains",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get a list of referring domains for a photostream"
-    },
-    "response": {
-      "_content": "<domains page=\"1\" perpage=\"25\" pages=\"1\" total=\"3\">\r\n\t<domain name=\"images.search.yahoo.com\" views=\"127\" />\r\n\t<domain name=\"flickr.com\" views=\"122\" />\r\n\t<domain name=\"images.google.com\" views=\"70\" />\r\n</domains>\r\n"
-    },
-    "explanation": {
-      "_content": "<p>There is one <code>&lt;domain&gt;</code> element for each referring domain, with attributes for the domain name and the number of views.</p>\r\n\r\n<p>For details on the referrers coming from each domain listed you can call <a href=\"/services/api/flickr.stats.getPhotostreamReferrers.html\">flickr.stats.getPhotostreamReferrers</a></p>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "0",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format.\r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day."
+        "optional": "0"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of domains to return per page. If this argument is omitted, it defaults to 25. The maximum allowed value is 100"
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getPhotostreamReferrers.json
+++ b/src/flickr.stats.getPhotostreamReferrers.json
@@ -1,136 +1,30 @@
 {
   "method": {
     "name": "flickr.stats.getPhotostreamReferrers",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get a list of referrers from a given domain to a user's photostream"
-    },
-    "response": {
-      "_content": "<domain page=\"1\" perpage=\"25\" pages=\"1\" total=\"3\" name=\"flickr.com\">\r\n\t<referrer url=\"http://flickr.com/\" views=\"11\"/>\r\n\t<referrer url=\"http://flickr.com/photos/friends/\" views=\"8\"/>\r\n\t<referrer url=\"http://flickr.com/search/?q=stats+api\" views=\"2\" searchterm=\"stats api\"/>\r\n</domain>"
-    },
-    "explanation": {
-      "_content": "<p>There is one <code>&lt;referrer&gt;</code> element for each referring page, with attributes for the url and the number of views.</p>\r\n\r\n<p>Where the referring page is a search engine and we have identified the search term it will be given in the searchterm attribute.</p>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "0",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format. \r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day."
+        "optional": "0"
       },
       {
         "name": "domain",
-        "optional": "0",
-        "_content": "The domain to return referrers for. This should be a hostname (eg: \"flickr.com\") with no protocol or pathname."
+        "optional": "0"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of referrers to return per page. If this argument is omitted, it defaults to 25. The maximum allowed value is 100."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": "5",
-        "message": "Invalid domain",
-        "_content": "The domain provided is not in the expected format."
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getPhotostreamStats.json
+++ b/src/flickr.stats.getPhotostreamStats.json
@@ -1,113 +1,18 @@
 {
   "method": {
     "name": "flickr.stats.getPhotostreamStats",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get the number of views on a user's photostream for a given date."
-    },
-    "response": {
-      "_content": "<stats views=\"24\" />"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "0",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format.\r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getPopularPhotos.json
+++ b/src/flickr.stats.getPopularPhotos.json
@@ -1,136 +1,30 @@
 {
   "method": {
     "name": "flickr.stats.getPopularPhotos",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "List the photos with the most views, comments or favorites"
-    },
-    "response": {
-      "_content": "<photos page=\"2\" pages=\"89\" perpage=\"10\" total=\"881\">\r\n\t<photo id=\"2636\" owner=\"47058503995@N01\" \r\n\t\tsecret=\"a123456\" server=\"2\" title=\"test_04\"\r\n\t\tispublic=\"1\" isfriend=\"0\" isfamily=\"0\">\r\n\t\t<stats views=\"941\" comments=\"18\" favorites=\"2\"/>\r\n\t</photo>\r\n\t<photo id=\"2635\" owner=\"47058503995@N01\"\r\n\t\tsecret=\"b123456\" server=\"2\" title=\"test_03\"\r\n\t\tispublic=\"0\" isfriend=\"1\" isfamily=\"1\">\r\n\t\t<stats views=\"141\" comments=\"1\" favorites=\"2\"/>\r\n\t</photo>\r\n</photos>"
-    },
-    "explanation": {
-      "_content": "<p>This method returns the standard photo list xml.</p>\r\n\r\n<p>In addition each photo element contains a <code>&lt;stats&gt;</code> element. This has attributes for the view, comment and favorite counts for the requested day.</p>\r\n\r\n<p>To map <code>&lt;photo&gt;</code> elements to urls, please read the <a href=\"misc.urls.html\">url documentation</a>.</p>\r\n"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "1",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format. \r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day.\r\n\r\nIf no date is provided, all time view counts will be returned."
+        "optional": "1"
       },
       {
         "name": "sort",
-        "optional": "1",
-        "_content": "The order in which to sort returned photos. Defaults to views. The possible values are views, comments and favorites. \r\n\r\nOther sort options are available through <a href=\"/services/api/flickr.photos.search.html\">flickr.photos.search</a>."
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of referrers to return per page. If this argument is omitted, it defaults to 25. The maximum allowed value is 100."
+        "optional": "1"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "The page of results to return. If this argument is omitted, it defaults to 1."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": "5",
-        "message": "Invalid sort",
-        "_content": "The sort provided is not valid"
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.stats.getTotalViews.json
+++ b/src/flickr.stats.getTotalViews.json
@@ -1,113 +1,18 @@
 {
   "method": {
     "name": "flickr.stats.getTotalViews",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get the overall view counts for an account"
-    },
-    "response": {
-      "_content": "<stats>\r\n\t<total views=\"469\" />\r\n\t<photos views=\"386\" />\r\n\t<photostream views=\"72\" />\r\n\t<sets views=\"11\" />\r\n\t<collections views=\"0\" />\r\n</stats>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "date",
-        "optional": "1",
-        "_content": "Stats will be returned for this date. This should be in either be in YYYY-MM-DD or unix timestamp format.\r\n\r\nA day according to Flickr Stats starts at midnight GMT for all users, and timestamps will automatically be rounded down to the start of the day.\r\n\r\nIf no date is provided, all time view counts will be returned."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User does not have stats",
-        "_content": "The user you have requested stats has not enabled stats on their account."
-      },
-      {
-        "code": "2",
-        "message": "No stats for that date",
-        "_content": "No stats are available for the date requested. Flickr only keeps stats data for the last 28 days."
-      },
-      {
-        "code": "3",
-        "message": "Invalid date",
-        "_content": "The date provided could not be parsed"
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.tags.getClusterPhotos.json
+++ b/src/flickr.tags.getClusterPhotos.json
@@ -1,75 +1,22 @@
 {
   "method": {
     "name": "flickr.tags.getClusterPhotos",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the first 24 photos for a given tag cluster"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "tag",
-        "optional": "0",
-        "_content": "The tag that this cluster belongs to."
+        "optional": "0"
       },
       {
         "name": "cluster_id",
-        "optional": "0",
-        "_content": "The top three tags for the cluster, separated by dashes (just like the url)."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.tags.getClusters.json
+++ b/src/flickr.tags.getClusters.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.tags.getClusters",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Gives you a list of tag clusters for the given tag."
-    },
-    "response": {
-      "_content": "<clusters source=\"cows\" total=\"2\">\r\n\t<cluster total=\"3\">\r\n\t\t<tag>farm</tag>\r\n\t\t<tag>animals</tag>\r\n\t\t<tag>cattle</tag>\r\n\t</cluster>\r\n\t<cluster total=\"3\">\r\n\t\t<tag>green</tag>\r\n\t\t<tag>landscape</tag>\r\n\t\t<tag>countryside</tag>\r\n\t</cluster>\r\n</clusters>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "tag",
-        "optional": "0",
-        "_content": "The tag to fetch clusters for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Tag cluster not found",
-        "_content": "The tag was invalid or no cluster exists for that tag."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.tags.getHotList.json
+++ b/src/flickr.tags.getHotList.json
@@ -1,83 +1,22 @@
 {
   "method": {
     "name": "flickr.tags.getHotList",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns a list of hot tags for the given period."
-    },
-    "response": {
-      "_content": "<hottags period=\"day\" count=\"6\">\r\n\t<tag score=\"20\">northerncalifornia</tag>\r\n\t<tag score=\"18\">top20</tag>\r\n\t<tag score=\"15\">keychain</tag>\r\n\t<tag score=\"10\">zb</tag>\r\n\t<tag score=\"9\">selfportraittuesday</tag>\r\n\t<tag score=\"4\">jan06</tag>\r\n</hottags>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "period",
-        "optional": "1",
-        "_content": "The period for which to fetch hot tags. Valid values are <code>day</code> and <code>week</code> (defaults to <code>day</code>)."
+        "optional": "1"
       },
       {
         "name": "count",
-        "optional": "1",
-        "_content": "The number of tags to return. Defaults to 20. Maximum allowed value is 200."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid period",
-        "_content": "The specified period was not understood."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.tags.getListPhoto.json
+++ b/src/flickr.tags.getListPhoto.json
@@ -1,81 +1,18 @@
 {
   "method": {
     "name": "flickr.tags.getListPhoto",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get the tag list for a given photo."
-    },
-    "response": {
-      "_content": "<photo id=\"2619\">\r\n\t<tags>\r\n\t\t<tag id=\"156\" author=\"12037949754@N01\"\r\n\t\t\tauthorname=\"Bees\" raw=\"tag 1\">tag1</tag> \r\n\t\t<tag id=\"157\" author=\"12037949754@N01\"\r\n\t\t\tauthorname=\"Bees\" raw=\"tag 2\">tag2</tag> \r\n\t</tags>\r\n</photo>"
-    },
-    "explanation": {
-      "_content": "<p>For an explanation of the <code>tag</code> element, please read the <a href=\"/services/api/misc.tags.html\">tags documentation</a>.</p>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "photo_id",
-        "optional": "0",
-        "_content": "The id of the photo to return tags for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Photo not found",
-        "_content": "The photo id passed was not a valid photo id."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.tags.getListUser.json
+++ b/src/flickr.tags.getListUser.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.tags.getListUser",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get the tag list for a given user (or the currently logged in user)."
-    },
-    "response": {
-      "_content": "<who id=\"12037949754@N01\">\r\n\t<tags>\r\n\t\t<tag>gull</tag> \r\n\t\t<tag>tag1</tag> \r\n\t\t<tag>tag2</tag> \r\n\t\t<tag>tags</tag> \r\n\t\t<tag>test</tag> \r\n\t</tags>\r\n</who>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "1",
-        "_content": "The NSID of the user to fetch the tag list for. If this argument is not specified, the currently logged in user (if any) is assumed."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The user NSID passed was not a valid user NSID and the calling user was not logged in.\r\n"
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.tags.getListUserPopular.json
+++ b/src/flickr.tags.getListUserPopular.json
@@ -1,83 +1,22 @@
 {
   "method": {
     "name": "flickr.tags.getListUserPopular",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get the popular tags for a given user (or the currently logged in user)."
-    },
-    "response": {
-      "_content": "<who id=\"12037949754@N01\">\r\n\t<tags>\r\n\t\t<tag count=\"10\">bar</tag> \r\n\t\t<tag count=\"11\">foo</tag> \r\n\t\t<tag count=\"147\">gull</tag> \r\n\t\t<tag count=\"3\">tags</tag> \r\n\t\t<tag count=\"3\">test</tag> \r\n\t</tags>\r\n</who>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "1",
-        "_content": "The NSID of the user to fetch the tag list for. If this argument is not specified, the currently logged in user (if any) is assumed."
+        "optional": "1"
       },
       {
         "name": "count",
-        "optional": "1",
-        "_content": "Number of popular tags to return. defaults to 10 when this argument is not present."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The user NSID passed was not a valid user NSID and the calling user was not logged in.\r\n"
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.tags.getListUserRaw.json
+++ b/src/flickr.tags.getListUserRaw.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.tags.getListUserRaw",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get the raw versions of a given tag (or all tags) for the currently logged-in user."
-    },
-    "response": {
-      "_content": "<who id=\"12037949754@N01\">\r\n    <tags>\r\n        <tag clean=\"foo\">\r\n            <raw>foo</raw>\r\n            <raw>Foo</raw>\r\n            <raw>f:oo</raw>\r\n        </tag>\r\n    </tags>\r\n</who>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "tag",
-        "optional": "1",
-        "_content": "The tag you want to retrieve all raw versions for."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The calling user was not logged in."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.tags.getMostFrequentlyUsed.json
+++ b/src/flickr.tags.getMostFrequentlyUsed.json
@@ -1,93 +1,14 @@
 {
   "method": {
     "name": "flickr.tags.getMostFrequentlyUsed",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Returns a list of most frequently used tags for a user."
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n<who id=\"30135021@N05\">\r\n\t<tags>\r\n\t\t<tag count=\"1\">blah</tag>\r\n\t\t<tag count=\"5\">publicdomain</tag>\r\n\t</tags>\r\n</who>\r\n</rsp>"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.tags.getRelated.json
+++ b/src/flickr.tags.getRelated.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.tags.getRelated",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns a list of tags 'related' to the given tag, based on clustered usage analysis."
-    },
-    "response": {
-      "_content": "<tags source=\"london\">\r\n\t<tag>england</tag>\r\n\t<tag>thames</tag>\r\n\t<tag>tube</tag>\r\n\t<tag>bigben</tag>\r\n\t<tag>uk</tag>\r\n</tags>\r\n"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "tag",
-        "optional": "0",
-        "_content": "The tag to fetch related tags for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Tag not found",
-        "_content": "The tag argument was missing."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.test.echo.json
+++ b/src/flickr.test.echo.json
@@ -1,68 +1,14 @@
 {
   "method": {
     "name": "flickr.test.echo",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "A testing method which echo's all parameters back in the response."
-    },
-    "response": {
-      "_content": "<method>echo</method>\r\n<foo>bar</foo>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.test.login.json
+++ b/src/flickr.test.login.json
@@ -1,93 +1,14 @@
 {
   "method": {
     "name": "flickr.test.login",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "A testing method which checks if the caller is logged in then returns their username."
-    },
-    "response": {
-      "_content": "<user id=\"12037949754@N01\">\r\n\t<username>Bees</username> \r\n</user>\r\n"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.test.null.json
+++ b/src/flickr.test.null.json
@@ -1,90 +1,14 @@
 {
   "method": {
     "name": "flickr.test.null",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Null test"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.testimonials.addTestimonial.json
+++ b/src/flickr.testimonials.addTestimonial.json
@@ -1,123 +1,22 @@
 {
   "method": {
     "name": "flickr.testimonials.addTestimonial",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Write a new testimonial"
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n    <testimonial id=\"72157659275062162\" date_create=\"1491516194\" date_approved=\"0\" approved=\"0\" body=\"great photographer!\">\r\n        <by_user nsid=\"45937598@N01\" path_alias=\"\" username=\"john\" ispro=\"1\" is_ad_free=\"0\" realname=\"john nelson\"/>\r\n        <about_user nsid=\"516314214@N05\" path_alias=\"stpaul\" username=\"paul\" ispro=\"0\" is_ad_free=\"0\" realname=\"paul peterson\"/>\r\n    </testimonial>\r\n</rsp>"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "ID of the user the testimonial is about"
+        "optional": "0"
       },
       {
         "name": "testimonial_text",
-        "optional": "0",
-        "_content": "The text of the testimonial. HTML/BBCode is not accepted"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid NSID provided",
-        "_content": ""
-      },
-      {
-        "code": "2",
-        "message": "Unable to save testimonial",
-        "_content": ""
-      },
-      {
-        "code": "3",
-        "message": "Failed to read back testimonial ID",
-        "_content": ""
-      },
-      {
-        "code": "4",
-        "message": "Testimonial already written for this user",
-        "_content": ""
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.testimonials.approveTestimonial.json
+++ b/src/flickr.testimonials.approveTestimonial.json
@@ -1,115 +1,18 @@
 {
   "method": {
     "name": "flickr.testimonials.approveTestimonial",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Approve a testimonial that has been written about the currently loggedin user"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "testimonial_id",
-        "optional": "0",
-        "_content": "ID of the testimonial to approve"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid NSID provided",
-        "_content": ""
-      },
-      {
-        "code": "2",
-        "message": "Testimonial not found",
-        "_content": ""
-      },
-      {
-        "code": "3",
-        "message": "Testimonial already approved",
-        "_content": ""
-      },
-      {
-        "code": "4",
-        "message": "Failed to approve testimonial",
-        "_content": ""
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.testimonials.deleteTestimonial.json
+++ b/src/flickr.testimonials.deleteTestimonial.json
@@ -1,110 +1,18 @@
 {
   "method": {
     "name": "flickr.testimonials.deleteTestimonial",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Permanently delete a testimonial. The loggedin user must be either the author or recipient of the testimonial"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "testimonial_id",
-        "optional": "0",
-        "_content": ""
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid NSID provided",
-        "_content": ""
-      },
-      {
-        "code": "2",
-        "message": "Testimonial not found",
-        "_content": ""
-      },
-      {
-        "code": "4",
-        "message": "Failed to delete testimonial",
-        "_content": ""
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.testimonials.editTestimonial.json
+++ b/src/flickr.testimonials.editTestimonial.json
@@ -1,128 +1,26 @@
 {
   "method": {
     "name": "flickr.testimonials.editTestimonial",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "2",
-    "description": {
-      "_content": "Change the text of a testimonial. The loggedin user must be the author of the existing testimonial. Editing a testimonial will mark it as pending and will require it to be re-approved by the recipient before appearing on their profile"
-    },
-    "response": {
-      "_content": "<rsp stat=\"ok\">\r\n    <testimonial id=\"72157659275062162\" date_create=\"1491516194\" date_approved=\"0\" approved=\"0\" body=\"great photographer!\">\r\n        <by_user nsid=\"45937598@N01\" path_alias=\"\" username=\"john\" ispro=\"1\" is_ad_free=\"0\" realname=\"john nelson\"/>\r\n        <about_user nsid=\"516314214@N05\" path_alias=\"stpaul\" username=\"paul\" ispro=\"0\" is_ad_free=\"0\" realname=\"paul peterson\"/>\r\n    </testimonial>\r\n</rsp>"
-    }
+    "requiredperms": "2"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "The NSID of the user the testimonial is about "
+        "optional": "0"
       },
       {
         "name": "testimonial_id",
-        "optional": "0",
-        "_content": "The ID of the testimonial to edit "
+        "optional": "0"
       },
       {
         "name": "testimonial_text",
-        "optional": "0",
-        "_content": "The text of the testimonial. HTML/BBCode is not accepted"
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid NSID provided",
-        "_content": ""
-      },
-      {
-        "code": "2",
-        "message": "Testimonial not found",
-        "_content": ""
-      },
-      {
-        "code": "3",
-        "message": "Failed to read back testimonial",
-        "_content": ""
-      },
-      {
-        "code": "4",
-        "message": "Unable to save testimonial",
-        "_content": ""
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.testimonials.getAllTestimonialsAbout.json
+++ b/src/flickr.testimonials.getAllTestimonialsAbout.json
@@ -1,110 +1,22 @@
 {
   "method": {
     "name": "flickr.testimonials.getAllTestimonialsAbout",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get all testimonials (pending and approved) written about the given user"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "Page number. Default is 0"
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of testimonials to return per page. Default is 10, maximum is 50"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid NSID provided",
-        "_content": ""
-      },
-      {
-        "code": "2",
-        "message": "Invalid status value provided",
-        "_content": ""
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.testimonials.getAllTestimonialsAboutBy.json
+++ b/src/flickr.testimonials.getAllTestimonialsAboutBy.json
@@ -1,0 +1,18 @@
+{
+  "method": {
+    "name": "flickr.testimonials.getAllTestimonialsAboutBy",
+    "requiredperms": "1"
+  },
+  "arguments": {
+    "argument": [
+      {
+        "name": "api_key",
+        "optional": 0
+      },
+      {
+        "name": "user_id",
+        "optional": "0"
+      }
+    ]
+  }
+}

--- a/src/flickr.testimonials.getAllTestimonialsBy.json
+++ b/src/flickr.testimonials.getAllTestimonialsBy.json
@@ -1,110 +1,22 @@
 {
   "method": {
     "name": "flickr.testimonials.getAllTestimonialsBy",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get all testimonials (pending and approved) written by the given user"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "Page number. Default is 0"
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of testimonials to return per page. Default is 10, maximum is 50"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid NSID provided",
-        "_content": ""
-      },
-      {
-        "code": "2",
-        "message": "Invalid status value provided",
-        "_content": ""
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.testimonials.getPendingTestimonialsAbout.json
+++ b/src/flickr.testimonials.getPendingTestimonialsAbout.json
@@ -1,110 +1,22 @@
 {
   "method": {
     "name": "flickr.testimonials.getPendingTestimonialsAbout",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get all pending testimonials written about the given user"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "Page number. Default is 0"
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of testimonials to return per page. Default is 10, maximum is 50"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid NSID provided",
-        "_content": ""
-      },
-      {
-        "code": "2",
-        "message": "Invalid status value provided",
-        "_content": ""
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.testimonials.getPendingTestimonialsAboutBy.json
+++ b/src/flickr.testimonials.getPendingTestimonialsAboutBy.json
@@ -1,0 +1,18 @@
+{
+  "method": {
+    "name": "flickr.testimonials.getPendingTestimonialsAboutBy",
+    "requiredperms": "1"
+  },
+  "arguments": {
+    "argument": [
+      {
+        "name": "api_key",
+        "optional": 0
+      },
+      {
+        "name": "user_id",
+        "optional": "0"
+      }
+    ]
+  }
+}

--- a/src/flickr.testimonials.getPendingTestimonialsBy.json
+++ b/src/flickr.testimonials.getPendingTestimonialsBy.json
@@ -1,110 +1,22 @@
 {
   "method": {
     "name": "flickr.testimonials.getPendingTestimonialsBy",
-    "needslogin": 1,
-    "needssigning": 1,
-    "requiredperms": "1",
-    "description": {
-      "_content": "Get all pending testimonials written by the given user"
-    }
+    "requiredperms": "1"
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "Page number. Default is 0"
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of testimonials to return per page. Default is 10, maximum is 50"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid NSID provided",
-        "_content": ""
-      },
-      {
-        "code": "2",
-        "message": "Invalid status value provided",
-        "_content": ""
-      },
-      {
-        "code": 95,
-        "message": "SSL is required",
-        "_content": "SSL is required to access the Flickr API."
-      },
-      {
-        "code": 96,
-        "message": "Invalid signature",
-        "_content": "The passed signature was invalid."
-      },
-      {
-        "code": 97,
-        "message": "Missing signature",
-        "_content": "The call required signing but no signature was sent."
-      },
-      {
-        "code": 98,
-        "message": "Login failed / Invalid auth token",
-        "_content": "The login details or auth token passed were invalid."
-      },
-      {
-        "code": 99,
-        "message": "User not logged in / Insufficient permissions",
-        "_content": "The method requires user authentication but the user was not logged in, or the authenticated method call did not have the required permissions."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.testimonials.getTestimonialsAbout.json
+++ b/src/flickr.testimonials.getTestimonialsAbout.json
@@ -1,90 +1,26 @@
 {
   "method": {
     "name": "flickr.testimonials.getTestimonialsAbout",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get approved testimonials about the given user"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "ID of the user to get testimonials about"
+        "optional": "0"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "Page number. Default is 0"
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of testimonials to return per page. Default is 10, maximum is 50"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid NSID provided",
-        "_content": ""
-      },
-      {
-        "code": "2",
-        "message": "Invalid status value provided",
-        "_content": ""
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.testimonials.getTestimonialsAboutBy.json
+++ b/src/flickr.testimonials.getTestimonialsAboutBy.json
@@ -1,0 +1,18 @@
+{
+  "method": {
+    "name": "flickr.testimonials.getTestimonialsAboutBy",
+    "requiredperms": "1"
+  },
+  "arguments": {
+    "argument": [
+      {
+        "name": "api_key",
+        "optional": 0
+      },
+      {
+        "name": "user_id",
+        "optional": "0"
+      }
+    ]
+  }
+}

--- a/src/flickr.testimonials.getTestimonialsBy.json
+++ b/src/flickr.testimonials.getTestimonialsBy.json
@@ -1,90 +1,26 @@
 {
   "method": {
     "name": "flickr.testimonials.getTestimonialsBy",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Get approved testimonials written by the given user"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "0",
-        "_content": "ID of the user to get testimonials written by"
+        "optional": "0"
       },
       {
         "name": "page",
-        "optional": "1",
-        "_content": "Page number. Default is 0"
+        "optional": "1"
       },
       {
         "name": "per_page",
-        "optional": "1",
-        "_content": "Number of testimonials to return per page. Default is 10, maximum is 50"
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Invalid NSID provided",
-        "_content": ""
-      },
-      {
-        "code": "2",
-        "message": "Invalid status value provided",
-        "_content": ""
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.urls.getGroup.json
+++ b/src/flickr.urls.getGroup.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.urls.getGroup",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the url to a group's page."
-    },
-    "response": {
-      "_content": "<group nsid=\"48508120860@N01\" url=\"http://www.flickr.com/groups/test1/\" /> "
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "group_id",
-        "optional": "0",
-        "_content": "The NSID of the group to fetch the url for."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Group not found",
-        "_content": "The NSID specified was not a valid group."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.urls.getUserPhotos.json
+++ b/src/flickr.urls.getUserPhotos.json
@@ -1,83 +1,18 @@
 {
   "method": {
     "name": "flickr.urls.getUserPhotos",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the url to a user's photos."
-    },
-    "response": {
-      "_content": "<user nsid=\"12037949754@N01\" url=\"http://www.flickr.com/photos/bees/\" />"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "1",
-        "_content": "The NSID of the user to fetch the url for. If omitted, the calling user is assumed."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The NSID specified was not a valid user."
-      },
-      {
-        "code": "2",
-        "message": "No user specified",
-        "_content": "No user_id was passed and the calling user was not logged in."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.urls.getUserProfile.json
+++ b/src/flickr.urls.getUserProfile.json
@@ -1,83 +1,18 @@
 {
   "method": {
     "name": "flickr.urls.getUserProfile",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns the url to a user's profile."
-    },
-    "response": {
-      "_content": "<user nsid=\"12037949754@N01\" url=\"http://www.flickr.com/people/bees/\" />"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "user_id",
-        "optional": "1",
-        "_content": "The NSID of the user to fetch the url for. If omitted, the calling user is assumed."
+        "optional": "1"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The NSID specified was not a valid user."
-      },
-      {
-        "code": "2",
-        "message": "No user specified",
-        "_content": "No user_id was passed and the calling user was not logged in."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.urls.lookupGallery.json
+++ b/src/flickr.urls.lookupGallery.json
@@ -1,76 +1,18 @@
 {
   "method": {
     "name": "flickr.urls.lookupGallery",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns gallery info, by url."
-    },
-    "response": {
-      "_content": "<gallery id=\"6065-72157617483228192\" url=\"/photos/straup/galleries/72157617483228192\" owner=\"35034348999@N01\" \r\nprimary_photo_id=\"292882708\" \r\ndate_create=\"1241028772\" date_update=\"1270111667\" \r\ncount_photos=\"17\" count_videos=\"0\" server=\"112\" farm=\"1\" secret=\"7f29861bc4\">\r\n\t<title>Cat Pictures I've Sent To Kevin Collins</title>\r\n\t<description />\r\n</gallery>"
-    },
-    "explanation": {
-      "_content": "This is the same format returned by <a href=\"http://www.flickr.com/services/api/flickr.galleries.getInfo.html\">flickr.galleries.getInfo</a>."
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "url",
-        "optional": "0",
-        "_content": "The gallery's URL."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.urls.lookupGroup.json
+++ b/src/flickr.urls.lookupGroup.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.urls.lookupGroup",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns a group NSID, given the url to a group's page or photo pool."
-    },
-    "response": {
-      "_content": "<group id=\"34427469792@N01\">\r\n\t<groupname>FlickrCentral</groupname> \r\n</group>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "url",
-        "optional": "0",
-        "_content": "The url to the group's page or photo pool."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "Group not found",
-        "_content": "The passed URL was not a valid group page or photo pool url."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/src/flickr.urls.lookupUser.json
+++ b/src/flickr.urls.lookupUser.json
@@ -1,78 +1,18 @@
 {
   "method": {
     "name": "flickr.urls.lookupUser",
-    "needslogin": 0,
-    "needssigning": 0,
-    "requiredperms": 0,
-    "description": {
-      "_content": "Returns a user NSID, given the url to a user's photos or profile."
-    },
-    "response": {
-      "_content": "<user id=\"12037949632@N01\">\r\n\t<username>Stewart</username> \r\n</user>"
-    }
+    "requiredperms": 0
   },
   "arguments": {
     "argument": [
       {
         "name": "api_key",
-        "optional": 0,
-        "_content": "Your API application key. <a href=\"/services/api/misc.api_keys.html\">See here</a> for more details."
+        "optional": 0
       },
       {
         "name": "url",
-        "optional": "0",
-        "_content": "The url to the user's profile or photos page."
+        "optional": "0"
       }
     ]
-  },
-  "errors": {
-    "error": [
-      {
-        "code": "1",
-        "message": "User not found",
-        "_content": "The passed URL was not a valid user profile or photos url."
-      },
-      {
-        "code": 100,
-        "message": "Invalid API Key",
-        "_content": "The API key passed was not valid or has expired."
-      },
-      {
-        "code": 105,
-        "message": "Service currently unavailable",
-        "_content": "The requested service is temporarily unavailable."
-      },
-      {
-        "code": 106,
-        "message": "Write operation failed",
-        "_content": "The requested operation failed due to a temporary issue."
-      },
-      {
-        "code": 111,
-        "message": "Format \"xxx\" not found",
-        "_content": "The requested response format was not found."
-      },
-      {
-        "code": 112,
-        "message": "Method \"xxx\" not found",
-        "_content": "The requested method was not found."
-      },
-      {
-        "code": 114,
-        "message": "Invalid SOAP envelope",
-        "_content": "The SOAP envelope send in the request could not be parsed."
-      },
-      {
-        "code": 115,
-        "message": "Invalid XML-RPC Method Call",
-        "_content": "The XML-RPC request document could not be parsed."
-      },
-      {
-        "code": 116,
-        "message": "Bad URL found",
-        "_content": "One or more arguments contained a URL that has been used for abuse on Flickr."
-      }
-    ]
-  },
-  "stat": "ok"
+  }
 }

--- a/test/flickr.testimonials.getAllTestimonialsAboutBy.js
+++ b/test/flickr.testimonials.getAllTestimonialsAboutBy.js
@@ -1,0 +1,29 @@
+var flickr = require('..')(function auth() { /* noop */ });
+var assert = require('assert');
+
+describe('flickr.testimonials.getAllTestimonialsAboutBy', function () {
+
+	it('requires "user_id"', function () {
+
+		assert.throws(function () {
+			flickr.testimonials.getAllTestimonialsAboutBy({});
+		}, function (err) {
+			return err.message === 'Missing required argument "user_id"';
+		});
+
+	});
+
+	it('returns a Request instance', function () {
+		var req = flickr.testimonials.getAllTestimonialsAboutBy({
+			user_id: '_'
+		});
+
+		assert.equal(req.method, 'GET');
+		assert.equal(req.url, 'https://api.flickr.com/services/rest');
+		assert.equal(req.qs.format, 'json');
+		assert.equal(req.qs.nojsoncallback, '1');
+		assert.equal(req.qs.method, 'flickr.testimonials.getAllTestimonialsAboutBy');
+		assert.equal(req.qs.user_id, '_');
+	});
+
+});

--- a/test/flickr.testimonials.getPendingTestimonialsAboutBy.js
+++ b/test/flickr.testimonials.getPendingTestimonialsAboutBy.js
@@ -1,0 +1,29 @@
+var flickr = require('..')(function auth() { /* noop */ });
+var assert = require('assert');
+
+describe('flickr.testimonials.getPendingTestimonialsAboutBy', function () {
+
+	it('requires "user_id"', function () {
+
+		assert.throws(function () {
+			flickr.testimonials.getPendingTestimonialsAboutBy({});
+		}, function (err) {
+			return err.message === 'Missing required argument "user_id"';
+		});
+
+	});
+
+	it('returns a Request instance', function () {
+		var req = flickr.testimonials.getPendingTestimonialsAboutBy({
+			user_id: '_'
+		});
+
+		assert.equal(req.method, 'GET');
+		assert.equal(req.url, 'https://api.flickr.com/services/rest');
+		assert.equal(req.qs.format, 'json');
+		assert.equal(req.qs.nojsoncallback, '1');
+		assert.equal(req.qs.method, 'flickr.testimonials.getPendingTestimonialsAboutBy');
+		assert.equal(req.qs.user_id, '_');
+	});
+
+});

--- a/test/flickr.testimonials.getTestimonialsAboutBy.js
+++ b/test/flickr.testimonials.getTestimonialsAboutBy.js
@@ -1,0 +1,29 @@
+var flickr = require('..')(function auth() { /* noop */ });
+var assert = require('assert');
+
+describe('flickr.testimonials.getTestimonialsAboutBy', function () {
+
+	it('requires "user_id"', function () {
+
+		assert.throws(function () {
+			flickr.testimonials.getTestimonialsAboutBy({});
+		}, function (err) {
+			return err.message === 'Missing required argument "user_id"';
+		});
+
+	});
+
+	it('returns a Request instance', function () {
+		var req = flickr.testimonials.getTestimonialsAboutBy({
+			user_id: '_'
+		});
+
+		assert.equal(req.method, 'GET');
+		assert.equal(req.url, 'https://api.flickr.com/services/rest');
+		assert.equal(req.qs.format, 'json');
+		assert.equal(req.qs.nojsoncallback, '1');
+		assert.equal(req.qs.method, 'flickr.testimonials.getTestimonialsAboutBy');
+		assert.equal(req.qs.user_id, '_');
+	});
+
+});


### PR DESCRIPTION
We're storing a whole bunch of data in our reflection cache that we don't need, so this patch filters a whole lot of that out. This also updates the SDK to match the current API:

- Adds `flickr.testimonials.getAllTestimonialsAboutBy`
- Adds `flickr.testimonials.getPendingTestimonialsAboutBy`
- Adds `flickr.testimonials.getTestimonialsAboutBy`