### PR TITLE
user_id of flickr.photosets.getPhotos is optional

### DIFF
--- a/src/flickr.photosets.getPhotos.json
+++ b/src/flickr.photosets.getPhotos.json
@@ -15,7 +15,7 @@
       },
       {
         "name": "user_id",
-        "optional": "0"
+        "optional": "1"
       },
       {
         "name": "extras",


### PR DESCRIPTION
https://www.flickr.com/services/api/flickr.photosets.getPhotos.html

> The `user_id` here is the owner of the set passed in `photoset_id`. This is optional, but passing this gives better performance.