### PR TITLE
Make "group_id" optional

### DIFF
--- a/src/flickr.groups.getInfo.json
+++ b/src/flickr.groups.getInfo.json
@@ -11,7 +11,7 @@
       },
       {
         "name": "group_id",
-        "optional": "0"
+        "optional": "1"
       },
       {
         "name": "group_path_alias",


### PR DESCRIPTION
`group_id` is optional because either it or `group_path_alias` is required:

> `group_path_alias`: The path alias of the group. One of this or the group_id param is required