### PR TITLE
Explicitly buffer xml responses

### DIFF
--- a/plugins/xml.js
+++ b/plugins/xml.js
@@ -58,5 +58,6 @@ function parseXML(res, fn) {
  */
 
 module.exports = function (req) {
+	req.buffer(true);
 	req.parse(parseXML);
 };


### PR DESCRIPTION
We need to explicitly tell superagent which buffering strategy to use for xml responses. This fixes a warning introduced in #144.