### PR TITLE
Build a standalone version for the browser

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 coverage
+flickr-sdk.js

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ typings/
 
 # Generated files
 services/rest.js
+flickr-sdk.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-Nothing yet!
+- [#109] Build a standalone version for the browser with each new npm release. ([@jeremyruppel])
 
 ## [v3.1.1] - 2017-08-22
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ The Flickr API is divided into several services:
 ``` js
 var Flickr = require('flickr-sdk');
 ```
+
+### Browser Usage
+
+Since OAuth 1.0 requires your application's key and secret to sign requests, flickr-sdk does not support this authentication method in the browser. Upload, Replace, and REST API calls that require authentication will not work without a valid OAuth signature. You can still use flickr-sdk to call REST API methods that don't require authentication or to get public feeds.
+
+flickr-sdk has been tested with [browserify][] but should work with other client-side module bundlers like [webpack][] and [rollup][]. If you need a standalone browser-ready version of flickr-sdk, each release on [npm](https://www.npmjs.com/package/flickr-sdk) will contain a browserified version of this module at `node_modules/flickr-sdk/flickr-sdk.js`. It is not minified.
 <a name="Flickr"></a>
 
 ## Flickr
@@ -727,3 +733,6 @@ Code licensed under the MIT license. See LICENSE file for terms.
 [flickr.photos.getInfo]: https://www.flickr.com/services/api/flickr.photos.getInfo.html
 [flickr.photos.search]: https://www.flickr.com/services/api/flickr.photos.search.html
 [superagent]: https://github.com/visionmedia/superagent/
+[browserify]: http://browserify.org/
+[webpack]: https://webpack.github.io/
+[rollup]: https://rollupjs.org/

--- a/hook.sh
+++ b/hook.sh
@@ -6,5 +6,6 @@ node package.json
 npm run build-rest
 npm run build-docs
 npm run build-tests
+npm run build-client
 npm run lint
 npm run test

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "main": "index.js",
   "files": [
     "index.js",
+    "flickr-sdk.js",
     "lib",
     "plugins",
     "services"
@@ -25,7 +26,8 @@
     "build-rest": "node script/build-rest > services/rest.js",
     "build-tests": "node script/build-tests",
     "build-docs": "node script/build-docs > README.md",
-    "build": "npm run build-rest && npm run build-docs",
+    "build-client": "browserify -s Flickr $npm_package_main > flickr-sdk.js",
+    "build": "npm run build-rest && npm run build-docs && npm run build-client",
     "lint": "eslint .",
     "test": "mocha",
     "coverage": "nyc mocha",
@@ -48,6 +50,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "devDependencies": {
+    "browserify": "^14.4.0",
     "chalk": "^2.0.1",
     "dotprune": "^0.1.10",
     "ejs": "~2.5.2",

--- a/script/build-docs.ejs
+++ b/script/build-docs.ejs
@@ -25,6 +25,12 @@ The Flickr API is divided into several services:
 ``` js
 var Flickr = require('<%= package.name %>');
 ```
+
+### Browser Usage
+
+Since OAuth 1.0 requires your application's key and secret to sign requests, <%= package.name %> does not support this authentication method in the browser. Upload, Replace, and REST API calls that require authentication will not work without a valid OAuth signature. You can still use <%= package.name %> to call REST API methods that don't require authentication or to get public feeds.
+
+<%= package.name %> has been tested with [browserify][] but should work with other client-side module bundlers like [webpack][] and [rollup][]. If you need a standalone browser-ready version of <%= package.name %>, each release on [npm](https://www.npmjs.com/package/<%= package.name %>) will contain a browserified version of this module at `node_modules/flickr-sdk/flickr-sdk.js`. It is not minified.
 <%- docs %>
 
 ## License
@@ -40,3 +46,6 @@ Code licensed under the MIT license. See LICENSE file for terms.
 [flickr.photos.getInfo]: https://www.flickr.com/services/api/flickr.photos.getInfo.html
 [flickr.photos.search]: https://www.flickr.com/services/api/flickr.photos.search.html
 [superagent]: https://github.com/visionmedia/superagent/
+[browserify]: http://browserify.org/
+[webpack]: https://webpack.github.io/
+[rollup]: https://rollupjs.org/


### PR DESCRIPTION
As part of each release, we should build a simple standalone version of this module for the browser for those who want to quickly include the SDK in a web page and start using public API methods. This file won't be minified or optimized in any way; users that require anything more should use [browserify](http://browserify.org/) or another module bundler.

Also, this updates the readme to make it clear why we don't support OAuth in the browser.

Resolves #108. 