### PR TITLE
Add an XML parser plugin for Upload/Replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-Nothing yet!
+#### Changed
+
+- [#104] Upload/Replace services now parse the response body. ([@jeremyruppel])
 
 ## [3.0.0-alpha.6] - 2017-08-08
 
@@ -107,6 +109,7 @@ This "release" marks the start of a complete rewrite of the Flickr SDK. Once the
 [#85]: https://github.com/flickr/flickr-sdk/pull/85
 [#90]: https://github.com/flickr/flickr-sdk/pull/90
 [#94]: https://github.com/flickr/flickr-sdk/pull/94
+[#104]: https://github.com/flickr/flickr-sdk/pull/104
 
 <!-- other links -->
 

--- a/examples/replace.js
+++ b/examples/replace.js
@@ -35,7 +35,7 @@ var replace = new Flickr.Replace(auth, photoID, __dirname + '/replace.png', {
 // to kick off the request.
 
 replace.then(function (res) {
-	console.log('res', res);
+	console.log('res', res.body);
 }).catch(function (err) {
 	console.log('err', err);
 });

--- a/examples/upload.js
+++ b/examples/upload.js
@@ -29,7 +29,7 @@ var upload = new Flickr.Upload(auth, __dirname + '/upload.png', {
 // to kick off the request.
 
 upload.then(function (res) {
-	console.log('res', res);
+	console.log('res', res.body);
 }).catch(function (err) {
 	console.log('err', err);
 });

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "stringify-object": "^3.2.0"
   },
   "dependencies": {
-    "superagent": "^3.5.3-beta.2"
+    "superagent": "^3.5.3-beta.2",
+    "xml2js": "^0.4.17"
   },
   "bugs": {
     "url": "https://github.com/flickr/flickr-sdk/issues"

--- a/plugins/json.js
+++ b/plugins/json.js
@@ -33,6 +33,13 @@ function parseFlickr(res, fn) {
 	});
 }
 
+/**
+ * Superagent plugin-style function to request and parse
+ * JSON responses from the Flickr REST API.
+ * @param {Request} req
+ * @returns {undefined}
+ */
+
 module.exports = function (req) {
 	req.query({ format: 'json' });
 	req.query({ nojsoncallback: 1 });

--- a/plugins/xml.js
+++ b/plugins/xml.js
@@ -1,0 +1,62 @@
+/*!
+ * Copyright 2017 Yahoo Holdings.
+ * Licensed under the terms of the MIT license. Please see LICENSE file in the project root for terms.
+ */
+
+var xml2js = require('xml2js');
+
+/**
+ * Custom response parse for parsing XML responses from Flickr.
+ * Currently, the Upload and Replace APIs don't support JSON
+ * as a response format. Until we fix this on the API side,
+ * we need to parse the XML response so that the end user
+ * can at least do something with it.
+ * @param {Response} res
+ * @param {Function} fn
+ * @returns {null}
+ */
+
+function parseXML(res, fn) {
+	// palmtree pray box this approach from superagent's JSON parser
+	res.text = '';
+	res.setEncoding('utf8');
+
+	// collect all the response text
+	res.on('data', function (chunk) {
+		res.text += chunk;
+	});
+
+	res.on('end', function () {
+		xml2js.parseString(res.text, {
+			mergeAttrs: true,
+			explicitArray: false,
+			explicitRoot: false,
+			explicitCharkey: true,
+			charkey: '_content'
+		}, function (err, body) {
+
+			if (err) {
+				return fn(new SyntaxError(err.message), body);
+			}
+
+			if (body.stat === 'fail' && body.err) {
+				err = new Error(body.err.msg);
+				err.stat = body.stat;
+				err.code = body.err.code;
+			}
+
+			fn(err, body);
+		});
+	});
+}
+
+/**
+ * Superagent plugin-style function to request and parse
+ * XML responses from the Flickr Upload and Replace APIs.
+ * @param {Request} req
+ * @returns {undefined}
+ */
+
+module.exports = function (req) {
+	req.parse(parseXML);
+};

--- a/script/build-docs.js
+++ b/script/build-docs.js
@@ -30,5 +30,5 @@ jsdoc.render({
 }).then(function (str) {
 	process.stdout.write(str);
 }).catch(function (err) {
-	console.error(err);
+	console.error(err); // eslint-disable-line no-console
 });

--- a/services/replace.js
+++ b/services/replace.js
@@ -4,6 +4,7 @@
  */
 
 var Request = require('../lib/request').Request;
+var xml = require('../plugins/xml');
 
 /**
  * Creates a new Replace service instance. Since the Replace API only
@@ -61,6 +62,7 @@ function Replace(auth, photoID, file, args) {
 	this.attach('photo', file);
 	this.field('photo_id', photoID);
 	this.field(args);
+	this.use(xml);
 	this.use(auth);
 }
 

--- a/services/upload.js
+++ b/services/upload.js
@@ -4,6 +4,7 @@
  */
 
 var Request = require('../lib/request').Request;
+var xml = require('../plugins/xml');
 
 /**
  * Creates a new Upload service instance. Since the Upload API only
@@ -55,6 +56,7 @@ function Upload(auth, file, args) {
 
 	this.attach('photo', file);
 	this.field(args);
+	this.use(xml);
 	this.use(auth);
 }
 

--- a/test/plugins.xml.js
+++ b/test/plugins.xml.js
@@ -1,0 +1,66 @@
+var subject = require('../plugins/xml');
+var request = require('../lib/request');
+var assert = require('assert');
+var nock = require('nock');
+
+describe('plugins/xml', function () {
+
+	function createMockResponse() {
+		return nock('https://up.flickr.com')
+			.post('/services/upload');
+	}
+
+	it('parses an xml response', function () {
+		var api = createMockResponse().reply(200,
+			'<?xml version="1.0" encoding="utf-8" ?>\n' +
+			'<rsp stat="ok">\n' +
+				'<photoid>41234567890</photoid>\n' +
+			'</rsp>\n');
+
+		return request('POST', 'https://up.flickr.com/services/upload')
+			.use(subject)
+			.then(function (res) {
+				assert(api.isDone(), 'Expected mock to have been called');
+				assert.deepEqual(res.body, {
+					stat: 'ok',
+					photoid: {
+						_content: '41234567890'
+					}
+				});
+			});
+	});
+
+	it('yields a SyntaxError if XML parsing fails', function () {
+		var api = createMockResponse().reply(200, '<?xml');
+
+		return request('POST', 'https://up.flickr.com/services/upload')
+			.use(subject)
+			.then(function () {
+				throw new Error('Expected errback');
+			}, function (err) {
+				assert(api.isDone(), 'Expected mock to have been called');
+				assert.equal(err.name, 'SyntaxError');
+			});
+
+	});
+
+	it('yields an error if stat=fail is returned', function () {
+		var api = createMockResponse().reply(200,
+			'<?xml version="1.0" encoding="utf-8" ?>\n' +
+			'<rsp stat="fail">\n' +
+				'<err code="8" msg="Filesize was too large" />\n' +
+			'</rsp>\n');
+
+		return request('POST', 'https://up.flickr.com/services/upload')
+			.use(subject)
+			.then(function () {
+				throw new Error('Expected errback');
+			}, function (err) {
+				assert(api.isDone(), 'Expected mock to have been called');
+				assert.equal(err.message, 'Filesize was too large');
+				assert.equal(err.code, 8);
+			});
+
+	});
+
+});


### PR DESCRIPTION
Right now our upload and replace endpoints only support returning XML responses so we need to parse them as such. We should totally make those endpoints support JSON (shouldn't be too difficult) but until they do we need this dependency.