### PR TITLE
Dedupe extras if passed as a string, array, or set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-Nothing yet!
+- [#122] Dedupe items in the "extras" param if passed as a string, array, or set.
 
 ## [v3.7.0] - 2018-02-14
 
@@ -186,6 +186,7 @@ This "release" marks the start of a complete rewrite of the Flickr SDK. Once the
 [#118]: https://github.com/flickr/flickr-sdk/pull/118
 [#119]: https://github.com/flickr/flickr-sdk/pull/119
 [#121]: https://github.com/flickr/flickr-sdk/pull/121
+[#122]: https://github.com/flickr/flickr-sdk/pull/122
 
 <!-- other links -->
 

--- a/script/build-rest.ejs
+++ b/script/build-rest.ejs
@@ -22,6 +22,28 @@ function createAPIKeyPlugin(str) {
 }
 
 /**
+ * Dedupes an array, set, or string of extras and returns
+ * a comma separated version of it
+ * @param {String|Array|Set} extras
+ * @returns {Function}
+ * @private
+ */
+
+function processExtras(extras) {
+	if (typeof extras === 'string') {
+		extras = extras.split(',');
+	}
+
+	if (Array.isArray(extras)) {
+		extras = new Set(extras);
+	}
+
+	if (extras instanceof Set) {
+		return Array.from(extras).join(',');
+	}
+}
+
+/**
  * Creates a new Flickr API client. This "client" is a factory
  * method that creates a new superagent request pre-configured
  * for talking to the Flickr API. You must pass an "auth"
@@ -53,13 +75,8 @@ function createClient(auth, opts) {
 			args = {};
 		}
 
-		// the API expects the "extras" param to be a
-		// comma-separated list, so if we are given an
-		// array we should join it
-		if (Array.isArray(args.extras)) {
-			args.extras = args.extras.join(',');
-		} else if (args.extras instanceof Set) {
-			args.extras = Array.from(args.extras).join(',');
+		if (args.extras) {
+			args.extras = processExtras(args.extras);
 		}
 
 		return request(verb, 'https://' + host + '/services/rest')

--- a/script/build-rest.ejs
+++ b/script/build-rest.ejs
@@ -30,6 +30,14 @@ function createAPIKeyPlugin(str) {
  */
 
 function processExtras(extras) {
+	if (
+		typeof extras !== 'string' &&
+		!Array.isArray(extras) &&
+		!(extras instanceof Set)
+	) {
+		throw new Error('Invalid type for argument "extras"');
+	}
+
 	if (typeof extras === 'string') {
 		extras = extras.split(',');
 	}

--- a/test/services.rest.js
+++ b/test/services.rest.js
@@ -171,4 +171,13 @@ describe('services/rest', function () {
 		assert.equal(url.query.extras, 'foo,bar,baz');
 	});
 
+	it('throws if "extras" as an invalid type', function () {
+
+		assert.throws(function () {
+			subject._('GET', 'flickr.test.echo', {
+				extras: { wat: 'NaNNaNNaNNaNNaNNaNNaN Batman!' }
+			}).request();
+		}, 'Invalid type for argument "extras"');
+	});
+
 });

--- a/test/services.rest.js
+++ b/test/services.rest.js
@@ -94,6 +94,32 @@ describe('services/rest', function () {
 		assert.equal(url.query.api_key, 'abcd1234');
 	});
 
+	it('supports "extras" if passed as an string', function () {
+		var req = subject._('GET', 'flickr.test.echo', {
+			extras: 'foo,bar,baz'
+		}).request();
+
+		var url = parse(req.path, true);
+
+		assert.equal(url.query.method, 'flickr.test.echo');
+		assert.equal(url.query.format, 'json');
+		assert.equal(url.query.nojsoncallback, '1');
+		assert.equal(url.query.extras, 'foo,bar,baz');
+	});
+
+	it('dedupes "extras" if passed as an string', function () {
+		var req = subject._('GET', 'flickr.test.echo', {
+			extras: 'foo,bar,foo'
+		}).request();
+
+		var url = parse(req.path, true);
+
+		assert.equal(url.query.method, 'flickr.test.echo');
+		assert.equal(url.query.format, 'json');
+		assert.equal(url.query.nojsoncallback, '1');
+		assert.equal(url.query.extras, 'foo,bar');
+	});
+
 	it('joins "extras" if passed as an array', function () {
 		var req = subject._('GET', 'flickr.test.echo', {
 			extras: [
@@ -109,6 +135,23 @@ describe('services/rest', function () {
 		assert.equal(url.query.format, 'json');
 		assert.equal(url.query.nojsoncallback, '1');
 		assert.equal(url.query.extras, 'foo,bar,baz');
+	});
+
+	it('dedupes "extras" if passed as an array', function () {
+		var req = subject._('GET', 'flickr.test.echo', {
+			extras: [
+				'foo',
+				'foo',
+				'bar'
+			]
+		}).request();
+
+		var url = parse(req.path, true);
+
+		assert.equal(url.query.method, 'flickr.test.echo');
+		assert.equal(url.query.format, 'json');
+		assert.equal(url.query.nojsoncallback, '1');
+		assert.equal(url.query.extras, 'foo,bar');
 	});
 
 	it('joins "extras" if passed as a set', function () {


### PR DESCRIPTION
This will ensure that no matter what’s passed, the list of extras will be guaranteed to have unique keys.