### PR TITLE
Add support for overriding a port when making a rest request

### DIFF
--- a/script/build-rest.ejs
+++ b/script/build-rest.ejs
@@ -63,7 +63,7 @@ function processExtras(extras) {
  */
 
 function createClient(auth, opts) {
-	var host;
+	var host, port;
 
 	// allow passing just an api key instead of a function
 	if (typeof auth === 'string') {
@@ -77,6 +77,7 @@ function createClient(auth, opts) {
 	// options
 	opts = opts || {};
 	host = opts.host || 'api.flickr.com';
+	port = opts.port || '443';
 
 	return function (verb, method, args) {
 		if (typeof args === 'undefined') {
@@ -87,7 +88,7 @@ function createClient(auth, opts) {
 			args.extras = processExtras(args.extras);
 		}
 
-		return request(verb, 'https://' + host + '/services/rest')
+		return request(verb, 'https://' + host + ':' + port + '/services/rest')
 			.query({ method: method })
 			.query(args)
 			.use(json)

--- a/script/build-rest.ejs
+++ b/script/build-rest.ejs
@@ -63,7 +63,7 @@ function processExtras(extras) {
  */
 
 function createClient(auth, opts) {
-	var host, port;
+	var host;
 
 	// allow passing just an api key instead of a function
 	if (typeof auth === 'string') {
@@ -77,7 +77,10 @@ function createClient(auth, opts) {
 	// options
 	opts = opts || {};
 	host = opts.host || 'api.flickr.com';
-	port = opts.port || '443';
+
+	if (opts.port) {
+		host += ':' + opts.port;
+	}
 
 	return function (verb, method, args) {
 		if (typeof args === 'undefined') {
@@ -88,7 +91,7 @@ function createClient(auth, opts) {
 			args.extras = processExtras(args.extras);
 		}
 
-		return request(verb, 'https://' + host + ':' + port + '/services/rest')
+		return request(verb, 'https://' + host + '/services/rest')
 			.query({ method: method })
 			.query(args)
 			.use(json)

--- a/test/services.rest.js
+++ b/test/services.rest.js
@@ -50,6 +50,19 @@ describe('services/rest', function () {
 		assert.equal(url.host, 'www.flickr.com');
 	});
 
+	it('can provide the port as an option', function () {
+		var req, url;
+
+		subject = new Subject(auth, {
+			port: '3337'
+		});
+
+		req = subject._('GET', 'flickr.test.echo');
+		url = parse(req.url);
+
+		assert.equal(url.port, '3337');
+	});
+
 	it('uses the correct path', function () {
 		var req = subject._('GET', 'flickr.test.echo');
 		var url = parse(req.url);
@@ -62,6 +75,13 @@ describe('services/rest', function () {
 		var url = parse(req.url);
 
 		assert.equal(url.host, 'api.flickr.com');
+	});
+
+	it('defaults to port 443', function () {
+		var req = subject._('GET', 'flickr.test.echo');
+		var url = parse(req.url);
+
+		assert.equal(url.port, '443');
 	});
 
 	it('adds default query string arguments', function () {

--- a/test/services.rest.js
+++ b/test/services.rest.js
@@ -77,13 +77,6 @@ describe('services/rest', function () {
 		assert.equal(url.host, 'api.flickr.com');
 	});
 
-	it('defaults to port 443', function () {
-		var req = subject._('GET', 'flickr.test.echo');
-		var url = parse(req.url);
-
-		assert.equal(url.port, '443');
-	});
-
 	it('adds default query string arguments', function () {
 		var req = subject._('GET', 'flickr.test.echo').request();
 		var url = parse(req.path, true);


### PR DESCRIPTION
host override was already supported.  simple change to also allow port
override.

when no port is provided, defaults to 443.