### PR TITLE
Return json response on error

### DIFF
--- a/src/services/rest/index.ts
+++ b/src/services/rest/index.ts
@@ -43,7 +43,7 @@ export class FlickrService {
     if (json.stat === "fail") {
       // @ts-expect-error
       throw new Error(json.message, {
-        cause: res,
+        cause: json,
       })
     }
 


### PR DESCRIPTION
Once we parse the `res` response with `const json = await parser.parse(res)` it cannot be parsed again. So we must return the JSON response to be able to understand the issue we are facing. Get the `error` or `stat`