### PR TITLE
Update webpack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,5 +734,5 @@ Code licensed under the MIT license. See LICENSE file for terms.
 [flickr.photos.search]: https://www.flickr.com/services/api/flickr.photos.search.html
 [superagent]: https://github.com/visionmedia/superagent/
 [browserify]: http://browserify.org/
-[webpack]: https://webpack.github.io/
+[webpack]: https://webpack.js.org/
 [rollup]: https://rollupjs.org/


### PR DESCRIPTION
It now links to the new documentation site.