### PR TITLE
fix: remove disallowed `user-agent` request header

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -20,9 +20,6 @@ function Request(method, url) {
 
 	// keep track of all request params for oauth signing
 	this.params = {};
-
-	// superagent no longer sets a default user agent header
-	this.set('user-agent', 'flickr-sdk/' + version);
 }
 
 Request.prototype = Object.create(request.Request.prototype);

--- a/test/request.js
+++ b/test/request.js
@@ -13,14 +13,6 @@ describe('lib/request', function () {
 		assert(subject('GET', 'http://www.example.com') instanceof Request);
 	});
 
-	it('has a default user agent', function () {
-		const req = subject('GET', 'http://www.example.com');
-
-		assert.strictEqual(req.get('user-agent'),
-			'flickr-sdk/' + process.env.npm_package_version
-		);
-	});
-
 	it('supports request(url, callback)', function () {
 		var end = sinon.stub(subject.Request.prototype, 'end').returnsThis();
 		var spy = sinon.spy();

--- a/test/services.feeds.js
+++ b/test/services.feeds.js
@@ -18,13 +18,6 @@ describe('services/feeds', function () {
 		assert(subject._('photos_public') instanceof Request);
 	});
 
-	it('adds default request headers', function () {
-		const req = subject._('photos_public');
-
-		assert.strictEqual(req.get('user-agent'),
-			'flickr-sdk/' + process.env.npm_package_version);
-	});
-
 	it('uses the correct path', function () {
 		var req = subject._('photos_public');
 		var url = parse(req.url);

--- a/test/services.replace.js
+++ b/test/services.replace.js
@@ -34,13 +34,6 @@ describe('services/replace', function () {
 		});
 	});
 
-	it('adds default request headers', function () {
-		const req = new Subject(auth, 41234567890);
-
-		assert.strictEqual(req.get('user-agent'),
-			'flickr-sdk/' + process.env.npm_package_version);
-	});
-
 	it('uses the correct method', function () {
 		var req = new Subject(auth, 41234567890);
 

--- a/test/services.upload.js
+++ b/test/services.upload.js
@@ -28,13 +28,6 @@ describe('services/upload', function () {
 		});
 	});
 
-	it('adds default request headers', function () {
-		const req = new Subject(auth, 41234567890);
-
-		assert.strictEqual(req.get('user-agent'),
-			'flickr-sdk/' + process.env.npm_package_version);
-	});
-
 	it('uses the correct method', function () {
 		var req = new Subject(auth);
 


### PR DESCRIPTION
despite the API change mentioned in #157, it looks like the flickr API did not go through with the change: https://www.flickr.com/groups/51035612836@N01/discuss/72157721918374433/72157721918410230.

unfortunately they also did not include `user-agent` as an allowed header, and setting it here results in CORS errors, e.g.

```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://api.flickr.com/services/[...]. (Reason: header ‘user-agent’ is not allowed according to header ‘Access-Control-Allow-Headers’ from CORS preflight response).
```