### PR TITLE
fix: correct `tsc` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build-types": "node script/build-types > flickr-sdk.d.ts && npm run tsc",
     "build-client": "browserify -s Flickr $npm_package_main > flickr-sdk.js",
     "build": "npm run build-rest && npm run build-docs && npm run build-types && npm run build-client",
-    "tsc": "npx tsc",
+    "tsc": "npx -p typescript@5.x -c tsc",
     "lint": "eslint .",
     "test": "mocha",
     "coverage": "nyc mocha",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build-types": "node script/build-types > flickr-sdk.d.ts && npm run tsc",
     "build-client": "browserify -s Flickr $npm_package_main > flickr-sdk.js",
     "build": "npm run build-rest && npm run build-docs && npm run build-types && npm run build-client",
-    "tsc": "npx -p typescript@5.x -c tsc",
+    "tsc": "npx -p typescript@4.x -c tsc",
     "lint": "eslint .",
     "test": "mocha",
     "coverage": "nyc mocha",


### PR DESCRIPTION
the typecheck script here is using `npx` in order to run `tsc`, but this may attempt to install and run `tsc`, which is actually a [separate npm package](https://www.npmjs.com/package/tsc) that will just warn you to install `typescript` instead.