### PR TITLE
Clean undefined oauth params from the base string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 - [#122] Dedupe items in the "extras" param if passed as a string, array, or set. ([@pdokas])
+- [#129] Clean `undefined` oauth params from the base string. ([@jeremyruppel])
 
 ## [v3.7.0] - 2018-02-14
 
@@ -187,6 +188,7 @@ This "release" marks the start of a complete rewrite of the Flickr SDK. Once the
 [#119]: https://github.com/flickr/flickr-sdk/pull/119
 [#121]: https://github.com/flickr/flickr-sdk/pull/121
 [#122]: https://github.com/flickr/flickr-sdk/pull/122
+[#129]: https://github.com/flickr/flickr-sdk/pull/129
 
 <!-- other links -->
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -85,6 +85,24 @@ function sortParams(obj) {
 }
 
 /**
+ * Returns a copy of `obj` with all undefined key/value pairs removed.
+ * @param {Object} obj
+ * @returns {Object}
+ */
+
+function cleanParams(obj) {
+	var tmp = {};
+
+	Object.keys(obj).forEach(function (key) {
+		if (typeof obj[key] !== 'undefined') {
+			tmp[key] = obj[key];
+		}
+	});
+
+	return tmp;
+}
+
+/**
  * @constructor
  * @param {String} consumerKey The application's API key
  * @param {String} consumerSecret The application's API secret
@@ -174,7 +192,7 @@ OAuth.prototype.signingKey = function (tokenSecret) {
  */
 
 OAuth.prototype.baseString = function (method, url, params) {
-	return join([ method, url, sortParams(params) ]);
+	return join([ method, url, sortParams(cleanParams(params)) ]);
 };
 
 /**

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -114,6 +114,16 @@ describe('oauth', function () {
 			);
 		});
 
+		it('cleans undefined params', function () {
+			assert.equal(
+				subject.baseString('GET', 'http://www.example.com', {
+					foo: '123',
+					bar: undefined // should be removed
+				}),
+				'GET&http%3A%2F%2Fwww.example.com&foo%3D123'
+			);
+		});
+
 	});
 
 	describe('#signature', function () {


### PR DESCRIPTION
This matches [the way `qs` handles `undefined` values](https://github.com/ljharb/qs/blob/master/test/stringify.js#L297-L304) and prevents a signature mismatch if one is passed to our request.