### PR TITLE
Set default `user-agent`

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -5,6 +5,7 @@
 
 var request = require('superagent');
 var parse = require('querystring').parse;
+var version = require('../package.json').version;
 
 /**
  * Subclass superagent's Request class so that we can add
@@ -19,6 +20,9 @@ function Request(method, url) {
 
 	// keep track of all request params for oauth signing
 	this.params = {};
+
+	// superagent no longer sets a default user agent header
+	this.set('user-agent', 'flickr-sdk/' + version);
 }
 
 Request.prototype = Object.create(request.Request.prototype);

--- a/test/request.js
+++ b/test/request.js
@@ -13,6 +13,14 @@ describe('lib/request', function () {
 		assert(subject('GET', 'http://www.example.com') instanceof Request);
 	});
 
+	it('has a default user agent', function () {
+		const req = subject('GET', 'http://www.example.com');
+
+		assert.strictEqual(req.get('user-agent'),
+			'flickr-sdk/' + process.env.npm_package_version
+		);
+	});
+
 	it('supports request(url, callback)', function () {
 		var end = sinon.stub(subject.Request.prototype, 'end').returnsThis();
 		var spy = sinon.spy();

--- a/test/services.feeds.js
+++ b/test/services.feeds.js
@@ -18,11 +18,12 @@ describe('services/feeds', function () {
 		assert(subject._('photos_public') instanceof Request);
 	});
 
-	/*
-		TODO user-agent
-	*/
+	it('adds default request headers', function () {
+		const req = subject._('photos_public');
 
-	it('adds default request headers');
+		assert.strictEqual(req.get('user-agent'),
+			'flickr-sdk/' + process.env.npm_package_version);
+	});
 
 	it('uses the correct path', function () {
 		var req = subject._('photos_public');

--- a/test/services.replace.js
+++ b/test/services.replace.js
@@ -34,11 +34,12 @@ describe('services/replace', function () {
 		});
 	});
 
-	/*
-		TODO user-agent
-	*/
+	it('adds default request headers', function () {
+		const req = new Subject(auth, 41234567890);
 
-	it('adds default request headers');
+		assert.strictEqual(req.get('user-agent'),
+			'flickr-sdk/' + process.env.npm_package_version);
+	});
 
 	it('uses the correct method', function () {
 		var req = new Subject(auth, 41234567890);

--- a/test/services.upload.js
+++ b/test/services.upload.js
@@ -28,11 +28,12 @@ describe('services/upload', function () {
 		});
 	});
 
-	/*
-		TODO user-agent
-	*/
+	it('adds default request headers', function () {
+		const req = new Subject(auth, 41234567890);
 
-	it('adds default request headers');
+		assert.strictEqual(req.get('user-agent'),
+			'flickr-sdk/' + process.env.npm_package_version);
+	});
 
 	it('uses the correct method', function () {
 		var req = new Subject(auth);


### PR DESCRIPTION
[Flickr is about to require a user-agent header on API calls](https://www.flickr.com/groups/api/discuss/72157721918374433/). superagent used to set this by default, but this was removed in ladjs/superagent#1495. This ensures we set a user-agent in our Request base.