### PR TITLE
Upgrade xml2js. Fixes #158

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "superagent": "^6.1.0",
-    "xml2js": "^0.4.17"
+    "xml2js": "^0.5.0"
   },
   "bugs": {
     "url": "https://github.com/flickr/flickr-sdk/issues"


### PR DESCRIPTION
This xml2js release contains a security fix for prototype pollution