### PR TITLE
Update oauth.ts

### DIFF
--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -40,13 +40,15 @@ export class OAuthService {
     const res = await this.transport.get(url, params)
     const parser = new FormParser()
 
-    const { user_nsid, oauth_token, oauth_token_secret } =
+    const { user_nsid, oauth_token, oauth_token_secret, fullname, username } =
       await parser.parse(res)
 
     return {
       nsid: user_nsid,
       oauthToken: oauth_token,
       oauthTokenSecret: oauth_token_secret,
+      fullname: fullname,
+      username: username
     }
   }
 


### PR DESCRIPTION
The OAuth verifier returns 5 fields, but only 3 are currently being parsed and returned. This PR proposes returning all 5.

From: https://www.flickr.com/services/api/auth.oauth.html

> Flickr returns a response similar to the following:
> 
> fullname=Jamal%20Fanaian
> &oauth_token=72157626318069415-087bfc7b5816092c
> &oauth_token_secret=a202d1f853ec69de
> &user_nsid=21207597%40N07
> &username=jamalfanaian