### PR TITLE
Adds support for passing extras as a Set

### DIFF
--- a/script/build-rest.ejs
+++ b/script/build-rest.ejs
@@ -56,6 +56,8 @@ function createClient(auth, opts) {
 		// array we should join it
 		if (Array.isArray(args.extras)) {
 			args.extras = args.extras.join(',');
+		} else if (args.extras instanceof Set) {
+			args.extras = Array.from(args.extras).join(',');
 		}
 
 		return request(verb, 'https://' + host + '/services/rest')

--- a/test/services.rest.js
+++ b/test/services.rest.js
@@ -111,4 +111,21 @@ describe('services/rest', function () {
 		assert.equal(url.query.extras, 'foo,bar,baz');
 	});
 
+	it('joins "extras" if passed as a set', function () {
+		var req = subject._('GET', 'flickr.test.echo', {
+			extras: new Set([
+				'foo',
+				'bar',
+				'baz'
+			])
+		}).request();
+
+		var url = parse(req.path, true);
+
+		assert.equal(url.query.method, 'flickr.test.echo');
+		assert.equal(url.query.format, 'json');
+		assert.equal(url.query.nojsoncallback, '1');
+		assert.equal(url.query.extras, 'foo,bar,baz');
+	});
+
 });


### PR DESCRIPTION
Lets you do:

```js
let extras = new Set([
  'fnord',
  'blorf'
];

flickr.people.getInfo({
  extras: extras
});
```

This follows the Array pattern and gets converted to a comma-separated string, thus guaranteeing unique values from start to finish.