### PR TITLE
Replace `jest` with `node:test`

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,8 +1,0 @@
-/** @type {import('jest').Config} */
-const config = {
-  transform: {
-    "^.+\\.tsx?$": "esbuild-jest",
-  },
-}
-
-export default config

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "build-cjs": "esbuild --bundle --outfile=dist/index.cjs --platform=node --format=cjs src/index.ts",
     "build-esm": "esbuild --bundle --outfile=dist/index.mjs --platform=node --format=esm src/index.ts",
     "build-browser": "esbuild --bundle --outfile=dist/index.js --format=esm src/index.ts",
-    "test": "jest"
+    "test": "node --import tsx --test test/*.ts"
   },
   "repository": {
     "type": "git",
@@ -67,16 +67,14 @@
   },
   "homepage": "https://github.com/flickr/flickr-sdk#readme",
   "devDependencies": {
-    "@jest/globals": "^29.7.0",
     "@types/node": "^20.8.4",
     "esbuild": "^0.19.4",
-    "esbuild-jest": "^0.5.0",
     "flickr-sdk": "file:.",
-    "jest": "^29.7.0",
     "min-qs": "^1.4.0",
     "min-url": "^1.5.0",
     "prettier": "^3.0.3",
     "stringlist-regexp": "^1.0.2",
+    "tsx": "^4.20.3",
     "typescript": "^5.2.2"
   },
   "dependencies": {

--- a/test/auth.api_key.ts
+++ b/test/auth.api_key.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@jest/globals"
+import { describe, it } from "node:test"
 import * as assert from "node:assert"
 import { APIKeyAuth } from "flickr-sdk"
 

--- a/test/auth.oauth.ts
+++ b/test/auth.oauth.ts
@@ -1,4 +1,4 @@
-import { jest, describe, it } from "@jest/globals"
+import { describe, it, mock } from "node:test"
 import * as assert from "node:assert"
 import { OAuthAuth } from "flickr-sdk"
 
@@ -77,21 +77,19 @@ describe("auth/oauth", function () {
         "oauth token secret",
       )
 
-      jest
-        .spyOn(
+      mock.method(
           // @ts-expect-error
           auth.oauth,
           "timestamp",
+          () => "499166400"
         )
-        .mockReturnValue("499166400")
 
-      jest
-        .spyOn(
+      mock.method(
           // @ts-expect-error
           auth.oauth,
           "nonce",
+          () => "p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k="
         )
-        .mockReturnValue("p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k=")
 
       const params = new Map()
 

--- a/test/flickr.ts
+++ b/test/flickr.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@jest/globals"
+import { describe, it } from "node:test"
 import * as assert from "node:assert"
 import { createFlickr } from "flickr-sdk"
 

--- a/test/oauth.ts
+++ b/test/oauth.ts
@@ -1,4 +1,4 @@
-import { jest, describe, it, beforeEach } from "@jest/globals"
+import { describe, it, beforeEach, mock } from "node:test"
 import * as assert from "node:assert"
 import { OAuth } from "flickr-sdk"
 
@@ -7,11 +7,13 @@ describe("OAuth", function () {
 
   beforeEach(function () {
     oauth = new OAuth("consumer key", "consumer secret")
-    jest.spyOn(oauth, "timestamp").mockReturnValue("499166400")
+    mock.method(oauth, "timestamp", () => "499166400")
 
-    jest
-      .spyOn(oauth, "nonce")
-      .mockReturnValue("p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k=")
+    mock.method(
+      oauth,
+      "nonce",
+      () => "p2m2bnHdXVIsQH0FUv0oN9XrJU57ak7dSSpHU36mn4k=",
+    )
   })
 
   it('requires "consumerKey" and "consumerSecret"', function () {
@@ -44,7 +46,7 @@ describe("OAuth", function () {
 
   describe("#timestamp", function () {
     beforeEach(function () {
-      jest.restoreAllMocks()
+      mock.restoreAll()
     })
 
     it("returns the current system time in seconds", function () {
@@ -54,7 +56,7 @@ describe("OAuth", function () {
 
   describe("#nonce", function () {
     beforeEach(function () {
-      jest.restoreAllMocks()
+      mock.restoreAll()
     })
 
     it("returns a string", function () {

--- a/test/params.ts
+++ b/test/params.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@jest/globals"
+import { describe, it } from "node:test"
 import * as assert from "node:assert"
 import { GET, POST } from "flickr-sdk"
 

--- a/test/parser.form.ts
+++ b/test/parser.form.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@jest/globals"
+import { describe, it } from "node:test"
 import * as assert from "node:assert"
 import { FormParser } from "flickr-sdk"
 

--- a/test/parser.json.ts
+++ b/test/parser.json.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@jest/globals"
+import { describe, it } from "node:test"
 import * as assert from "node:assert"
 import { JSONParser } from "flickr-sdk"
 

--- a/test/parser.xml.ts
+++ b/test/parser.xml.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@jest/globals"
+import { describe, it } from "node:test"
 import * as assert from "node:assert"
 import { XMLParser } from "flickr-sdk"
 

--- a/test/services.oauth.ts
+++ b/test/services.oauth.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@jest/globals"
+import { describe, it } from "node:test"
 import { MockTransport, NullAuth, OAuthService } from "flickr-sdk"
 import * as assert from "node:assert"
 

--- a/test/services.replace.ts
+++ b/test/services.replace.ts
@@ -1,10 +1,10 @@
-import { describe, it } from "@jest/globals"
+import { describe, it } from "node:test"
 import * as assert from "node:assert"
-import { MockTransport, NullAuth, UploadService } from "flickr-sdk"
+import { ReplaceService, NullAuth, MockTransport } from "flickr-sdk"
 
-describe("UploadService", function () {
-  describe(".upload", function () {
-    it("uploads a photo", async function () {
+describe("ReplaceService", function () {
+  describe(".replace", function () {
+    it("replaces a photo", async function () {
       const transport = new MockTransport(
         `<?xml version="1.0" encoding="utf-8" ?>
 <rsp stat="ok">
@@ -14,13 +14,11 @@ describe("UploadService", function () {
 
       const auth = new NullAuth()
 
-      const service = new UploadService(transport, auth)
+      const service = new ReplaceService(transport, auth)
 
       const file = new Blob([])
 
-      const res = await service.upload(file, {
-        title: "test",
-      })
+      const res = await service.replace("1234", file)
 
       assert.strictEqual(res.id, "1234")
       assert.strictEqual(res.secret, "abcdef")
@@ -37,11 +35,11 @@ describe("UploadService", function () {
 
       const auth = new NullAuth()
 
-      const service = new UploadService(transport, auth)
+      const service = new ReplaceService(transport, auth)
 
-      const file = new Blob(["big ol jpeg"])
+      const file = new Blob([])
 
-      await assert.rejects(() => service.upload(file), {
+      await assert.rejects(() => service.replace("1234", file), {
         name: "Error",
         message: "Invalid API Key (Key has invalid format)",
       })

--- a/test/services.rest.ts
+++ b/test/services.rest.ts
@@ -1,4 +1,4 @@
-import { jest, describe, it } from "@jest/globals"
+import { describe, it, mock } from "node:test"
 import * as assert from "node:assert"
 import { FlickrService, MockTransport, NullAuth } from "flickr-sdk"
 
@@ -44,12 +44,12 @@ describe("FlickrService", function () {
         stat: "ok",
       })
 
-      const get = jest.spyOn(transport, "get")
+      const get = mock.method(transport, "get")
 
       const service = new FlickrService(transport, auth)
       await service.call("flickr.test.echo", { foo: "bar" })
 
-      assert.strictEqual(get.mock.calls.length, 1)
+      assert.strictEqual(get.mock.callCount(), 1)
     })
 
     it("makes a POST request for a write method", async function () {
@@ -59,12 +59,12 @@ describe("FlickrService", function () {
         stat: "ok",
       })
 
-      const post = jest.spyOn(transport, "post")
+      const post = mock.method(transport, "post")
 
       const service = new FlickrService(transport, auth)
       await service.call("flickr.photosets.editPhotos", { foo: "bar" })
 
-      assert.strictEqual(post.mock.calls.length, 1)
+      assert.strictEqual(post.mock.callCount(), 1)
     })
 
     it("makes a POST request for a delete method", async function () {
@@ -73,12 +73,12 @@ describe("FlickrService", function () {
         stat: "ok",
       })
 
-      const post = jest.spyOn(transport, "post")
+      const post = mock.method(transport, "post")
 
       const service = new FlickrService(transport, auth)
       await service.call("flickr.photosets.delete", { foo: "bar" })
 
-      assert.strictEqual(post.mock.calls.length, 1)
+      assert.strictEqual(post.mock.callCount(), 1)
     })
   })
 })

--- a/test/services.upload.ts
+++ b/test/services.upload.ts
@@ -1,10 +1,10 @@
-import { describe, it } from "@jest/globals"
+import { describe, it } from "node:test"
 import * as assert from "node:assert"
-import { ReplaceService, NullAuth, MockTransport } from "flickr-sdk"
+import { MockTransport, NullAuth, UploadService } from "flickr-sdk"
 
-describe("ReplaceService", function () {
-  describe(".replace", function () {
-    it("replaces a photo", async function () {
+describe("UploadService", function () {
+  describe(".upload", function () {
+    it("uploads a photo", async function () {
       const transport = new MockTransport(
         `<?xml version="1.0" encoding="utf-8" ?>
 <rsp stat="ok">
@@ -14,11 +14,13 @@ describe("ReplaceService", function () {
 
       const auth = new NullAuth()
 
-      const service = new ReplaceService(transport, auth)
+      const service = new UploadService(transport, auth)
 
       const file = new Blob([])
 
-      const res = await service.replace("1234", file)
+      const res = await service.upload(file, {
+        title: "test",
+      })
 
       assert.strictEqual(res.id, "1234")
       assert.strictEqual(res.secret, "abcdef")
@@ -35,11 +37,11 @@ describe("ReplaceService", function () {
 
       const auth = new NullAuth()
 
-      const service = new ReplaceService(transport, auth)
+      const service = new UploadService(transport, auth)
 
-      const file = new Blob([])
+      const file = new Blob(["big ol jpeg"])
 
-      await assert.rejects(() => service.replace("1234", file), {
+      await assert.rejects(() => service.upload(file), {
         name: "Error",
         message: "Invalid API Key (Key has invalid format)",
       })

--- a/test/transport.fetch.ts
+++ b/test/transport.fetch.ts
@@ -1,4 +1,4 @@
-import { jest, afterEach, describe, it } from "@jest/globals"
+import { afterEach, describe, it, mock } from "node:test"
 import * as assert from "node:assert"
 import { FetchTransport, GET, POST } from "flickr-sdk"
 import { createServer } from "node:http"
@@ -9,9 +9,7 @@ describe("transport/fetch", function () {
     it("makes a GET fetch request", async function () {
       const transport = new FetchTransport()
 
-      const fn = jest
-        .spyOn(transport, "fetch")
-        .mockResolvedValue(new Response())
+      const fn = mock.method(transport, "fetch", async () => new Response())
 
       const params = new GET()
 
@@ -19,9 +17,9 @@ describe("transport/fetch", function () {
 
       await transport.get("http://example.com/foo", params)
 
-      assert.strictEqual(fn.mock.calls.length, 1)
+      assert.strictEqual(fn.mock.callCount(), 1)
 
-      const [url, init] = fn.mock.calls[0]
+      const [url, init] = fn.mock.calls[0].arguments
 
       assert.strictEqual(url, "http://example.com/foo?foo=bar")
       assert.strictEqual(init.method, "GET")
@@ -34,15 +32,13 @@ describe("transport/fetch", function () {
         },
       })
 
-      const fn = jest
-        .spyOn(transport, "fetch")
-        .mockResolvedValue(new Response())
+      const fn = mock.method(transport, "fetch", async () => new Response())
 
       await transport.get("http://example.com/foo")
 
-      assert.strictEqual(fn.mock.calls.length, 1)
+      assert.strictEqual(fn.mock.callCount(), 1)
 
-      const [url, init] = fn.mock.calls[0]
+      const [url, init] = fn.mock.calls[0].arguments
 
       // @ts-ignore
       assert.strictEqual(init.headers.cookie, "foo")
@@ -53,9 +49,7 @@ describe("transport/fetch", function () {
     it("makes a POST fetch request", async function () {
       const transport = new FetchTransport()
 
-      const fn = jest
-        .spyOn(transport, "fetch")
-        .mockResolvedValue(new Response())
+      const fn = mock.method(transport, "fetch", async () => new Response())
 
       const params = new POST()
 
@@ -63,9 +57,9 @@ describe("transport/fetch", function () {
 
       await transport.post("http://example.com/foo", params)
 
-      assert.strictEqual(fn.mock.calls.length, 1)
+      assert.strictEqual(fn.mock.callCount(), 1)
 
-      const [url, init] = fn.mock.calls[0]
+      const [url, init] = fn.mock.calls[0].arguments
 
       assert.strictEqual(url, "http://example.com/foo")
       assert.strictEqual(init.method, "POST")
@@ -80,15 +74,13 @@ describe("transport/fetch", function () {
         },
       })
 
-      const fn = jest
-        .spyOn(transport, "fetch")
-        .mockResolvedValue(new Response())
+      const fn = mock.method(transport, "fetch", async () => new Response())
 
       await transport.post("http://example.com/foo")
 
-      assert.strictEqual(fn.mock.calls.length, 1)
+      assert.strictEqual(fn.mock.callCount(), 1)
 
-      const [url, init] = fn.mock.calls[0]
+      const [_, init] = fn.mock.calls[0].arguments
 
       // @ts-ignore
       assert.strictEqual(init.headers.cookie, "foo")


### PR DESCRIPTION
Node ships with its own test runner now. This PR replaces `jest` with the now-standard-lib `node:test`