### PR TITLE
Request text/plain from the REST API

### DIFF
--- a/plugins/json.js
+++ b/plugins/json.js
@@ -32,7 +32,9 @@ function parseFlickr(res) {
 
 /**
  * Superagent plugin-style function to request and parse
- * JSON responses from the Flickr REST API.
+ * JSON responses from the Flickr REST API. We need to
+ * specify content-type: text/plain here to appease CORS
+ * since the API does not accept application/json.
  * @param {Request} req
  * @returns {undefined}
  */
@@ -40,6 +42,6 @@ function parseFlickr(res) {
 module.exports = function (req) {
 	req.query({ format: 'json' });
 	req.query({ nojsoncallback: 1 });
-	req.type('json');
+	req.type('text/plain');
 	req.ok(parseFlickr);
 };

--- a/script/build-tests.ejs
+++ b/script/build-tests.ejs
@@ -23,6 +23,7 @@ describe('<%= method %>', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, '<%= method %>');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		<%_ Object.keys(args).forEach(function (arg) { _%>
 		assert.equal(req.qs.<%= arg %>, '<%= args[arg] %>');
 		<%_ }); _%>

--- a/test/flickr.activity.userComments.js
+++ b/test/flickr.activity.userComments.js
@@ -11,6 +11,7 @@ describe('flickr.activity.userComments', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.activity.userComments');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.activity.userPhotos.js
+++ b/test/flickr.activity.userPhotos.js
@@ -11,6 +11,7 @@ describe('flickr.activity.userPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.activity.userPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.auth.checkToken.js
+++ b/test/flickr.auth.checkToken.js
@@ -23,6 +23,7 @@ describe('flickr.auth.checkToken', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.auth.checkToken');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.auth_token, '_');
 	});
 

--- a/test/flickr.auth.getFrob.js
+++ b/test/flickr.auth.getFrob.js
@@ -11,6 +11,7 @@ describe('flickr.auth.getFrob', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.auth.getFrob');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.auth.getFullToken.js
+++ b/test/flickr.auth.getFullToken.js
@@ -23,6 +23,7 @@ describe('flickr.auth.getFullToken', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.auth.getFullToken');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.mini_token, '_');
 	});
 

--- a/test/flickr.auth.getToken.js
+++ b/test/flickr.auth.getToken.js
@@ -23,6 +23,7 @@ describe('flickr.auth.getToken', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.auth.getToken');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.frob, '_');
 	});
 

--- a/test/flickr.auth.oauth.checkToken.js
+++ b/test/flickr.auth.oauth.checkToken.js
@@ -23,6 +23,7 @@ describe('flickr.auth.oauth.checkToken', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.auth.oauth.checkToken');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.oauth_token, '_');
 	});
 

--- a/test/flickr.auth.oauth.getAccessToken.js
+++ b/test/flickr.auth.oauth.getAccessToken.js
@@ -11,6 +11,7 @@ describe('flickr.auth.oauth.getAccessToken', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.auth.oauth.getAccessToken');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.blogs.getList.js
+++ b/test/flickr.blogs.getList.js
@@ -11,6 +11,7 @@ describe('flickr.blogs.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.blogs.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.blogs.getServices.js
+++ b/test/flickr.blogs.getServices.js
@@ -11,6 +11,7 @@ describe('flickr.blogs.getServices', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.blogs.getServices');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.blogs.postPhoto.js
+++ b/test/flickr.blogs.postPhoto.js
@@ -54,6 +54,7 @@ describe('flickr.blogs.postPhoto', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.blogs.postPhoto');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.title, '_');
 		assert.equal(req.qs.description, '_');

--- a/test/flickr.cameras.getBrandModels.js
+++ b/test/flickr.cameras.getBrandModels.js
@@ -23,6 +23,7 @@ describe('flickr.cameras.getBrandModels', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.cameras.getBrandModels');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.brand, '_');
 	});
 

--- a/test/flickr.cameras.getBrands.js
+++ b/test/flickr.cameras.getBrands.js
@@ -11,6 +11,7 @@ describe('flickr.cameras.getBrands', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.cameras.getBrands');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.collections.getInfo.js
+++ b/test/flickr.collections.getInfo.js
@@ -23,6 +23,7 @@ describe('flickr.collections.getInfo', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.collections.getInfo');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.collection_id, '_');
 	});
 

--- a/test/flickr.collections.getTree.js
+++ b/test/flickr.collections.getTree.js
@@ -11,6 +11,7 @@ describe('flickr.collections.getTree', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.collections.getTree');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.commons.getInstitutions.js
+++ b/test/flickr.commons.getInstitutions.js
@@ -11,6 +11,7 @@ describe('flickr.commons.getInstitutions', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.commons.getInstitutions');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.contacts.getList.js
+++ b/test/flickr.contacts.getList.js
@@ -11,6 +11,7 @@ describe('flickr.contacts.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.contacts.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.contacts.getListRecentlyUploaded.js
+++ b/test/flickr.contacts.getListRecentlyUploaded.js
@@ -11,6 +11,7 @@ describe('flickr.contacts.getListRecentlyUploaded', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.contacts.getListRecentlyUploaded');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.contacts.getPublicList.js
+++ b/test/flickr.contacts.getPublicList.js
@@ -23,6 +23,7 @@ describe('flickr.contacts.getPublicList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.contacts.getPublicList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.contacts.getTaggingSuggestions.js
+++ b/test/flickr.contacts.getTaggingSuggestions.js
@@ -11,6 +11,7 @@ describe('flickr.contacts.getTaggingSuggestions', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.contacts.getTaggingSuggestions');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.favorites.add.js
+++ b/test/flickr.favorites.add.js
@@ -23,6 +23,7 @@ describe('flickr.favorites.add', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.favorites.add');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.favorites.getContext.js
+++ b/test/flickr.favorites.getContext.js
@@ -38,6 +38,7 @@ describe('flickr.favorites.getContext', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.favorites.getContext');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.user_id, '_');
 	});

--- a/test/flickr.favorites.getList.js
+++ b/test/flickr.favorites.getList.js
@@ -11,6 +11,7 @@ describe('flickr.favorites.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.favorites.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.favorites.getPublicList.js
+++ b/test/flickr.favorites.getPublicList.js
@@ -23,6 +23,7 @@ describe('flickr.favorites.getPublicList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.favorites.getPublicList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.favorites.remove.js
+++ b/test/flickr.favorites.remove.js
@@ -23,6 +23,7 @@ describe('flickr.favorites.remove', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.favorites.remove');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.galleries.addPhoto.js
+++ b/test/flickr.galleries.addPhoto.js
@@ -38,6 +38,7 @@ describe('flickr.galleries.addPhoto', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.galleries.addPhoto');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.gallery_id, '_');
 		assert.equal(req.qs.photo_id, '_');
 	});

--- a/test/flickr.galleries.create.js
+++ b/test/flickr.galleries.create.js
@@ -38,6 +38,7 @@ describe('flickr.galleries.create', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.galleries.create');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.title, '_');
 		assert.equal(req.qs.description, '_');
 	});

--- a/test/flickr.galleries.editMeta.js
+++ b/test/flickr.galleries.editMeta.js
@@ -38,6 +38,7 @@ describe('flickr.galleries.editMeta', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.galleries.editMeta');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.gallery_id, '_');
 		assert.equal(req.qs.title, '_');
 	});

--- a/test/flickr.galleries.editPhoto.js
+++ b/test/flickr.galleries.editPhoto.js
@@ -54,6 +54,7 @@ describe('flickr.galleries.editPhoto', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.galleries.editPhoto');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.gallery_id, '_');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.comment, '_');

--- a/test/flickr.galleries.editPhotos.js
+++ b/test/flickr.galleries.editPhotos.js
@@ -54,6 +54,7 @@ describe('flickr.galleries.editPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.galleries.editPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.gallery_id, '_');
 		assert.equal(req.qs.primary_photo_id, '_');
 		assert.equal(req.qs.photo_ids, '_');

--- a/test/flickr.galleries.getInfo.js
+++ b/test/flickr.galleries.getInfo.js
@@ -23,6 +23,7 @@ describe('flickr.galleries.getInfo', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.galleries.getInfo');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.gallery_id, '_');
 	});
 

--- a/test/flickr.galleries.getList.js
+++ b/test/flickr.galleries.getList.js
@@ -23,6 +23,7 @@ describe('flickr.galleries.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.galleries.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.galleries.getListForPhoto.js
+++ b/test/flickr.galleries.getListForPhoto.js
@@ -23,6 +23,7 @@ describe('flickr.galleries.getListForPhoto', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.galleries.getListForPhoto');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.galleries.getPhotos.js
+++ b/test/flickr.galleries.getPhotos.js
@@ -23,6 +23,7 @@ describe('flickr.galleries.getPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.galleries.getPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.gallery_id, '_');
 	});
 

--- a/test/flickr.groups.browse.js
+++ b/test/flickr.groups.browse.js
@@ -11,6 +11,7 @@ describe('flickr.groups.browse', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.browse');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.groups.discuss.replies.add.js
+++ b/test/flickr.groups.discuss.replies.add.js
@@ -54,6 +54,7 @@ describe('flickr.groups.discuss.replies.add', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.discuss.replies.add');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 		assert.equal(req.qs.topic_id, '_');
 		assert.equal(req.qs.message, '_');

--- a/test/flickr.groups.discuss.replies.delete.js
+++ b/test/flickr.groups.discuss.replies.delete.js
@@ -54,6 +54,7 @@ describe('flickr.groups.discuss.replies.delete', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.discuss.replies.delete');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 		assert.equal(req.qs.topic_id, '_');
 		assert.equal(req.qs.reply_id, '_');

--- a/test/flickr.groups.discuss.replies.edit.js
+++ b/test/flickr.groups.discuss.replies.edit.js
@@ -72,6 +72,7 @@ describe('flickr.groups.discuss.replies.edit', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.discuss.replies.edit');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 		assert.equal(req.qs.topic_id, '_');
 		assert.equal(req.qs.reply_id, '_');

--- a/test/flickr.groups.discuss.replies.getInfo.js
+++ b/test/flickr.groups.discuss.replies.getInfo.js
@@ -54,6 +54,7 @@ describe('flickr.groups.discuss.replies.getInfo', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.discuss.replies.getInfo');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 		assert.equal(req.qs.topic_id, '_');
 		assert.equal(req.qs.reply_id, '_');

--- a/test/flickr.groups.discuss.replies.getList.js
+++ b/test/flickr.groups.discuss.replies.getList.js
@@ -54,6 +54,7 @@ describe('flickr.groups.discuss.replies.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.discuss.replies.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 		assert.equal(req.qs.topic_id, '_');
 		assert.equal(req.qs.per_page, '_');

--- a/test/flickr.groups.discuss.topics.add.js
+++ b/test/flickr.groups.discuss.topics.add.js
@@ -54,6 +54,7 @@ describe('flickr.groups.discuss.topics.add', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.discuss.topics.add');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 		assert.equal(req.qs.subject, '_');
 		assert.equal(req.qs.message, '_');

--- a/test/flickr.groups.discuss.topics.getInfo.js
+++ b/test/flickr.groups.discuss.topics.getInfo.js
@@ -38,6 +38,7 @@ describe('flickr.groups.discuss.topics.getInfo', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.discuss.topics.getInfo');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 		assert.equal(req.qs.topic_id, '_');
 	});

--- a/test/flickr.groups.discuss.topics.getList.js
+++ b/test/flickr.groups.discuss.topics.getList.js
@@ -23,6 +23,7 @@ describe('flickr.groups.discuss.topics.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.discuss.topics.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 	});
 

--- a/test/flickr.groups.getInfo.js
+++ b/test/flickr.groups.getInfo.js
@@ -23,6 +23,7 @@ describe('flickr.groups.getInfo', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.getInfo');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 	});
 

--- a/test/flickr.groups.join.js
+++ b/test/flickr.groups.join.js
@@ -23,6 +23,7 @@ describe('flickr.groups.join', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.join');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 	});
 

--- a/test/flickr.groups.joinRequest.js
+++ b/test/flickr.groups.joinRequest.js
@@ -54,6 +54,7 @@ describe('flickr.groups.joinRequest', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.joinRequest');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 		assert.equal(req.qs.message, '_');
 		assert.equal(req.qs.accept_rules, '_');

--- a/test/flickr.groups.leave.js
+++ b/test/flickr.groups.leave.js
@@ -23,6 +23,7 @@ describe('flickr.groups.leave', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.leave');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 	});
 

--- a/test/flickr.groups.members.getList.js
+++ b/test/flickr.groups.members.getList.js
@@ -23,6 +23,7 @@ describe('flickr.groups.members.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.members.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 	});
 

--- a/test/flickr.groups.pools.add.js
+++ b/test/flickr.groups.pools.add.js
@@ -38,6 +38,7 @@ describe('flickr.groups.pools.add', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.pools.add');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.group_id, '_');
 	});

--- a/test/flickr.groups.pools.getContext.js
+++ b/test/flickr.groups.pools.getContext.js
@@ -38,6 +38,7 @@ describe('flickr.groups.pools.getContext', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.pools.getContext');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.group_id, '_');
 	});

--- a/test/flickr.groups.pools.getGroups.js
+++ b/test/flickr.groups.pools.getGroups.js
@@ -11,6 +11,7 @@ describe('flickr.groups.pools.getGroups', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.pools.getGroups');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.groups.pools.getPhotos.js
+++ b/test/flickr.groups.pools.getPhotos.js
@@ -23,6 +23,7 @@ describe('flickr.groups.pools.getPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.pools.getPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 	});
 

--- a/test/flickr.groups.pools.remove.js
+++ b/test/flickr.groups.pools.remove.js
@@ -38,6 +38,7 @@ describe('flickr.groups.pools.remove', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.pools.remove');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.group_id, '_');
 	});

--- a/test/flickr.groups.search.js
+++ b/test/flickr.groups.search.js
@@ -23,6 +23,7 @@ describe('flickr.groups.search', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.groups.search');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.text, '_');
 	});
 

--- a/test/flickr.interestingness.getList.js
+++ b/test/flickr.interestingness.getList.js
@@ -11,6 +11,7 @@ describe('flickr.interestingness.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.interestingness.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.machinetags.getNamespaces.js
+++ b/test/flickr.machinetags.getNamespaces.js
@@ -11,6 +11,7 @@ describe('flickr.machinetags.getNamespaces', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.machinetags.getNamespaces');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.machinetags.getPairs.js
+++ b/test/flickr.machinetags.getPairs.js
@@ -11,6 +11,7 @@ describe('flickr.machinetags.getPairs', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.machinetags.getPairs');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.machinetags.getPredicates.js
+++ b/test/flickr.machinetags.getPredicates.js
@@ -11,6 +11,7 @@ describe('flickr.machinetags.getPredicates', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.machinetags.getPredicates');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.machinetags.getRecentValues.js
+++ b/test/flickr.machinetags.getRecentValues.js
@@ -11,6 +11,7 @@ describe('flickr.machinetags.getRecentValues', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.machinetags.getRecentValues');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.machinetags.getValues.js
+++ b/test/flickr.machinetags.getValues.js
@@ -38,6 +38,7 @@ describe('flickr.machinetags.getValues', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.machinetags.getValues');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.namespace, '_');
 		assert.equal(req.qs.predicate, '_');
 	});

--- a/test/flickr.panda.getList.js
+++ b/test/flickr.panda.getList.js
@@ -11,6 +11,7 @@ describe('flickr.panda.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.panda.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.panda.getPhotos.js
+++ b/test/flickr.panda.getPhotos.js
@@ -23,6 +23,7 @@ describe('flickr.panda.getPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.panda.getPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.panda_name, '_');
 	});
 

--- a/test/flickr.people.findByEmail.js
+++ b/test/flickr.people.findByEmail.js
@@ -23,6 +23,7 @@ describe('flickr.people.findByEmail', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.people.findByEmail');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.find_email, '_');
 	});
 

--- a/test/flickr.people.findByUsername.js
+++ b/test/flickr.people.findByUsername.js
@@ -23,6 +23,7 @@ describe('flickr.people.findByUsername', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.people.findByUsername');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.username, '_');
 	});
 

--- a/test/flickr.people.getGroups.js
+++ b/test/flickr.people.getGroups.js
@@ -23,6 +23,7 @@ describe('flickr.people.getGroups', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.people.getGroups');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.people.getInfo.js
+++ b/test/flickr.people.getInfo.js
@@ -23,6 +23,7 @@ describe('flickr.people.getInfo', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.people.getInfo');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.people.getLimits.js
+++ b/test/flickr.people.getLimits.js
@@ -11,6 +11,7 @@ describe('flickr.people.getLimits', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.people.getLimits');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.people.getPhotos.js
+++ b/test/flickr.people.getPhotos.js
@@ -23,6 +23,7 @@ describe('flickr.people.getPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.people.getPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.people.getPhotosOf.js
+++ b/test/flickr.people.getPhotosOf.js
@@ -23,6 +23,7 @@ describe('flickr.people.getPhotosOf', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.people.getPhotosOf');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.people.getPublicGroups.js
+++ b/test/flickr.people.getPublicGroups.js
@@ -23,6 +23,7 @@ describe('flickr.people.getPublicGroups', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.people.getPublicGroups');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.people.getPublicPhotos.js
+++ b/test/flickr.people.getPublicPhotos.js
@@ -23,6 +23,7 @@ describe('flickr.people.getPublicPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.people.getPublicPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.people.getUploadStatus.js
+++ b/test/flickr.people.getUploadStatus.js
@@ -11,6 +11,7 @@ describe('flickr.people.getUploadStatus', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.people.getUploadStatus');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photos.addTags.js
+++ b/test/flickr.photos.addTags.js
@@ -38,6 +38,7 @@ describe('flickr.photos.addTags', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.addTags');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.tags, '_');
 	});

--- a/test/flickr.photos.comments.addComment.js
+++ b/test/flickr.photos.comments.addComment.js
@@ -38,6 +38,7 @@ describe('flickr.photos.comments.addComment', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.comments.addComment');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.comment_text, '_');
 	});

--- a/test/flickr.photos.comments.deleteComment.js
+++ b/test/flickr.photos.comments.deleteComment.js
@@ -23,6 +23,7 @@ describe('flickr.photos.comments.deleteComment', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.comments.deleteComment');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.comment_id, '_');
 	});
 

--- a/test/flickr.photos.comments.editComment.js
+++ b/test/flickr.photos.comments.editComment.js
@@ -38,6 +38,7 @@ describe('flickr.photos.comments.editComment', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.comments.editComment');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.comment_id, '_');
 		assert.equal(req.qs.comment_text, '_');
 	});

--- a/test/flickr.photos.comments.getList.js
+++ b/test/flickr.photos.comments.getList.js
@@ -23,6 +23,7 @@ describe('flickr.photos.comments.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.comments.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.comments.getRecentForContacts.js
+++ b/test/flickr.photos.comments.getRecentForContacts.js
@@ -11,6 +11,7 @@ describe('flickr.photos.comments.getRecentForContacts', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.comments.getRecentForContacts');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photos.delete.js
+++ b/test/flickr.photos.delete.js
@@ -23,6 +23,7 @@ describe('flickr.photos.delete', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.delete');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.geo.batchCorrectLocation.js
+++ b/test/flickr.photos.geo.batchCorrectLocation.js
@@ -54,6 +54,7 @@ describe('flickr.photos.geo.batchCorrectLocation', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.geo.batchCorrectLocation');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.lat, '_');
 		assert.equal(req.qs.lon, '_');
 		assert.equal(req.qs.accuracy, '_');

--- a/test/flickr.photos.geo.correctLocation.js
+++ b/test/flickr.photos.geo.correctLocation.js
@@ -38,6 +38,7 @@ describe('flickr.photos.geo.correctLocation', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.geo.correctLocation');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.foursquare_id, '_');
 	});

--- a/test/flickr.photos.geo.getLocation.js
+++ b/test/flickr.photos.geo.getLocation.js
@@ -23,6 +23,7 @@ describe('flickr.photos.geo.getLocation', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.geo.getLocation');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.geo.getPerms.js
+++ b/test/flickr.photos.geo.getPerms.js
@@ -23,6 +23,7 @@ describe('flickr.photos.geo.getPerms', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.geo.getPerms');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.geo.photosForLocation.js
+++ b/test/flickr.photos.geo.photosForLocation.js
@@ -38,6 +38,7 @@ describe('flickr.photos.geo.photosForLocation', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.geo.photosForLocation');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.lat, '_');
 		assert.equal(req.qs.lon, '_');
 	});

--- a/test/flickr.photos.geo.removeLocation.js
+++ b/test/flickr.photos.geo.removeLocation.js
@@ -23,6 +23,7 @@ describe('flickr.photos.geo.removeLocation', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.geo.removeLocation');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.geo.setContext.js
+++ b/test/flickr.photos.geo.setContext.js
@@ -38,6 +38,7 @@ describe('flickr.photos.geo.setContext', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.geo.setContext');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.context, '_');
 	});

--- a/test/flickr.photos.geo.setLocation.js
+++ b/test/flickr.photos.geo.setLocation.js
@@ -54,6 +54,7 @@ describe('flickr.photos.geo.setLocation', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.geo.setLocation');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.lat, '_');
 		assert.equal(req.qs.lon, '_');

--- a/test/flickr.photos.geo.setPerms.js
+++ b/test/flickr.photos.geo.setPerms.js
@@ -92,6 +92,7 @@ describe('flickr.photos.geo.setPerms', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.geo.setPerms');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.is_public, '_');
 		assert.equal(req.qs.is_contact, '_');
 		assert.equal(req.qs.is_friend, '_');

--- a/test/flickr.photos.getAllContexts.js
+++ b/test/flickr.photos.getAllContexts.js
@@ -23,6 +23,7 @@ describe('flickr.photos.getAllContexts', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getAllContexts');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.getContactsPhotos.js
+++ b/test/flickr.photos.getContactsPhotos.js
@@ -11,6 +11,7 @@ describe('flickr.photos.getContactsPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getContactsPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photos.getContactsPublicPhotos.js
+++ b/test/flickr.photos.getContactsPublicPhotos.js
@@ -23,6 +23,7 @@ describe('flickr.photos.getContactsPublicPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getContactsPublicPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.photos.getContext.js
+++ b/test/flickr.photos.getContext.js
@@ -23,6 +23,7 @@ describe('flickr.photos.getContext', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getContext');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.getCounts.js
+++ b/test/flickr.photos.getCounts.js
@@ -11,6 +11,7 @@ describe('flickr.photos.getCounts', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getCounts');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photos.getExif.js
+++ b/test/flickr.photos.getExif.js
@@ -23,6 +23,7 @@ describe('flickr.photos.getExif', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getExif');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.getFavorites.js
+++ b/test/flickr.photos.getFavorites.js
@@ -23,6 +23,7 @@ describe('flickr.photos.getFavorites', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getFavorites');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.getInfo.js
+++ b/test/flickr.photos.getInfo.js
@@ -23,6 +23,7 @@ describe('flickr.photos.getInfo', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getInfo');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.getNotInSet.js
+++ b/test/flickr.photos.getNotInSet.js
@@ -11,6 +11,7 @@ describe('flickr.photos.getNotInSet', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getNotInSet');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photos.getPerms.js
+++ b/test/flickr.photos.getPerms.js
@@ -23,6 +23,7 @@ describe('flickr.photos.getPerms', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getPerms');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.getPopular.js
+++ b/test/flickr.photos.getPopular.js
@@ -11,6 +11,7 @@ describe('flickr.photos.getPopular', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getPopular');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photos.getRecent.js
+++ b/test/flickr.photos.getRecent.js
@@ -11,6 +11,7 @@ describe('flickr.photos.getRecent', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getRecent');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photos.getSizes.js
+++ b/test/flickr.photos.getSizes.js
@@ -23,6 +23,7 @@ describe('flickr.photos.getSizes', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getSizes');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.getUntagged.js
+++ b/test/flickr.photos.getUntagged.js
@@ -11,6 +11,7 @@ describe('flickr.photos.getUntagged', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getUntagged');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photos.getWithGeoData.js
+++ b/test/flickr.photos.getWithGeoData.js
@@ -11,6 +11,7 @@ describe('flickr.photos.getWithGeoData', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getWithGeoData');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photos.getWithoutGeoData.js
+++ b/test/flickr.photos.getWithoutGeoData.js
@@ -11,6 +11,7 @@ describe('flickr.photos.getWithoutGeoData', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.getWithoutGeoData');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photos.licenses.getInfo.js
+++ b/test/flickr.photos.licenses.getInfo.js
@@ -11,6 +11,7 @@ describe('flickr.photos.licenses.getInfo', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.licenses.getInfo');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photos.licenses.setLicense.js
+++ b/test/flickr.photos.licenses.setLicense.js
@@ -38,6 +38,7 @@ describe('flickr.photos.licenses.setLicense', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.licenses.setLicense');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.license_id, '_');
 	});

--- a/test/flickr.photos.notes.add.js
+++ b/test/flickr.photos.notes.add.js
@@ -114,6 +114,7 @@ describe('flickr.photos.notes.add', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.notes.add');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.note_x, '_');
 		assert.equal(req.qs.note_y, '_');

--- a/test/flickr.photos.notes.delete.js
+++ b/test/flickr.photos.notes.delete.js
@@ -23,6 +23,7 @@ describe('flickr.photos.notes.delete', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.notes.delete');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.note_id, '_');
 	});
 

--- a/test/flickr.photos.notes.edit.js
+++ b/test/flickr.photos.notes.edit.js
@@ -114,6 +114,7 @@ describe('flickr.photos.notes.edit', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.notes.edit');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.note_id, '_');
 		assert.equal(req.qs.note_x, '_');
 		assert.equal(req.qs.note_y, '_');

--- a/test/flickr.photos.people.add.js
+++ b/test/flickr.photos.people.add.js
@@ -38,6 +38,7 @@ describe('flickr.photos.people.add', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.people.add');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.user_id, '_');
 	});

--- a/test/flickr.photos.people.delete.js
+++ b/test/flickr.photos.people.delete.js
@@ -38,6 +38,7 @@ describe('flickr.photos.people.delete', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.people.delete');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.user_id, '_');
 	});

--- a/test/flickr.photos.people.deleteCoords.js
+++ b/test/flickr.photos.people.deleteCoords.js
@@ -38,6 +38,7 @@ describe('flickr.photos.people.deleteCoords', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.people.deleteCoords');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.user_id, '_');
 	});

--- a/test/flickr.photos.people.editCoords.js
+++ b/test/flickr.photos.people.editCoords.js
@@ -114,6 +114,7 @@ describe('flickr.photos.people.editCoords', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.people.editCoords');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.user_id, '_');
 		assert.equal(req.qs.person_x, '_');

--- a/test/flickr.photos.people.getList.js
+++ b/test/flickr.photos.people.getList.js
@@ -23,6 +23,7 @@ describe('flickr.photos.people.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.people.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.recentlyUpdated.js
+++ b/test/flickr.photos.recentlyUpdated.js
@@ -23,6 +23,7 @@ describe('flickr.photos.recentlyUpdated', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.recentlyUpdated');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.min_date, '_');
 	});
 

--- a/test/flickr.photos.removeTag.js
+++ b/test/flickr.photos.removeTag.js
@@ -23,6 +23,7 @@ describe('flickr.photos.removeTag', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.removeTag');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.tag_id, '_');
 	});
 

--- a/test/flickr.photos.search.js
+++ b/test/flickr.photos.search.js
@@ -11,6 +11,7 @@ describe('flickr.photos.search', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.search');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photos.setContentType.js
+++ b/test/flickr.photos.setContentType.js
@@ -38,6 +38,7 @@ describe('flickr.photos.setContentType', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.setContentType');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.content_type, '_');
 	});

--- a/test/flickr.photos.setDates.js
+++ b/test/flickr.photos.setDates.js
@@ -23,6 +23,7 @@ describe('flickr.photos.setDates', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.setDates');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.setMeta.js
+++ b/test/flickr.photos.setMeta.js
@@ -23,6 +23,7 @@ describe('flickr.photos.setMeta', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.setMeta');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.setPerms.js
+++ b/test/flickr.photos.setPerms.js
@@ -72,6 +72,7 @@ describe('flickr.photos.setPerms', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.setPerms');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.is_public, '_');
 		assert.equal(req.qs.is_friend, '_');

--- a/test/flickr.photos.setSafetyLevel.js
+++ b/test/flickr.photos.setSafetyLevel.js
@@ -23,6 +23,7 @@ describe('flickr.photos.setSafetyLevel', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.setSafetyLevel');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.photos.setTags.js
+++ b/test/flickr.photos.setTags.js
@@ -38,6 +38,7 @@ describe('flickr.photos.setTags', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.setTags');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.tags, '_');
 	});

--- a/test/flickr.photos.suggestions.approveSuggestion.js
+++ b/test/flickr.photos.suggestions.approveSuggestion.js
@@ -23,6 +23,7 @@ describe('flickr.photos.suggestions.approveSuggestion', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.suggestions.approveSuggestion');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.suggestion_id, '_');
 	});
 

--- a/test/flickr.photos.suggestions.getList.js
+++ b/test/flickr.photos.suggestions.getList.js
@@ -11,6 +11,7 @@ describe('flickr.photos.suggestions.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.suggestions.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photos.suggestions.rejectSuggestion.js
+++ b/test/flickr.photos.suggestions.rejectSuggestion.js
@@ -23,6 +23,7 @@ describe('flickr.photos.suggestions.rejectSuggestion', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.suggestions.rejectSuggestion');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.suggestion_id, '_');
 	});
 

--- a/test/flickr.photos.suggestions.removeSuggestion.js
+++ b/test/flickr.photos.suggestions.removeSuggestion.js
@@ -23,6 +23,7 @@ describe('flickr.photos.suggestions.removeSuggestion', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.suggestions.removeSuggestion');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.suggestion_id, '_');
 	});
 

--- a/test/flickr.photos.suggestions.suggestLocation.js
+++ b/test/flickr.photos.suggestions.suggestLocation.js
@@ -54,6 +54,7 @@ describe('flickr.photos.suggestions.suggestLocation', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.suggestions.suggestLocation');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.lat, '_');
 		assert.equal(req.qs.lon, '_');

--- a/test/flickr.photos.transform.rotate.js
+++ b/test/flickr.photos.transform.rotate.js
@@ -38,6 +38,7 @@ describe('flickr.photos.transform.rotate', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.transform.rotate');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.degrees, '_');
 	});

--- a/test/flickr.photos.upload.checkTickets.js
+++ b/test/flickr.photos.upload.checkTickets.js
@@ -23,6 +23,7 @@ describe('flickr.photos.upload.checkTickets', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photos.upload.checkTickets');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.tickets, '_');
 	});
 

--- a/test/flickr.photosets.addPhoto.js
+++ b/test/flickr.photosets.addPhoto.js
@@ -38,6 +38,7 @@ describe('flickr.photosets.addPhoto', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.addPhoto');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photoset_id, '_');
 		assert.equal(req.qs.photo_id, '_');
 	});

--- a/test/flickr.photosets.comments.addComment.js
+++ b/test/flickr.photosets.comments.addComment.js
@@ -38,6 +38,7 @@ describe('flickr.photosets.comments.addComment', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.comments.addComment');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photoset_id, '_');
 		assert.equal(req.qs.comment_text, '_');
 	});

--- a/test/flickr.photosets.comments.deleteComment.js
+++ b/test/flickr.photosets.comments.deleteComment.js
@@ -23,6 +23,7 @@ describe('flickr.photosets.comments.deleteComment', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.comments.deleteComment');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.comment_id, '_');
 	});
 

--- a/test/flickr.photosets.comments.editComment.js
+++ b/test/flickr.photosets.comments.editComment.js
@@ -38,6 +38,7 @@ describe('flickr.photosets.comments.editComment', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.comments.editComment');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.comment_id, '_');
 		assert.equal(req.qs.comment_text, '_');
 	});

--- a/test/flickr.photosets.comments.getList.js
+++ b/test/flickr.photosets.comments.getList.js
@@ -23,6 +23,7 @@ describe('flickr.photosets.comments.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.comments.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photoset_id, '_');
 	});
 

--- a/test/flickr.photosets.create.js
+++ b/test/flickr.photosets.create.js
@@ -38,6 +38,7 @@ describe('flickr.photosets.create', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.create');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.title, '_');
 		assert.equal(req.qs.primary_photo_id, '_');
 	});

--- a/test/flickr.photosets.delete.js
+++ b/test/flickr.photosets.delete.js
@@ -23,6 +23,7 @@ describe('flickr.photosets.delete', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.delete');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photoset_id, '_');
 	});
 

--- a/test/flickr.photosets.editMeta.js
+++ b/test/flickr.photosets.editMeta.js
@@ -38,6 +38,7 @@ describe('flickr.photosets.editMeta', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.editMeta');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photoset_id, '_');
 		assert.equal(req.qs.title, '_');
 	});

--- a/test/flickr.photosets.editPhotos.js
+++ b/test/flickr.photosets.editPhotos.js
@@ -54,6 +54,7 @@ describe('flickr.photosets.editPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.editPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photoset_id, '_');
 		assert.equal(req.qs.primary_photo_id, '_');
 		assert.equal(req.qs.photo_ids, '_');

--- a/test/flickr.photosets.getContext.js
+++ b/test/flickr.photosets.getContext.js
@@ -38,6 +38,7 @@ describe('flickr.photosets.getContext', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.getContext');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 		assert.equal(req.qs.photoset_id, '_');
 	});

--- a/test/flickr.photosets.getInfo.js
+++ b/test/flickr.photosets.getInfo.js
@@ -38,6 +38,7 @@ describe('flickr.photosets.getInfo', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.getInfo');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photoset_id, '_');
 		assert.equal(req.qs.user_id, '_');
 	});

--- a/test/flickr.photosets.getList.js
+++ b/test/flickr.photosets.getList.js
@@ -11,6 +11,7 @@ describe('flickr.photosets.getList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.getList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.photosets.getPhotos.js
+++ b/test/flickr.photosets.getPhotos.js
@@ -38,6 +38,7 @@ describe('flickr.photosets.getPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.getPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photoset_id, '_');
 		assert.equal(req.qs.user_id, '_');
 	});

--- a/test/flickr.photosets.orderSets.js
+++ b/test/flickr.photosets.orderSets.js
@@ -23,6 +23,7 @@ describe('flickr.photosets.orderSets', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.orderSets');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photoset_ids, '_');
 	});
 

--- a/test/flickr.photosets.removePhoto.js
+++ b/test/flickr.photosets.removePhoto.js
@@ -38,6 +38,7 @@ describe('flickr.photosets.removePhoto', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.removePhoto');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photoset_id, '_');
 		assert.equal(req.qs.photo_id, '_');
 	});

--- a/test/flickr.photosets.removePhotos.js
+++ b/test/flickr.photosets.removePhotos.js
@@ -38,6 +38,7 @@ describe('flickr.photosets.removePhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.removePhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photoset_id, '_');
 		assert.equal(req.qs.photo_ids, '_');
 	});

--- a/test/flickr.photosets.reorderPhotos.js
+++ b/test/flickr.photosets.reorderPhotos.js
@@ -38,6 +38,7 @@ describe('flickr.photosets.reorderPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.reorderPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photoset_id, '_');
 		assert.equal(req.qs.photo_ids, '_');
 	});

--- a/test/flickr.photosets.setPrimaryPhoto.js
+++ b/test/flickr.photosets.setPrimaryPhoto.js
@@ -38,6 +38,7 @@ describe('flickr.photosets.setPrimaryPhoto', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.photosets.setPrimaryPhoto');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photoset_id, '_');
 		assert.equal(req.qs.photo_id, '_');
 	});

--- a/test/flickr.places.find.js
+++ b/test/flickr.places.find.js
@@ -23,6 +23,7 @@ describe('flickr.places.find', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.find');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.query, '_');
 	});
 

--- a/test/flickr.places.findByLatLon.js
+++ b/test/flickr.places.findByLatLon.js
@@ -38,6 +38,7 @@ describe('flickr.places.findByLatLon', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.findByLatLon');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.lat, '_');
 		assert.equal(req.qs.lon, '_');
 	});

--- a/test/flickr.places.getChildrenWithPhotosPublic.js
+++ b/test/flickr.places.getChildrenWithPhotosPublic.js
@@ -11,6 +11,7 @@ describe('flickr.places.getChildrenWithPhotosPublic', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.getChildrenWithPhotosPublic');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.places.getInfo.js
+++ b/test/flickr.places.getInfo.js
@@ -11,6 +11,7 @@ describe('flickr.places.getInfo', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.getInfo');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.places.getInfoByUrl.js
+++ b/test/flickr.places.getInfoByUrl.js
@@ -23,6 +23,7 @@ describe('flickr.places.getInfoByUrl', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.getInfoByUrl');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.url, '_');
 	});
 

--- a/test/flickr.places.getPlaceTypes.js
+++ b/test/flickr.places.getPlaceTypes.js
@@ -11,6 +11,7 @@ describe('flickr.places.getPlaceTypes', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.getPlaceTypes');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.places.getShapeHistory.js
+++ b/test/flickr.places.getShapeHistory.js
@@ -11,6 +11,7 @@ describe('flickr.places.getShapeHistory', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.getShapeHistory');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.places.getTopPlacesList.js
+++ b/test/flickr.places.getTopPlacesList.js
@@ -23,6 +23,7 @@ describe('flickr.places.getTopPlacesList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.getTopPlacesList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.place_type_id, '_');
 	});
 

--- a/test/flickr.places.placesForBoundingBox.js
+++ b/test/flickr.places.placesForBoundingBox.js
@@ -23,6 +23,7 @@ describe('flickr.places.placesForBoundingBox', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.placesForBoundingBox');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.bbox, '_');
 	});
 

--- a/test/flickr.places.placesForContacts.js
+++ b/test/flickr.places.placesForContacts.js
@@ -11,6 +11,7 @@ describe('flickr.places.placesForContacts', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.placesForContacts');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.places.placesForTags.js
+++ b/test/flickr.places.placesForTags.js
@@ -23,6 +23,7 @@ describe('flickr.places.placesForTags', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.placesForTags');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.place_type_id, '_');
 	});
 

--- a/test/flickr.places.placesForUser.js
+++ b/test/flickr.places.placesForUser.js
@@ -11,6 +11,7 @@ describe('flickr.places.placesForUser', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.placesForUser');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.places.resolvePlaceId.js
+++ b/test/flickr.places.resolvePlaceId.js
@@ -23,6 +23,7 @@ describe('flickr.places.resolvePlaceId', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.resolvePlaceId');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.place_id, '_');
 	});
 

--- a/test/flickr.places.resolvePlaceURL.js
+++ b/test/flickr.places.resolvePlaceURL.js
@@ -23,6 +23,7 @@ describe('flickr.places.resolvePlaceURL', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.resolvePlaceURL');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.url, '_');
 	});
 

--- a/test/flickr.places.tagsForPlace.js
+++ b/test/flickr.places.tagsForPlace.js
@@ -11,6 +11,7 @@ describe('flickr.places.tagsForPlace', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.places.tagsForPlace');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.prefs.getContentType.js
+++ b/test/flickr.prefs.getContentType.js
@@ -11,6 +11,7 @@ describe('flickr.prefs.getContentType', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.prefs.getContentType');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.prefs.getGeoPerms.js
+++ b/test/flickr.prefs.getGeoPerms.js
@@ -11,6 +11,7 @@ describe('flickr.prefs.getGeoPerms', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.prefs.getGeoPerms');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.prefs.getHidden.js
+++ b/test/flickr.prefs.getHidden.js
@@ -11,6 +11,7 @@ describe('flickr.prefs.getHidden', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.prefs.getHidden');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.prefs.getPrivacy.js
+++ b/test/flickr.prefs.getPrivacy.js
@@ -11,6 +11,7 @@ describe('flickr.prefs.getPrivacy', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.prefs.getPrivacy');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.prefs.getSafetyLevel.js
+++ b/test/flickr.prefs.getSafetyLevel.js
@@ -11,6 +11,7 @@ describe('flickr.prefs.getSafetyLevel', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.prefs.getSafetyLevel');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.profile.getProfile.js
+++ b/test/flickr.profile.getProfile.js
@@ -23,6 +23,7 @@ describe('flickr.profile.getProfile', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.profile.getProfile');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.push.getSubscriptions.js
+++ b/test/flickr.push.getSubscriptions.js
@@ -11,6 +11,7 @@ describe('flickr.push.getSubscriptions', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.push.getSubscriptions');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.push.getTopics.js
+++ b/test/flickr.push.getTopics.js
@@ -11,6 +11,7 @@ describe('flickr.push.getTopics', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.push.getTopics');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.push.subscribe.js
+++ b/test/flickr.push.subscribe.js
@@ -54,6 +54,7 @@ describe('flickr.push.subscribe', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.push.subscribe');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.topic, '_');
 		assert.equal(req.qs.callback, '_');
 		assert.equal(req.qs.verify, '_');

--- a/test/flickr.push.unsubscribe.js
+++ b/test/flickr.push.unsubscribe.js
@@ -54,6 +54,7 @@ describe('flickr.push.unsubscribe', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.push.unsubscribe');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.topic, '_');
 		assert.equal(req.qs.callback, '_');
 		assert.equal(req.qs.verify, '_');

--- a/test/flickr.reflection.getMethodInfo.js
+++ b/test/flickr.reflection.getMethodInfo.js
@@ -23,6 +23,7 @@ describe('flickr.reflection.getMethodInfo', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.reflection.getMethodInfo');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.method_name, '_');
 	});
 

--- a/test/flickr.reflection.getMethods.js
+++ b/test/flickr.reflection.getMethods.js
@@ -11,6 +11,7 @@ describe('flickr.reflection.getMethods', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.reflection.getMethods');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.stats.getCSVFiles.js
+++ b/test/flickr.stats.getCSVFiles.js
@@ -11,6 +11,7 @@ describe('flickr.stats.getCSVFiles', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getCSVFiles');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.stats.getCollectionDomains.js
+++ b/test/flickr.stats.getCollectionDomains.js
@@ -23,6 +23,7 @@ describe('flickr.stats.getCollectionDomains', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getCollectionDomains');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.date, '_');
 	});
 

--- a/test/flickr.stats.getCollectionReferrers.js
+++ b/test/flickr.stats.getCollectionReferrers.js
@@ -38,6 +38,7 @@ describe('flickr.stats.getCollectionReferrers', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getCollectionReferrers');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.date, '_');
 		assert.equal(req.qs.domain, '_');
 	});

--- a/test/flickr.stats.getCollectionStats.js
+++ b/test/flickr.stats.getCollectionStats.js
@@ -38,6 +38,7 @@ describe('flickr.stats.getCollectionStats', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getCollectionStats');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.date, '_');
 		assert.equal(req.qs.collection_id, '_');
 	});

--- a/test/flickr.stats.getPhotoDomains.js
+++ b/test/flickr.stats.getPhotoDomains.js
@@ -23,6 +23,7 @@ describe('flickr.stats.getPhotoDomains', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getPhotoDomains');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.date, '_');
 	});
 

--- a/test/flickr.stats.getPhotoReferrers.js
+++ b/test/flickr.stats.getPhotoReferrers.js
@@ -38,6 +38,7 @@ describe('flickr.stats.getPhotoReferrers', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getPhotoReferrers');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.date, '_');
 		assert.equal(req.qs.domain, '_');
 	});

--- a/test/flickr.stats.getPhotoStats.js
+++ b/test/flickr.stats.getPhotoStats.js
@@ -38,6 +38,7 @@ describe('flickr.stats.getPhotoStats', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getPhotoStats');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.date, '_');
 		assert.equal(req.qs.photo_id, '_');
 	});

--- a/test/flickr.stats.getPhotosetDomains.js
+++ b/test/flickr.stats.getPhotosetDomains.js
@@ -23,6 +23,7 @@ describe('flickr.stats.getPhotosetDomains', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getPhotosetDomains');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.date, '_');
 	});
 

--- a/test/flickr.stats.getPhotosetReferrers.js
+++ b/test/flickr.stats.getPhotosetReferrers.js
@@ -38,6 +38,7 @@ describe('flickr.stats.getPhotosetReferrers', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getPhotosetReferrers');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.date, '_');
 		assert.equal(req.qs.domain, '_');
 	});

--- a/test/flickr.stats.getPhotosetStats.js
+++ b/test/flickr.stats.getPhotosetStats.js
@@ -38,6 +38,7 @@ describe('flickr.stats.getPhotosetStats', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getPhotosetStats');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.date, '_');
 		assert.equal(req.qs.photoset_id, '_');
 	});

--- a/test/flickr.stats.getPhotostreamDomains.js
+++ b/test/flickr.stats.getPhotostreamDomains.js
@@ -23,6 +23,7 @@ describe('flickr.stats.getPhotostreamDomains', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getPhotostreamDomains');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.date, '_');
 	});
 

--- a/test/flickr.stats.getPhotostreamReferrers.js
+++ b/test/flickr.stats.getPhotostreamReferrers.js
@@ -38,6 +38,7 @@ describe('flickr.stats.getPhotostreamReferrers', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getPhotostreamReferrers');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.date, '_');
 		assert.equal(req.qs.domain, '_');
 	});

--- a/test/flickr.stats.getPhotostreamStats.js
+++ b/test/flickr.stats.getPhotostreamStats.js
@@ -23,6 +23,7 @@ describe('flickr.stats.getPhotostreamStats', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getPhotostreamStats');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.date, '_');
 	});
 

--- a/test/flickr.stats.getPopularPhotos.js
+++ b/test/flickr.stats.getPopularPhotos.js
@@ -11,6 +11,7 @@ describe('flickr.stats.getPopularPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getPopularPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.stats.getTotalViews.js
+++ b/test/flickr.stats.getTotalViews.js
@@ -11,6 +11,7 @@ describe('flickr.stats.getTotalViews', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.stats.getTotalViews');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.tags.getClusterPhotos.js
+++ b/test/flickr.tags.getClusterPhotos.js
@@ -38,6 +38,7 @@ describe('flickr.tags.getClusterPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.tags.getClusterPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.tag, '_');
 		assert.equal(req.qs.cluster_id, '_');
 	});

--- a/test/flickr.tags.getClusters.js
+++ b/test/flickr.tags.getClusters.js
@@ -23,6 +23,7 @@ describe('flickr.tags.getClusters', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.tags.getClusters');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.tag, '_');
 	});
 

--- a/test/flickr.tags.getHotList.js
+++ b/test/flickr.tags.getHotList.js
@@ -11,6 +11,7 @@ describe('flickr.tags.getHotList', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.tags.getHotList');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.tags.getListPhoto.js
+++ b/test/flickr.tags.getListPhoto.js
@@ -23,6 +23,7 @@ describe('flickr.tags.getListPhoto', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.tags.getListPhoto');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.photo_id, '_');
 	});
 

--- a/test/flickr.tags.getListUser.js
+++ b/test/flickr.tags.getListUser.js
@@ -11,6 +11,7 @@ describe('flickr.tags.getListUser', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.tags.getListUser');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.tags.getListUserPopular.js
+++ b/test/flickr.tags.getListUserPopular.js
@@ -11,6 +11,7 @@ describe('flickr.tags.getListUserPopular', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.tags.getListUserPopular');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.tags.getListUserRaw.js
+++ b/test/flickr.tags.getListUserRaw.js
@@ -11,6 +11,7 @@ describe('flickr.tags.getListUserRaw', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.tags.getListUserRaw');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.tags.getMostFrequentlyUsed.js
+++ b/test/flickr.tags.getMostFrequentlyUsed.js
@@ -11,6 +11,7 @@ describe('flickr.tags.getMostFrequentlyUsed', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.tags.getMostFrequentlyUsed');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.tags.getRelated.js
+++ b/test/flickr.tags.getRelated.js
@@ -23,6 +23,7 @@ describe('flickr.tags.getRelated', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.tags.getRelated');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.tag, '_');
 	});
 

--- a/test/flickr.test.echo.js
+++ b/test/flickr.test.echo.js
@@ -11,6 +11,7 @@ describe('flickr.test.echo', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.test.echo');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.test.login.js
+++ b/test/flickr.test.login.js
@@ -11,6 +11,7 @@ describe('flickr.test.login', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.test.login');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.test.null.js
+++ b/test/flickr.test.null.js
@@ -11,6 +11,7 @@ describe('flickr.test.null', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.test.null');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.testimonials.addTestimonial.js
+++ b/test/flickr.testimonials.addTestimonial.js
@@ -38,6 +38,7 @@ describe('flickr.testimonials.addTestimonial', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.testimonials.addTestimonial');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 		assert.equal(req.qs.testimonial_text, '_');
 	});

--- a/test/flickr.testimonials.approveTestimonial.js
+++ b/test/flickr.testimonials.approveTestimonial.js
@@ -23,6 +23,7 @@ describe('flickr.testimonials.approveTestimonial', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.testimonials.approveTestimonial');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.testimonial_id, '_');
 	});
 

--- a/test/flickr.testimonials.deleteTestimonial.js
+++ b/test/flickr.testimonials.deleteTestimonial.js
@@ -23,6 +23,7 @@ describe('flickr.testimonials.deleteTestimonial', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.testimonials.deleteTestimonial');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.testimonial_id, '_');
 	});
 

--- a/test/flickr.testimonials.editTestimonial.js
+++ b/test/flickr.testimonials.editTestimonial.js
@@ -54,6 +54,7 @@ describe('flickr.testimonials.editTestimonial', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.testimonials.editTestimonial');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 		assert.equal(req.qs.testimonial_id, '_');
 		assert.equal(req.qs.testimonial_text, '_');

--- a/test/flickr.testimonials.getAllTestimonialsAbout.js
+++ b/test/flickr.testimonials.getAllTestimonialsAbout.js
@@ -11,6 +11,7 @@ describe('flickr.testimonials.getAllTestimonialsAbout', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.testimonials.getAllTestimonialsAbout');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.testimonials.getAllTestimonialsAboutBy.js
+++ b/test/flickr.testimonials.getAllTestimonialsAboutBy.js
@@ -23,6 +23,7 @@ describe('flickr.testimonials.getAllTestimonialsAboutBy', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.testimonials.getAllTestimonialsAboutBy');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.testimonials.getAllTestimonialsBy.js
+++ b/test/flickr.testimonials.getAllTestimonialsBy.js
@@ -11,6 +11,7 @@ describe('flickr.testimonials.getAllTestimonialsBy', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.testimonials.getAllTestimonialsBy');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.testimonials.getPendingTestimonialsAbout.js
+++ b/test/flickr.testimonials.getPendingTestimonialsAbout.js
@@ -11,6 +11,7 @@ describe('flickr.testimonials.getPendingTestimonialsAbout', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.testimonials.getPendingTestimonialsAbout');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.testimonials.getPendingTestimonialsAboutBy.js
+++ b/test/flickr.testimonials.getPendingTestimonialsAboutBy.js
@@ -23,6 +23,7 @@ describe('flickr.testimonials.getPendingTestimonialsAboutBy', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.testimonials.getPendingTestimonialsAboutBy');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.testimonials.getPendingTestimonialsBy.js
+++ b/test/flickr.testimonials.getPendingTestimonialsBy.js
@@ -11,6 +11,7 @@ describe('flickr.testimonials.getPendingTestimonialsBy', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.testimonials.getPendingTestimonialsBy');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.testimonials.getTestimonialsAbout.js
+++ b/test/flickr.testimonials.getTestimonialsAbout.js
@@ -23,6 +23,7 @@ describe('flickr.testimonials.getTestimonialsAbout', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.testimonials.getTestimonialsAbout');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.testimonials.getTestimonialsAboutBy.js
+++ b/test/flickr.testimonials.getTestimonialsAboutBy.js
@@ -23,6 +23,7 @@ describe('flickr.testimonials.getTestimonialsAboutBy', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.testimonials.getTestimonialsAboutBy');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.testimonials.getTestimonialsBy.js
+++ b/test/flickr.testimonials.getTestimonialsBy.js
@@ -23,6 +23,7 @@ describe('flickr.testimonials.getTestimonialsBy', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.testimonials.getTestimonialsBy');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.user_id, '_');
 	});
 

--- a/test/flickr.urls.getGroup.js
+++ b/test/flickr.urls.getGroup.js
@@ -23,6 +23,7 @@ describe('flickr.urls.getGroup', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.urls.getGroup');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.group_id, '_');
 	});
 

--- a/test/flickr.urls.getUserPhotos.js
+++ b/test/flickr.urls.getUserPhotos.js
@@ -11,6 +11,7 @@ describe('flickr.urls.getUserPhotos', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.urls.getUserPhotos');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.urls.getUserProfile.js
+++ b/test/flickr.urls.getUserProfile.js
@@ -11,6 +11,7 @@ describe('flickr.urls.getUserProfile', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.urls.getUserProfile');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 	});
 
 });

--- a/test/flickr.urls.lookupGallery.js
+++ b/test/flickr.urls.lookupGallery.js
@@ -23,6 +23,7 @@ describe('flickr.urls.lookupGallery', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.urls.lookupGallery');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.url, '_');
 	});
 

--- a/test/flickr.urls.lookupGroup.js
+++ b/test/flickr.urls.lookupGroup.js
@@ -23,6 +23,7 @@ describe('flickr.urls.lookupGroup', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.urls.lookupGroup');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.url, '_');
 	});
 

--- a/test/flickr.urls.lookupUser.js
+++ b/test/flickr.urls.lookupUser.js
@@ -23,6 +23,7 @@ describe('flickr.urls.lookupUser', function () {
 		assert.equal(req.qs.format, 'json');
 		assert.equal(req.qs.nojsoncallback, '1');
 		assert.equal(req.qs.method, 'flickr.urls.lookupUser');
+		assert.equal(req.header['Content-Type'], 'text/plain');
 		assert.equal(req.qs.url, '_');
 	});
 


### PR DESCRIPTION
As demonstrated in #111, the API rejects CORS preflight requests because we're requesting content-type application/json. This is technically incorrect (for the Flickr API) because we're using a query param for the content type (format) instead of the content-type header. So, the Flickr Way™ is to request text/plain and get back application/json.