### PR TITLE
Add a browser-specific json parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "services"
   ],
   "browser": {
+    "./plugins/json.js": "./plugins/json-browser.js",
     "./plugins/oauth.js": "./plugins/oauth-browser.js",
     "./services/oauth.js": "./services/oauth-browser.js"
   },
@@ -61,6 +62,7 @@
     "jsdoc-to-markdown": "^3.0.0",
     "mocha": "~3.0.2",
     "nock": "~8.0.0",
+    "node-http-xhr": "^1.3.4",
     "nyc": "^10.3.2",
     "ora": "^1.3.0",
     "p-limit": "^1.1.0",

--- a/plugins/json-browser.js
+++ b/plugins/json-browser.js
@@ -1,0 +1,44 @@
+/*!
+ * Copyright 2017 Yahoo Holdings.
+ * Licensed under the terms of the MIT license. Please see LICENSE file in the project root for terms.
+ */
+
+/**
+ * Custom response parser routine to handle Flickr API-style
+ * error responses. The Flickr API has a whole bunch of client
+ * error codes, but they all come back as HTTP 200 responses.
+ * Here, we extend the normal JSON response parser and check
+ * for a Flickr API error. If we find one, craft a new error
+ * out of that and throw it.
+ * @param {Response} res
+ * @param {String} json
+ * @returns {Object}
+ */
+
+function parseFlickr(res, json) {
+	var body = JSON.parse(json);
+	var err;
+
+	if (body.stat === 'fail') {
+		err = new Error(body.message);
+		err.stat = body.stat;
+		err.code = body.code;
+
+		throw err;
+	}
+
+	return body;
+}
+
+/**
+ * Superagent plugin-style function to request and parse
+ * JSON responses from the Flickr REST API.
+ * @param {Request} req
+ * @returns {undefined}
+ */
+
+module.exports = function (req) {
+	req.query({ format: 'json' });
+	req.query({ nojsoncallback: 1 });
+	req.parse(parseFlickr);
+};

--- a/test/plugins.json-browser.js
+++ b/test/plugins.json-browser.js
@@ -1,0 +1,67 @@
+var subject = require('../plugins/json-browser');
+var request = require('superagent/superagent'); // use browser version
+var XMLHttpRequest = require('node-http-xhr');
+var assert = require('assert');
+var nock = require('nock');
+
+// override getXHR to return a nodejs implementation
+// of XMLHttpRequest for testing
+request.getXHR = function () {
+	return new XMLHttpRequest;
+};
+
+describe('plugins/json-browser', function () {
+
+	function createMockResponse() {
+		return nock('https://api.flickr.com')
+			.get('/services/rest')
+			.query({
+				format: 'json',
+				nojsoncallback: 1
+			});
+	}
+
+	it('parses a json response', function () {
+		var api = createMockResponse().reply(200, '{"stat":"ok"}');
+
+		return request('GET', 'https://api.flickr.com/services/rest')
+			.use(subject)
+			.then(function (res) {
+				assert(api.isDone(), 'Expected mock to have been called');
+				assert.deepEqual(res.body, { stat: 'ok' });
+			});
+	});
+
+	it('yields an Error if JSON parsing fails', function () {
+		var api = createMockResponse().reply(200, '{');
+
+		return request('GET', 'https://api.flickr.com/services/rest')
+			.use(subject)
+			.then(function () {
+				throw new Error('Expected errback');
+			}, function (err) {
+				assert(api.isDone(), 'Expected mock to have been called');
+				assert.equal(err.message, 'Parser is unable to parse the response');
+			});
+
+	});
+
+	it('yields an error if stat=fail is returned', function () {
+		var api = createMockResponse().reply(200, {
+			stat: 'fail',
+			code: 100,
+			message: 'Invalid API Key (Key has invalid format)'
+		});
+
+		return request('GET', 'https://api.flickr.com/services/rest')
+			.use(subject)
+			.then(function () {
+				throw new Error('Expected errback');
+			}, function (err) {
+				assert(api.isDone(), 'Expected mock to have been called');
+				assert.equal(err.message, 'Parser is unable to parse the response');
+			});
+
+	});
+
+});


### PR DESCRIPTION
[superagent's client-side version parses responses very differently than the node version.][1] This adds a browser-specific, synchronous `parseFlickr` method. 

Fixes #111.

[1]: https://github.com/visionmedia/superagent/blob/master/lib/client.js#L326-L348