### PR TITLE
Improve MockTransport

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ const res = await flickr.test.login()
 console.log(res.body)
 
 // new
-const body = await flickr('flickr.test.login')
+const body = await flickr('flickr.test.login', {})
 console.log(body)
 ```
 
@@ -116,6 +116,7 @@ import * as assert from 'node:assert'
 // mock transport returns the response you pass in the constructor
 const transport = new MockTransport({
     stat: 'ok',
+    foo: 'bar'
 })
 
 // null auth does nothing

--- a/src/transport/mock.ts
+++ b/src/transport/mock.ts
@@ -1,18 +1,29 @@
 import { Transport } from "../types"
 
 export class MockTransport implements Transport {
-  private response: string
+  private responses: string[] = []
 
-  constructor(response: any) {
-    this.response =
+  constructor(response?: string) {
+    if (response) {
+      this.addMock(response)
+    }
+  }
+
+  reset():void {
+    this.responses = []
+  }
+
+  addMock(response: string): void {
+    const stringResponse =
       typeof response === "string" ? response : JSON.stringify(response)
+    this.responses.push(stringResponse)
   }
 
   async get(): Promise<Response> {
-    return new Response(this.response)
+    return new Response(this.responses.shift())
   }
 
   async post(): Promise<Response> {
-    return new Response(this.response)
+    return new Response(this.responses.shift())
   }
 }


### PR DESCRIPTION
**Readme updates**

1. Right now params are mandatory even if empty or not needed ( like `flickr.test.login` case ). Not sure if that is the intended case.
2. Missing response part.

**MockTransport update**

The test example is just a happy example with almost no real use case when testing another app using this package. A more likelihood scenario would be that we can require multiple queries on the same test. The current implementation of the MockTransport does not allow this. The proposal should be backwards compatible while allowing to add multiple responses to the MockTransport and returning once each time in the same order they have been added.

Example:
```
const transport = new MockTransport(`oauth_token=token&oauth_token_secret=secret&user_nsid=${flickrId}`)
transport.addMock({
    person: {
      username: { _content: 'Username' },
      ispro: 1,
    },
    stat: 'ok',
  })

  FetchTransport.mockImplementationOnce(() => transport)
```