### PR TITLE
Introducing `flinch` for compile-time tests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -17,12 +17,14 @@ jobs:
         node-version: [20.x, 22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install dependencies
-        run: npm install
+      - run: npm install
+      - run: npm install --workspaces
       - run: npm run build
+      - run: npm run build --workspaces
       - run: npm test
+      - run: npm test --workspaces

--- a/README.md
+++ b/README.md
@@ -57,10 +57,24 @@ const { flickr } = createFlickr("<your API key>")
 ```
 #### OAuth 1.0
 
-OAuth lets users grant your application access and then you may act on their
-behalf. The OAuth flow is described [here][oauth].
+OAuth lets users grant your application access and then you may act on
+their behalf. The OAuth flow is described [here][oauth].
 
 ```js
+// create a flickr upload flickr without oauth credentials. Use this to
+// obtain a request token and authorize a user
+const { upload } = createFlickr({
+    consumerKey: "<your API key>",
+    consumerSecret: "<your API secret>",
+    oauthToken: "<the oauth token>",
+    oauthTokenSecret: "<the oauth token secret>",
+})
+```
+
+Then, once you have your OAuth token and secret:
+
+```js
+// create a flickr upload client with oauth credentials
 const { upload } = createFlickr({
     consumerKey: "<your API key>",
     consumerSecret: "<your API secret>",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "build-browser": "esbuild --bundle --outfile=dist/index.js --format=esm src/index.ts",
     "test": "node --import tsx --test test/*.ts"
   },
+  "workspaces": [
+    "packages/*"
+  ],
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/flickr/flickr-sdk.git"

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
   ],
   "scripts": {
     "tsc": "tsc",
-    "build": "npm run tsc && npm run build-cjs && npm run build-esm && npm run build-browser",
+    "build": "tsc && npm run build-cjs && npm run build-esm && npm run build-browser",
     "build-cjs": "esbuild --bundle --outfile=dist/index.cjs --platform=node --format=cjs src/index.ts",
     "build-esm": "esbuild --bundle --outfile=dist/index.mjs --platform=node --format=esm src/index.ts",
     "build-browser": "esbuild --bundle --outfile=dist/index.js --format=esm src/index.ts",
-    "test": "node --import tsx --test test/*.ts"
+    "test": "tsc -p tsconfig.test.json && node --import tsx --test test/*.ts"
   },
   "workspaces": [
     "packages/*"
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@types/node": "^20.8.4",
     "esbuild": "^0.19.4",
+    "@flickr/flinch": "file:./packages/flinch",
     "flickr-sdk": "file:.",
     "min-qs": "^1.4.0",
     "min-url": "^1.5.0",

--- a/packages/flinch/.gitignore
+++ b/packages/flinch/.gitignore
@@ -1,0 +1,3 @@
+dist/
+dist-esm/
+node_modules/

--- a/packages/flinch/LICENSE
+++ b/packages/flinch/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 SmugMug, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/flinch/README.md
+++ b/packages/flinch/README.md
@@ -1,0 +1,359 @@
+# flinch 🎯
+
+> almost certainly the best typescript type testing library in the world.
+
+flinch is a zero-dependency typescript library for compile-time type testing. it provides utilities to assert type relationships, detect type properties, and validate complex type scenarios at compile time.
+
+## table of contents 📚
+
+- [installation](#installation)
+- [quick start](#quick-start)
+- [flinch object methods](#flinch-object-methods)
+- [core type utilities](#core-type-utilities)
+- [type detection utilities](#type-detection-utilities)
+- [property analysis utilities](#property-analysis-utilities)
+- [function type utilities](#function-type-utilities)
+- [advanced type utilities](#advanced-type-utilities)
+- [tuple and array utilities](#tuple-and-array-utilities)
+- [literal type utilities](#literal-type-utilities)
+- [assertion functions](#assertion-functions)
+- [examples](#examples)
+- [license](#license)
+
+## installation 📦
+
+```bash
+npm install @flickr/flinch
+```
+
+## quick start 🚀
+
+```typescript
+import flinch, { expectTrue, expectFalse, Equal, Extends } from '@flickr/flinch'
+
+// these will compile successfully
+expectTrue<Equal<string, string>>()
+expectTrue<Extends<'hello', string>>()
+expectFalse<Equal<string, number>>()
+
+// these will cause typescript compilation errors
+expectTrue<Equal<string, number>>() // ❌ compilation error
+expectFalse<Equal<string, string>>() // ❌ compilation error
+
+// these will compile successfully
+flinch.equal<string, string>() // ✅ passes
+flinch.extends<'hello', string>() // ✅ passes
+
+// these will cause typescript compilation errors
+flinch.equal<string, number>() // ❌ compilation error
+```
+## flinch object methods
+
+the main interface of `flinch` exposes assertion methods for convenient testing (causes compilation errors on fail).
+
+```typescript
+import assert from '@flickr/flinch'
+
+assert.equal<string, string>()
+assert.notEqual<string, number>()
+assert.extends<'hello', string>()
+assert.notExtends<string, number>()
+assert.isAny<any>()
+assert.isNever<never>()
+assert.isUnknown<unknown>()
+assert.isFunction<()
+assert.isArray<string[]>()
+assert.isObject<{ a: string }>()
+assert.hasProperty<{ a: string }, 'a'>()
+assert.isOptional<{ a?: string }, 'a'>()
+assert.isReadonly<{ readonly a: string }, 'a'>()
+```
+
+## core type utilities 🔧
+
+### `Equal<X, Y>`
+tests if two types are exactly equal.
+
+```typescript
+type Test1 = Equal<string, string> // true
+type Test2 = Equal<string, number> // false
+```
+
+### `NotEqual<X, Y>`
+tests if two types are not equal.
+
+```typescript
+type Test1 = NotEqual<string, number> // true
+type Test2 = NotEqual<string, string> // false
+```
+
+### `Extends<X, Y>`
+tests if type X extends type Y.
+
+```typescript
+type Test1 = Extends<'hello', string> // true
+type Test2 = Extends<string, 'hello'> // false
+```
+
+### `NotExtends<X, Y>`
+tests if type X does not extend type Y.
+
+```typescript
+type Test1 = NotExtends<string, 'hello'> // true
+type Test2 = NotExtends<'hello', string> // false
+```
+
+## type detection utilities 🔍
+
+### `IsAny<T>`
+detects if a type is `any`.
+
+```typescript
+type Test1 = IsAny<any> // true
+type Test2 = IsAny<string> // false
+```
+
+### `IsNever<T>`
+detects if a type is `never`.
+
+```typescript
+type Test1 = IsNever<never> // true
+type Test2 = IsNever<string> // false
+```
+
+### `IsUnknown<T>`
+detects if a type is `unknown`.
+
+```typescript
+type Test1 = IsUnknown<unknown> // true
+type Test2 = IsUnknown<any> // false
+```
+
+### `IsFunction<T>`
+detects if a type is a function.
+
+```typescript
+type Test1 = IsFunction<() => void> // true
+type Test2 = IsFunction<string> // false
+```
+
+### `IsArray<T>`
+detects if a type is an array.
+
+```typescript
+type Test1 = IsArray<string[]> // true
+type Test2 = IsArray<string> // false
+```
+
+### `IsObject<T>`
+detects if a type is an object (excluding arrays and functions).
+
+```typescript
+type Test1 = IsObject<{ a: string }> // true
+type Test2 = IsObject<string[]> // false
+```
+
+## property analysis utilities 🔬
+
+### `HasProperty<T, K>`
+checks if a type has a specific property.
+
+```typescript
+interface User { name: string; age?: number }
+type Test1 = HasProperty<User, 'name'> // true
+type Test2 = HasProperty<User, 'email'> // false
+```
+
+### `IsOptional<T, K>`
+checks if a property is optional.
+
+```typescript
+interface User { name: string; age?: number }
+type Test1 = IsOptional<User, 'age'> // true
+type Test2 = IsOptional<User, 'name'> // false
+```
+
+### `IsReadonly<T, K>`
+checks if a property is readonly.
+
+```typescript
+interface User { name: string; readonly id: number }
+type Test1 = IsReadonly<User, 'id'> // true
+type Test2 = IsReadonly<User, 'name'> // false
+```
+
+## function type utilities ⚡
+
+### `GetParameters<T>`
+extracts parameter types from a function type.
+
+```typescript
+type Fn = (a: string, b: number) => void
+type Params = GetParameters<Fn> // [string, number]
+```
+
+### `GetReturnType<T>`
+extracts the return type from a function type.
+
+```typescript
+type Fn = (a: string) => number
+type Return = GetReturnType<Fn> // number
+```
+
+## advanced type utilities 🧠
+
+### `IsUnion<T>`
+detects if a type is a union type.
+
+```typescript
+type Test1 = IsUnion<string | number> // true
+type Test2 = IsUnion<string> // false
+```
+
+### `UnionToIntersection<U>`
+converts a union type to an intersection type.
+
+```typescript
+type Union = { a: string } | { b: number }
+type Intersection = UnionToIntersection<Union> // { a: string } & { b: number }
+```
+
+## tuple and array utilities 📋
+
+### `IsTuple<T>`
+detects if a type is a tuple (fixed-length array).
+
+```typescript
+type Test1 = IsTuple<[string, number]> // true
+type Test2 = IsTuple<string[]> // false
+```
+
+### `TupleLength<T>`
+gets the length of a tuple type.
+
+```typescript
+type Length = TupleLength<[string, number, boolean]> // 3
+```
+
+### `Head<T>`
+gets the first element type of a tuple.
+
+```typescript
+type First = Head<[string, number, boolean]> // string
+```
+
+### `Tail<T>`
+gets all elements except the first from a tuple.
+
+```typescript
+type Rest = Tail<[string, number, boolean]> // [number, boolean]
+```
+
+## literal type utilities 📝
+
+### `IsStringLiteral<T>`
+detects if a type is a string literal.
+
+```typescript
+type Test1 = IsStringLiteral<'hello'> // true
+type Test2 = IsStringLiteral<string> // false
+```
+
+### `IsNumberLiteral<T>`
+detects if a type is a number literal.
+
+```typescript
+type Test1 = IsNumberLiteral<42> // true
+type Test2 = IsNumberLiteral<number> // false
+```
+
+## assertion functions 🎪
+
+flinch provides both type-level utilities and runtime assertion functions:
+
+### `expectTrue<T>()`
+asserts that a type condition is true (causes compilation error if false).
+
+```typescript
+expectTrue<Equal<string, string>>() // ✅ compiles
+expectTrue<Equal<string, number>>() // ❌ compilation error
+```
+
+### `expectFalse<T>()`
+asserts that a type condition is false (causes compilation error if true).
+
+```typescript
+expectFalse<Equal<string, number>>() // ✅ compiles
+expectFalse<Equal<string, string>>() // ❌ compilation error
+```
+
+## examples 💡
+
+### testing api response types
+
+```typescript
+import { expectTrue, Equal, HasProperty, IsOptional } from '@flickr/flinch'
+
+interface ApiResponse<T> {
+  data: T
+  status: number
+  message?: string
+}
+
+interface User {
+  id: number
+  name: string
+  email?: string
+}
+
+type UserResponse = ApiResponse<User>
+
+// test the structure
+expectTrue<HasProperty<UserResponse, 'data'>>()
+expectTrue<HasProperty<UserResponse, 'status'>>()
+expectTrue<IsOptional<UserResponse, 'message'>>()
+
+// test nested properties
+expectTrue<HasProperty<UserResponse['data'], 'id'>>()
+expectTrue<HasProperty<UserResponse['data'], 'name'>>()
+expectTrue<IsOptional<UserResponse['data'], 'email'>>()
+```
+
+### testing utility types
+
+```typescript
+import { expectTrue, Equal, IsUnion, IsTuple } from '@flickr/flinch'
+
+// test conditional types
+type NonNullable<T> = T extends null | undefined ? never : T
+
+expectTrue<Equal<NonNullable<string>, string>>()
+expectTrue<Equal<NonNullable<string | null>, string>>()
+
+// test mapped types
+type Partial<T> = { [P in keyof T]?: T[P] }
+
+interface Original { a: string; b: number }
+type PartialOriginal = Partial<Original>
+
+expectTrue<IsOptional<PartialOriginal, 'a'>>()
+expectTrue<IsOptional<PartialOriginal, 'b'>>()
+```
+
+### testing failure cases
+
+use `@ts-expect-error` to tell typescript to expect a compilation error.
+if an error is not produced, typescript will complain.
+
+```typescript
+import assert from '@flickr/flinch'
+
+assert.extends<string, number>() // ❌ compilation error
+
+// @ts-expect-error - string is not number
+assert.extends<string, number>() // ✅ compiles
+```
+
+## license 📄
+
+MIT © SmugMug, Inc

--- a/packages/flinch/package.json
+++ b/packages/flinch/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@flickr/flinch",
+  "version": "1.0.0",
+  "description": "Almost certainly the best Typescript type testing library in the  world.",
+  "keywords": [
+    "typescript",
+    "types",
+    "test",
+    "testing",
+    "zero-dependency",
+    "flickr"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc && npm run build-esm",
+    "build-esm": "tsc --module esnext --outDir dist-esm && mv dist-esm/index.js dist/index.mjs",
+    "test": "tsc --noEmit src/test.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "github:flickr/flickr-sdk",
+    "directory": "packages/flinch"
+  },
+  "author": "Jeremy Ruppel",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 20"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}
+

--- a/packages/flinch/src/index.ts
+++ b/packages/flinch/src/index.ts
@@ -1,0 +1,252 @@
+// Core type testing utilities
+export type Expect<T extends true> = T
+export type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false
+export type NotEqual<X, Y> = Equal<X, Y> extends true ? false : true
+export type Extends<X, Y> = X extends Y ? true : false
+export type NotExtends<X, Y> = Extends<X, Y> extends true ? false : true
+
+// Utility types for common type checks
+export type IsAny<T> = 0 extends 1 & T ? true : false
+export type IsNever<T> = [T] extends [never] ? true : false
+export type IsUnknown<T> =
+  IsAny<T> extends true
+    ? false
+    : Equal<T, unknown> extends true
+      ? true
+      : false
+export type IsFunction<T> = T extends (...args: any[]) => any 
+  ? true 
+  : T extends Function 
+    ? true 
+    : false
+export type IsArray<T> = T extends readonly any[] ? true : false
+export type IsObject<T> = T extends object
+  ? T extends any[]
+    ? false
+    : T extends (...args: any[]) => any
+      ? false
+      : T extends Function
+        ? false
+        : true
+  : false
+
+// Advanced type checks
+export type HasProperty<T, K extends PropertyKey> = K extends keyof T
+  ? true
+  : false
+export type PropertyType<T, K extends keyof T> = T[K]
+export type IsOptional<T, K extends keyof T> =
+  {} extends Pick<T, K> ? true : false
+export type IsReadonly<T, K extends keyof T> =
+  Equal<{ -readonly [P in K]: T[P] }, { [P in K]: T[P] }> extends true
+    ? false
+    : true
+
+// Function type utilities
+export type GetParameters<T extends (...args: any) => any> = T extends (
+  ...args: infer P
+) => any
+  ? P
+  : never
+export type GetReturnType<T extends (...args: any) => any> = T extends (
+  ...args: any
+) => infer R
+  ? R
+  : any
+
+
+// Advanced type utilities for complex scenarios
+export type IsUnion<T> = [T] extends [UnionToIntersection<T>] ? false : true
+export type UnionToIntersection<U> = (
+  U extends any ? (k: U) => void : never
+) extends (k: infer I) => void
+  ? I
+  : never
+export type UnionToTuple<T> =
+  UnionToIntersection<T extends any ? () => T : never> extends () => infer W
+    ? [...UnionToTuple<Exclude<T, W>>, W]
+    : []
+
+// Conditional type utilities
+export type IsConditional<T> = T extends any ? true : false
+export type IsMappedType<T> = T extends { [K in keyof T]: T[K] } ? true : false
+
+
+
+// Tuple and array utilities
+export type IsTuple<T> = T extends readonly any[]
+  ? number extends T["length"]
+    ? false
+    : true
+  : false
+export type TupleLength<T extends readonly any[]> = T["length"]
+export type Head<T extends readonly any[]> = T extends readonly [
+  infer H,
+  ...any[],
+]
+  ? H
+  : never
+export type Tail<T extends readonly any[]> = T extends readonly [
+  any,
+  ...infer Rest,
+]
+  ? Rest
+  : never
+
+// String literal type utilities
+export type IsStringLiteral<T> = T extends string
+  ? string extends T
+    ? false
+    : true
+  : false
+export type IsNumberLiteral<T> = T extends number
+  ? number extends T
+    ? false
+    : true
+  : false
+
+/**
+ * Assertion functions for compile-time type checking
+ * These functions will cause TypeScript compilation
+ * errors if the type assertions fail
+ */
+const flinch = {
+  /**
+   * Assert that a type equals another type
+   */
+  equal<T, U>(this: Equal<T, U> extends true ? void : never): void {},
+
+  /**
+   * Assert that a type does not equal another type
+   */
+  notEqual<T, U>(this: NotEqual<T, U> extends true ? void : never): void {},
+
+  /**
+   * Assert that a type extends another type
+   */
+  extends<T, U>(this: Extends<T, U> extends true ? void : never): void {},
+
+  /**
+   * Assert that a type does not extend another type
+   */
+  notExtends<T, U>(this: NotExtends<T, U> extends true ? void : never): void {},
+
+  /**
+   * Assert that a type is any
+   */
+  isAny<T>(this: IsAny<T> extends true ? void : never): void {},
+
+  /**
+   * Assert that a type is never
+   */
+  isNever<T>(this: IsNever<T> extends true ? void : never): void {},
+
+  /**
+   * Assert that a type is unknown
+   */
+  isUnknown<T>(this: IsUnknown<T> extends true ? void : never): void {},
+
+  /**
+   * Assert that a type is a function
+   */
+  isFunction<T>(this: IsFunction<T> extends true ? void : never): void {},
+
+  /**
+   * Assert that a type is an array
+   */
+  isArray<T>(this: IsArray<T> extends true ? void : never): void {},
+
+  /**
+   * Assert that a type is an object (but not array)
+   */
+  isObject<T>(this: IsObject<T> extends true ? void : never): void {},
+
+  /**
+   * Assert that a type has a specific property
+   */
+  hasProperty<T, K extends PropertyKey>(this: HasProperty<T, K> extends true ? void : never): void {},
+
+  /**
+   * Assert that a property is optional
+   */
+  isOptional<T, K extends keyof T>(this: IsOptional<T, K> extends true ? void : never): void {},
+
+  /**
+   * Assert that a property is readonly
+   */
+  isReadonly<T, K extends keyof T>(this: IsReadonly<T, K> extends true ? void : never): void {},
+}
+
+/**
+ * Compile-time type assertion that will cause TypeScript
+ * errors if the condition is false
+ * Usage: expectTrue<Equal<string, string>>() // OK
+ *        expectTrue<Equal<string, number>>() // TypeScript error
+ */
+export function expectTrue<T extends true>(): void {
+  // Compile-time only assertion
+}
+
+/**
+ * Compile-time type assertion that will cause TypeScript
+ * errors if the condition is true
+ * Usage: expectFalse<Equal<string, number>>() // OK
+ *        expectFalse<Equal<string, string>>() // TypeScript error
+ */
+export function expectFalse<T extends false>(): void {
+  // Compile-time only assertion
+}
+
+/**
+ * Advanced type assertion utilities
+ */
+
+/**
+ * Assert that a type is a union type
+ */
+export function isUnion<T>(): IsUnion<T> extends true ? void : never {
+  return undefined as IsUnion<T> extends true ? void : never
+}
+
+/**
+ * Assert that a type is a tuple (fixed-length array)
+ */
+export function isTuple<T>(): IsTuple<T> extends true ? void : never {
+  return undefined as IsTuple<T> extends true ? void : never
+}
+
+/**
+ * Assert that a tuple has a specific length
+ */
+export function tupleLength<
+  T extends readonly any[],
+  N extends number,
+>(): TupleLength<T> extends N ? void : never {
+  return undefined as TupleLength<T> extends N ? void : never
+}
+
+/**
+ * Assert that a type is a string literal
+ */
+export function isStringLiteral<T>(): IsStringLiteral<T> extends true
+  ? void
+  : never {
+  return undefined as IsStringLiteral<T> extends true ? void : never
+}
+
+/**
+ * Assert that a type is a number literal
+ */
+export function isNumberLiteral<T>(): IsNumberLiteral<T> extends true
+  ? void
+  : never {
+  return undefined as IsNumberLiteral<T> extends true ? void : never
+}
+
+
+
+// Make flinch the default export
+export default flinch

--- a/packages/flinch/src/index.ts
+++ b/packages/flinch/src/index.ts
@@ -186,7 +186,7 @@ const flinch = {
  * Usage: expectTrue<Equal<string, string>>() // OK
  *        expectTrue<Equal<string, number>>() // TypeScript error
  */
-export function expectTrue<T extends true>(): void {
+export function expectTrue<T extends true>() {
   // Compile-time only assertion
 }
 
@@ -196,7 +196,7 @@ export function expectTrue<T extends true>(): void {
  * Usage: expectFalse<Equal<string, number>>() // OK
  *        expectFalse<Equal<string, string>>() // TypeScript error
  */
-export function expectFalse<T extends false>(): void {
+export function expectFalse<T extends false>() {
   // Compile-time only assertion
 }
 
@@ -207,14 +207,14 @@ export function expectFalse<T extends false>(): void {
 /**
  * Assert that a type is a union type
  */
-export function isUnion<T>(): IsUnion<T> extends true ? void : never {
+export function isUnion<T>() {
   return undefined as IsUnion<T> extends true ? void : never
 }
 
 /**
  * Assert that a type is a tuple (fixed-length array)
  */
-export function isTuple<T>(): IsTuple<T> extends true ? void : never {
+export function isTuple<T>() {
   return undefined as IsTuple<T> extends true ? void : never
 }
 
@@ -224,25 +224,21 @@ export function isTuple<T>(): IsTuple<T> extends true ? void : never {
 export function tupleLength<
   T extends readonly any[],
   N extends number,
->(): TupleLength<T> extends N ? void : never {
+>() {
   return undefined as TupleLength<T> extends N ? void : never
 }
 
 /**
  * Assert that a type is a string literal
  */
-export function isStringLiteral<T>(): IsStringLiteral<T> extends true
-  ? void
-  : never {
+export function isStringLiteral<T>() {
   return undefined as IsStringLiteral<T> extends true ? void : never
 }
 
 /**
  * Assert that a type is a number literal
  */
-export function isNumberLiteral<T>(): IsNumberLiteral<T> extends true
-  ? void
-  : never {
+export function isNumberLiteral<T>() {
   return undefined as IsNumberLiteral<T> extends true ? void : never
 }
 

--- a/packages/flinch/src/test.ts
+++ b/packages/flinch/src/test.ts
@@ -35,6 +35,7 @@ import flinch, {
   isUnion,
   isTuple,
   tupleLength,
+  isNumberLiteral,
 } from "./index"
 
 // Core Type Utilities Tests
@@ -439,6 +440,12 @@ flinch.isOptional<TestInterface, "existingProp">()
 // @ts-expect-error - existingProp is not readonly
 flinch.isReadonly<TestInterface, "existingProp">()
 
+// @ts-expect-error - false is not true
+expectTrue<false>()
+
+// @ts-expect-error - true is not false
+expectFalse<true>()
+
 // Flinch API Validation Tests
 // Test that Flinch can validate its own API
 
@@ -469,3 +476,4 @@ flinch.isFunction<typeof isUnion>()
 flinch.isFunction<typeof isTuple>()
 flinch.isFunction<typeof tupleLength>()
 flinch.isFunction<typeof isStringLiteral>()
+flinch.isFunction<typeof isNumberLiteral>()

--- a/packages/flinch/src/test.ts
+++ b/packages/flinch/src/test.ts
@@ -1,4 +1,11 @@
-import { describe, it } from "node:test"
+/**
+ * Flinch Self-Test Suite
+ *
+ * This file contains compile-time type assertions to validate that Flinch's
+ * type testing utilities work correctly. These tests verify the framework
+ * by testing its own type system.
+ */
+
 import flinch, {
   expectTrue,
   expectFalse,
@@ -25,478 +32,440 @@ import flinch, {
   type GetParameters,
   type GetReturnType,
   isStringLiteral,
+  isUnion,
   isTuple,
   tupleLength,
-  isUnion,
 } from "./index"
 
-describe("Flinch Self-Test Suite", () => {
-  describe("Core Type Utilities", () => {
-    it("should validate Equal type utility", () => {
-      // Test Equal with identical types
-      expectTrue<Equal<string, string>>()
-      expectTrue<Equal<number, number>>()
-      expectTrue<Equal<{ a: string }, { a: string }>>()
-
-      // Test Equal with different types
-      expectFalse<Equal<string, number>>()
-      expectFalse<Equal<{ a: string }, { a: number }>>()
-      expectFalse<Equal<string[], number[]>>()
-
-      // Test Equal with complex types
-      type ComplexType1 = { a: string; b: number; c?: boolean }
-      type ComplexType2 = { a: string; b: number; c?: boolean }
-      type ComplexType3 = { a: string; b: number; c: boolean }
-
-      expectTrue<Equal<ComplexType1, ComplexType2>>()
-      expectFalse<Equal<ComplexType1, ComplexType3>>()
-    })
-
-    it("should validate NotEqual type utility", () => {
-      expectTrue<NotEqual<string, number>>()
-      expectTrue<NotEqual<boolean, string>>()
-      expectFalse<NotEqual<string, string>>()
-      expectFalse<NotEqual<number, number>>()
-    })
-
-    it("should validate Extends type utility", () => {
-      expectTrue<Extends<string, string | number>>()
-      expectTrue<Extends<"hello", string>>()
-      expectTrue<Extends<never, string>>()
-      expectTrue<Extends<{ a: string; b: number }, { a: string }>>()
-
-      expectFalse<Extends<number, string>>()
-      expectFalse<Extends<string, "hello">>()
-      expectFalse<Extends<{ a: string }, { a: string; b: number }>>()
-    })
-
-    it("should validate NotExtends type utility", () => {
-      expectTrue<NotExtends<string | number, string>>()
-      expectTrue<NotExtends<string, "hello">>()
-      expectFalse<NotExtends<string, string | number>>()
-      expectFalse<NotExtends<"hello", string>>()
-    })
-  })
-
-  describe("Special Type Detection", () => {
-    it("should validate IsAny type utility", () => {
-      expectTrue<IsAny<any>>()
-      expectFalse<IsAny<string>>()
-      expectFalse<IsAny<unknown>>()
-      expectFalse<IsAny<never>>()
-      expectFalse<IsAny<{}>>()
-    })
-
-    it("should validate IsNever type utility", () => {
-      expectTrue<IsNever<never>>()
-      expectFalse<IsNever<string>>()
-      expectFalse<IsNever<any>>()
-      expectFalse<IsNever<unknown>>()
-      expectFalse<IsNever<void>>()
-
-      // Test with conditional types that resolve to never
-      type NeverType = string & number
-      expectTrue<IsNever<NeverType>>()
-    })
-
-    it("should validate IsUnknown type utility", () => {
-      expectTrue<IsUnknown<unknown>>()
-      expectFalse<IsUnknown<string>>()
-      expectFalse<IsUnknown<any>>()
-      expectFalse<IsUnknown<never>>()
-      expectFalse<IsUnknown<{}>>()
-    })
-  })
-
-  describe("Structural Type Detection", () => {
-    it("should validate IsFunction type utility", () => {
-      expectTrue<IsFunction<() => void>>()
-      expectTrue<IsFunction<(x: string) => number>>()
-      expectTrue<IsFunction<(...args: any[]) => any>>()
-      expectTrue<IsFunction<Function>>()
-
-      expectFalse<IsFunction<string>>()
-      expectFalse<IsFunction<number>>()
-      expectFalse<IsFunction<{}>>()
-      expectFalse<IsFunction<string[]>>()
-    })
-
-    it("should validate IsArray type utility", () => {
-      expectTrue<IsArray<string[]>>()
-      expectTrue<IsArray<number[]>>()
-      expectTrue<IsArray<readonly string[]>>()
-      expectTrue<IsArray<[string, number]>>()
-      expectTrue<IsArray<Array<any>>>()
-
-      expectFalse<IsArray<string>>()
-      expectFalse<IsArray<number>>()
-      expectFalse<IsArray<{}>>()
-      expectFalse<IsArray<{ length: number }>>()
-    })
-
-    it("should validate IsObject type utility", () => {
-      expectTrue<IsObject<{ a: string }>>()
-      expectTrue<IsObject<Record<string, any>>>()
-      expectTrue<IsObject<{}>>()
-      expectTrue<IsObject<object>>()
-
-      expectFalse<IsObject<string>>()
-      expectFalse<IsObject<number>>()
-      expectFalse<IsObject<string[]>>()
-      expectFalse<IsObject<Function>>()
-      expectFalse<IsObject<null>>()
-      expectFalse<IsObject<undefined>>()
-    })
-  })
-
-  describe("Property Analysis", () => {
-    interface TestInterface {
-      required: string
-      optional?: number
-      readonly readonlyProp: boolean
-      normalProp: string
-    }
-
-    it("should validate HasProperty type utility", () => {
-      expectTrue<HasProperty<TestInterface, "required">>()
-      expectTrue<HasProperty<TestInterface, "optional">>()
-      expectTrue<HasProperty<TestInterface, "readonlyProp">>()
-      expectTrue<HasProperty<TestInterface, "normalProp">>()
-
-      expectFalse<HasProperty<TestInterface, "nonexistent">>()
-      expectFalse<HasProperty<TestInterface, "missing">>()
-    })
-
-    it("should validate IsOptional type utility", () => {
-      expectTrue<IsOptional<TestInterface, "optional">>()
-      expectFalse<IsOptional<TestInterface, "required">>()
-      expectFalse<IsOptional<TestInterface, "readonlyProp">>()
-      expectFalse<IsOptional<TestInterface, "normalProp">>()
-    })
-
-    it("should validate IsReadonly type utility", () => {
-      expectTrue<IsReadonly<TestInterface, "readonlyProp">>()
-      expectFalse<IsReadonly<TestInterface, "required">>()
-      expectFalse<IsReadonly<TestInterface, "optional">>()
-      expectFalse<IsReadonly<TestInterface, "normalProp">>()
-    })
-  })
-
-  describe("Function Type Utilities", () => {
-    type TestFunction = (a: string, b: number, c?: boolean) => Promise<string>
-    type GenericFunction = <T>(x: T) => T
-    type VoidFunction = () => void
-
-    it("should validate GetParameters type utility", () => {
-      expectTrue<
-        Equal<GetParameters<TestFunction>, [string, number, boolean?]>
-      >()
-      expectTrue<Equal<GetParameters<VoidFunction>, []>>()
-
-      // Test with built-in function types
-      expectTrue<Equal<GetParameters<typeof parseInt>, [string, number?]>>()
-    })
-
-    it("should validate GetReturnType type utility", () => {
-      expectTrue<Equal<GetReturnType<TestFunction>, Promise<string>>>()
-      expectTrue<Equal<GetReturnType<VoidFunction>, void>>()
-      expectTrue<Equal<GetReturnType<() => number>, number>>()
-    })
-  })
-
-  describe("Advanced Type Utilities", () => {
-    it("should validate IsUnion type utility", () => {
-      expectTrue<IsUnion<string | number>>()
-      expectTrue<IsUnion<"a" | "b" | "c">>()
-      expectTrue<IsUnion<boolean>>() // boolean is true | false
-
-      expectFalse<IsUnion<string>>()
-      expectFalse<IsUnion<number>>()
-      expectFalse<IsUnion<{}>>()
-    })
-
-    it("should validate IsTuple type utility", () => {
-      expectTrue<IsTuple<[string, number]>>()
-      expectTrue<IsTuple<[string, number, boolean]>>()
-      expectTrue<IsTuple<[]>>()
-      expectTrue<IsTuple<readonly [string, number]>>()
-
-      expectFalse<IsTuple<string[]>>()
-      expectFalse<IsTuple<number[]>>()
-      expectFalse<IsTuple<Array<string>>>()
-    })
-
-    it("should validate TupleLength type utility", () => {
-      expectTrue<Equal<TupleLength<[string, number]>, 2>>()
-      expectTrue<Equal<TupleLength<[string, number, boolean]>, 3>>()
-      expectTrue<Equal<TupleLength<[]>, 0>>()
-      expectTrue<Equal<TupleLength<[string]>, 1>>()
-    })
-
-    it("should validate Head and Tail type utilities", () => {
-      type TestTuple = [string, number, boolean]
-
-      expectTrue<Equal<Head<TestTuple>, string>>()
-      expectTrue<Equal<Tail<TestTuple>, [number, boolean]>>()
-      expectTrue<Equal<Head<[number]>, number>>()
-      expectTrue<Equal<Tail<[number]>, []>>()
-    })
-
-    it("should validate literal type utilities", () => {
-      expectTrue<IsStringLiteral<"hello">>()
-      expectTrue<IsStringLiteral<"world">>()
-      expectFalse<IsStringLiteral<string>>()
-
-      expectTrue<IsNumberLiteral<42>>()
-      expectTrue<IsNumberLiteral<0>>()
-      expectTrue<IsNumberLiteral<-1>>()
-      expectFalse<IsNumberLiteral<number>>()
-    })
-  })
-
-  describe("Type Assertion Functions", () => {
-    it("should validate flinch functions work correctly", () => {
-      // These should compile without errors if the type assertions are correct
-      flinch.equal<string, string>()
-      flinch.notEqual<string, number>()
-      flinch.extends<string, string | number>()
-      flinch.notExtends<string | number, string>()
-
-      flinch.isFunction<() => void>()
-      flinch.isArray<string[]>()
-      flinch.isObject<{ a: string }>()
-
-      interface TestType {
-        prop: string
-        optional?: number
-        readonly readonlyProp: boolean
-      }
-
-      flinch.hasProperty<TestType, "prop">()
-      flinch.isOptional<TestType, "optional">()
-      flinch.isReadonly<TestType, "readonlyProp">()
-    })
-  })
-
-  describe("Complex Type Scenarios", () => {
-    it("should handle deeply nested generic types", () => {
-      interface ApiResponse<T> {
-        data: T
-        meta: {
-          status: number
-          message?: string
-        }
-      }
-
-      interface User {
-        id: number
-        profile: {
-          name: string
-          settings: {
-            theme: "light" | "dark"
-            notifications: boolean
-          }
-        }
-      }
-
-      type UserApiResponse = ApiResponse<User>
-
-      // Test nested property access
-      flinch.hasProperty<UserApiResponse, "data">()
-      flinch.hasProperty<UserApiResponse, "meta">()
-      flinch.hasProperty<UserApiResponse["data"], "id">()
-      flinch.hasProperty<UserApiResponse["data"], "profile">()
-      flinch.hasProperty<UserApiResponse["data"]["profile"], "name">()
-      flinch.hasProperty<UserApiResponse["data"]["profile"], "settings">()
-
-      // Test deep type equality
-      flinch.equal<
-        UserApiResponse["data"]["profile"]["settings"]["theme"],
-        "light" | "dark"
-      >()
-      flinch.equal<UserApiResponse["meta"]["status"], number>()
-
-      // Test optional properties at different levels
-      flinch.isOptional<UserApiResponse["meta"], "message">()
-    })
-
-    it("should handle conditional and mapped types", () => {
-      // Conditional type
-      type NonNullable<T> = T extends null | undefined ? never : T
-
-      flinch.equal<NonNullable<string>, string>()
-      flinch.equal<NonNullable<string | null>, string>()
-      flinch.isNever<NonNullable<null>>()
-
-      // Mapped type
-      type Partial<T> = {
-        [P in keyof T]?: T[P]
-      }
-
-      interface Original {
-        a: string
-        b: number
-      }
-
-      type PartialOriginal = Partial<Original>
-
-      flinch.isOptional<PartialOriginal, "a">()
-      flinch.isOptional<PartialOriginal, "b">()
-      flinch.equal<PartialOriginal["a"], string | undefined>()
-    })
-
-    it("should handle template literal types", () => {
-      type EventName<T extends string> = `on${Capitalize<T>}`
-      type ClickEvent = EventName<"click">
-      type HoverEvent = EventName<"hover">
-
-      flinch.equal<ClickEvent, "onClick">()
-      flinch.equal<HoverEvent, "onHover">()
-
-      // Test that these are string literals
-      isStringLiteral<ClickEvent>()
-      isStringLiteral<HoverEvent>()
-    })
-  })
-
-  describe("Edge Cases and Error Conditions", () => {
-    it("should handle empty types correctly", () => {
-      type EmptyObject = {}
-      type EmptyTuple = []
-      type EmptyUnion = never
-
-      flinch.isObject<EmptyObject>()
-      isTuple<EmptyTuple>()
-      tupleLength<EmptyTuple, 0>()
-      flinch.isNever<EmptyUnion>()
-    })
-
-    it("should handle recursive types", () => {
-      interface TreeNode {
-        value: string
-        children?: TreeNode[]
-      }
-
-      flinch.hasProperty<TreeNode, "value">()
-      flinch.hasProperty<TreeNode, "children">()
-      flinch.isOptional<TreeNode, "children">()
-
-      // Test that children is an array of TreeNode
-      type ChildrenType = NonNullable<TreeNode["children"]>
-      flinch.isArray<ChildrenType>()
-    })
-
-    it("should handle intersection types", () => {
-      interface A {
-        a: string
-      }
-
-      interface B {
-        b: number
-      }
-
-      type AB = A & B
-
-      flinch.hasProperty<AB, "a">()
-      flinch.hasProperty<AB, "b">()
-      flinch.equal<AB["a"], string>()
-      flinch.equal<AB["b"], number>()
-
-      // Test that AB extends both A and B
-      flinch.extends<AB, A>()
-      flinch.extends<AB, B>()
-    })
-  })
-})
-
-// Test that flinch methods properly fail with invalid types
-describe("Flinch Method Failure Tests", () => {
-  interface TestInterface {
-    existingProp: string
-    optionalProp?: number
-    readonly readonlyProp: boolean
+// Core Type Utilities Tests
+
+// Equal type utility validation
+// Test Equal with identical types
+expectTrue<Equal<string, string>>()
+expectTrue<Equal<number, number>>()
+expectTrue<Equal<{ a: string }, { a: string }>>()
+
+// Test Equal with different types
+expectFalse<Equal<string, number>>()
+expectFalse<Equal<{ a: string }, { a: number }>>()
+expectFalse<Equal<string[], number[]>>()
+
+// Test Equal with complex types
+type ComplexType1 = { a: string; b: number; c?: boolean }
+type ComplexType2 = { a: string; b: number; c?: boolean }
+type ComplexType3 = { a: string; b: number; c: boolean }
+
+expectTrue<Equal<ComplexType1, ComplexType2>>()
+expectFalse<Equal<ComplexType1, ComplexType3>>()
+
+// NotEqual type utility validation
+expectTrue<NotEqual<string, number>>()
+expectTrue<NotEqual<boolean, string>>()
+expectFalse<NotEqual<string, string>>()
+expectFalse<NotEqual<number, number>>()
+
+// Extends type utility validation
+expectTrue<Extends<string, string | number>>()
+expectTrue<Extends<"hello", string>>()
+expectTrue<Extends<never, string>>()
+expectTrue<Extends<{ a: string; b: number }, { a: string }>>()
+
+expectFalse<Extends<number, string>>()
+expectFalse<Extends<string, "hello">>()
+expectFalse<Extends<{ a: string }, { a: string; b: number }>>()
+
+// NotExtends type utility validation
+expectTrue<NotExtends<string | number, string>>()
+expectTrue<NotExtends<string, "hello">>()
+expectFalse<NotExtends<string, string | number>>()
+expectFalse<NotExtends<"hello", string>>()
+
+// Special Type Detection Tests
+
+// IsAny type utility validation
+expectTrue<IsAny<any>>()
+expectFalse<IsAny<string>>()
+expectFalse<IsAny<unknown>>()
+expectFalse<IsAny<never>>()
+expectFalse<IsAny<{}>>()
+
+// IsNever type utility validation
+expectTrue<IsNever<never>>()
+expectFalse<IsNever<string>>()
+expectFalse<IsNever<any>>()
+expectFalse<IsNever<unknown>>()
+expectFalse<IsNever<void>>()
+
+// Test with conditional types that resolve to never
+type NeverType = string & number
+expectTrue<IsNever<NeverType>>()
+
+// IsUnknown type utility validation
+expectTrue<IsUnknown<unknown>>()
+expectFalse<IsUnknown<string>>()
+expectFalse<IsUnknown<any>>()
+expectFalse<IsUnknown<never>>()
+expectFalse<IsUnknown<{}>>()
+
+// Structural Type Detection Tests
+
+// IsFunction type utility validation
+expectTrue<IsFunction<() => void>>()
+expectTrue<IsFunction<(x: string) => number>>()
+expectTrue<IsFunction<(...args: any[]) => any>>()
+expectTrue<IsFunction<Function>>()
+
+expectFalse<IsFunction<string>>()
+expectFalse<IsFunction<number>>()
+expectFalse<IsFunction<{}>>()
+expectFalse<IsFunction<string[]>>()
+
+// IsArray type utility validation
+expectTrue<IsArray<string[]>>()
+expectTrue<IsArray<number[]>>()
+expectTrue<IsArray<readonly string[]>>()
+expectTrue<IsArray<[string, number]>>()
+expectTrue<IsArray<Array<any>>>()
+
+expectFalse<IsArray<string>>()
+expectFalse<IsArray<number>>()
+expectFalse<IsArray<{}>>()
+expectFalse<IsArray<{ length: number }>>()
+
+// IsObject type utility validation
+expectTrue<IsObject<{ a: string }>>()
+expectTrue<IsObject<Record<string, any>>>()
+expectTrue<IsObject<{}>>()
+expectTrue<IsObject<object>>()
+
+expectFalse<IsObject<string>>()
+expectFalse<IsObject<number>>()
+expectFalse<IsObject<string[]>>()
+expectFalse<IsObject<Function>>()
+expectFalse<IsObject<null>>()
+expectFalse<IsObject<undefined>>()
+
+// Property Analysis Tests
+
+interface TestInterface {
+  required: string
+  optional?: number
+  readonly readonlyProp: boolean
+  normalProp: string
+}
+
+// HasProperty type utility validation
+expectTrue<HasProperty<TestInterface, "required">>()
+expectTrue<HasProperty<TestInterface, "optional">>()
+expectTrue<HasProperty<TestInterface, "readonlyProp">>()
+expectTrue<HasProperty<TestInterface, "normalProp">>()
+
+expectFalse<HasProperty<TestInterface, "nonexistent">>()
+expectFalse<HasProperty<TestInterface, "missing">>()
+
+// IsOptional type utility validation
+expectTrue<IsOptional<TestInterface, "optional">>()
+expectFalse<IsOptional<TestInterface, "required">>()
+expectFalse<IsOptional<TestInterface, "readonlyProp">>()
+expectFalse<IsOptional<TestInterface, "normalProp">>()
+
+// IsReadonly type utility validation
+expectTrue<IsReadonly<TestInterface, "readonlyProp">>()
+expectFalse<IsReadonly<TestInterface, "required">>()
+expectFalse<IsReadonly<TestInterface, "optional">>()
+expectFalse<IsReadonly<TestInterface, "normalProp">>()
+
+// Function Type Utilities Tests
+
+type TestFunction = (a: string, b: number, c?: boolean) => Promise<string>
+type VoidFunction = () => void
+
+// GetParameters type utility validation
+expectTrue<Equal<GetParameters<TestFunction>, [string, number, boolean?]>>()
+expectTrue<Equal<GetParameters<VoidFunction>, []>>()
+
+// Test with built-in function types
+expectTrue<Equal<GetParameters<typeof parseInt>, [string, number?]>>()
+
+// GetReturnType type utility validation
+expectTrue<Equal<GetReturnType<TestFunction>, Promise<string>>>()
+expectTrue<Equal<GetReturnType<VoidFunction>, void>>()
+expectTrue<Equal<GetReturnType<() => number>, number>>()
+
+// Advanced Type Utilities Tests
+
+// IsUnion type utility validation
+expectTrue<IsUnion<string | number>>()
+expectTrue<IsUnion<"a" | "b" | "c">>()
+expectTrue<IsUnion<boolean>>() // boolean is true | false
+
+expectFalse<IsUnion<string>>()
+expectFalse<IsUnion<number>>()
+expectFalse<IsUnion<{}>>()
+
+// IsTuple type utility validation
+expectTrue<IsTuple<[string, number]>>()
+expectTrue<IsTuple<[string, number, boolean]>>()
+expectTrue<IsTuple<[]>>()
+expectTrue<IsTuple<readonly [string, number]>>()
+
+expectFalse<IsTuple<string[]>>()
+expectFalse<IsTuple<number[]>>()
+expectFalse<IsTuple<Array<string>>>()
+
+// TupleLength type utility validation
+expectTrue<Equal<TupleLength<[string, number]>, 2>>()
+expectTrue<Equal<TupleLength<[string, number, boolean]>, 3>>()
+expectTrue<Equal<TupleLength<[]>, 0>>()
+expectTrue<Equal<TupleLength<[string]>, 1>>()
+
+// Head and Tail type utilities validation
+type TestTuple = [string, number, boolean]
+
+expectTrue<Equal<Head<TestTuple>, string>>()
+expectTrue<Equal<Tail<TestTuple>, [number, boolean]>>()
+expectTrue<Equal<Head<[number]>, number>>()
+expectTrue<Equal<Tail<[number]>, []>>()
+
+// Literal type utilities validation
+expectTrue<IsStringLiteral<"hello">>()
+expectTrue<IsStringLiteral<"world">>()
+expectFalse<IsStringLiteral<string>>()
+
+expectTrue<IsNumberLiteral<42>>()
+expectTrue<IsNumberLiteral<0>>()
+expectTrue<IsNumberLiteral<-1>>()
+expectFalse<IsNumberLiteral<number>>()
+
+// Type Assertion Functions Tests
+
+// Flinch functions validation - these should compile without errors if the type assertions are correct
+flinch.equal<string, string>()
+flinch.notEqual<string, number>()
+flinch.extends<string, string | number>()
+flinch.notExtends<string | number, string>()
+
+flinch.isFunction<() => void>()
+flinch.isArray<string[]>()
+flinch.isObject<{ a: string }>()
+
+interface TestType {
+  prop: string
+  optional?: number
+  readonly readonlyProp: boolean
+}
+
+flinch.hasProperty<TestType, "prop">()
+flinch.isOptional<TestType, "optional">()
+flinch.isReadonly<TestType, "readonlyProp">()
+
+// Complex Type Scenarios Tests
+
+// Deeply nested generic types
+interface ApiResponse<T> {
+  data: T
+  meta: {
+    status: number
+    message?: string
   }
+}
 
-  it("should cause compilation errors for invalid type assertions", () => {
-    // These should all cause TypeScript compilation errors:
+interface User {
+  id: number
+  profile: {
+    name: string
+    settings: {
+      theme: "light" | "dark"
+      notifications: boolean
+    }
+  }
+}
 
-    // @ts-expect-error - string does not equal number
-    flinch.equal<string, number>()
+type UserApiResponse = ApiResponse<User>
 
-    // @ts-expect-error - string equals string
-    flinch.notEqual<string, string>()
+// Test nested property access
+flinch.hasProperty<UserApiResponse, "data">()
+flinch.hasProperty<UserApiResponse, "meta">()
+flinch.hasProperty<UserApiResponse["data"], "id">()
+flinch.hasProperty<UserApiResponse["data"], "profile">()
+flinch.hasProperty<UserApiResponse["data"]["profile"], "name">()
+flinch.hasProperty<UserApiResponse["data"]["profile"], "settings">()
 
-    // @ts-expect-error - string does not extend number
-    flinch.extends<string, number>()
+// Test deep type equality
+flinch.equal<
+  UserApiResponse["data"]["profile"]["settings"]["theme"],
+  "light" | "dark"
+>()
+flinch.equal<UserApiResponse["meta"]["status"], number>()
 
-    // @ts-expect-error - string extends string | number
-    flinch.notExtends<string, string | number>()
+// Test optional properties at different levels
+flinch.isOptional<UserApiResponse["meta"], "message">()
 
-    // @ts-expect-error - string is not any
-    flinch.isAny<string>()
+// Conditional and mapped types
+// Conditional type
+type NonNullable<T> = T extends null | undefined ? never : T
 
-    // @ts-expect-error - string is not never
-    flinch.isNever<string>()
+flinch.equal<NonNullable<string>, string>()
+flinch.equal<NonNullable<string | null>, string>()
+flinch.isNever<NonNullable<null>>()
 
-    // @ts-expect-error - string is not unknown
-    flinch.isUnknown<string>()
+// Mapped type
+type Partial<T> = {
+  [P in keyof T]?: T[P]
+}
 
-    // @ts-expect-error - string is not a function
-    flinch.isFunction<string>()
+interface Original {
+  a: string
+  b: number
+}
 
-    // @ts-expect-error - string is not an array
-    flinch.isArray<string>()
+type PartialOriginal = Partial<Original>
 
-    // @ts-expect-error - string is not an object
-    flinch.isObject<string>()
+flinch.isOptional<PartialOriginal, "a">()
+flinch.isOptional<PartialOriginal, "b">()
+flinch.equal<PartialOriginal["a"], string | undefined>()
 
-    // @ts-expect-error - arrays are not objects in our definition
-    flinch.isObject<string[]>()
+// Template literal types
+type EventName<T extends string> = `on${Capitalize<T>}`
+type ClickEvent = EventName<"click">
+type HoverEvent = EventName<"hover">
 
-    // @ts-expect-error - functions are not objects in our definition
-    flinch.isObject<() => void>()
+flinch.equal<ClickEvent, "onClick">()
+flinch.equal<HoverEvent, "onHover">()
 
-    // @ts-expect-error - property doesn't exist
-    flinch.hasProperty<TestInterface, "nonExistentProp">()
+// Test that these are string literals
+isStringLiteral<ClickEvent>()
+isStringLiteral<HoverEvent>()
 
-    // @ts-expect-error - existingProp is required, not optional
-    flinch.isOptional<TestInterface, "existingProp">()
+// Edge Cases and Error Conditions Tests
 
-    // @ts-expect-error - existingProp is not readonly
-    flinch.isReadonly<TestInterface, "existingProp">()
-  })
-})
+// Empty types handling
+type EmptyObject = {}
+type EmptyTuple = []
+type EmptyUnion = never
 
+flinch.isObject<EmptyObject>()
+isTuple<EmptyTuple>()
+tupleLength<EmptyTuple, 0>()
+flinch.isNever<EmptyUnion>()
+
+// Recursive types handling
+interface TreeNode {
+  value: string
+  children?: TreeNode[]
+}
+
+flinch.hasProperty<TreeNode, "value">()
+flinch.hasProperty<TreeNode, "children">()
+flinch.isOptional<TreeNode, "children">()
+
+// Test that children is an array of TreeNode
+type ChildrenType = NonNullable<TreeNode["children"]>
+flinch.isArray<ChildrenType>()
+
+// Intersection types handling
+interface A {
+  a: string
+}
+
+interface B {
+  b: number
+}
+
+type AB = A & B
+
+flinch.hasProperty<AB, "a">()
+flinch.hasProperty<AB, "b">()
+flinch.equal<AB["a"], string>()
+flinch.equal<AB["b"], number>()
+
+// Test that AB extends both A and B
+flinch.extends<AB, A>()
+flinch.extends<AB, B>()
+
+// Flinch Method Failure Tests
+// These tests verify that flinch methods properly fail with invalid types
+
+interface TestInterface {
+  existingProp: string
+  optionalProp?: number
+  readonly readonlyProp: boolean
+}
+
+// These should all cause TypeScript compilation errors:
+
+// @ts-expect-error - string does not equal number
+flinch.equal<string, number>()
+
+// @ts-expect-error - string equals string
+flinch.notEqual<string, string>()
+
+// @ts-expect-error - string does not extend number
+flinch.extends<string, number>()
+
+// @ts-expect-error - string extends string | number
+flinch.notExtends<string, string | number>()
+
+// @ts-expect-error - string is not any
+flinch.isAny<string>()
+
+// @ts-expect-error - string is not never
+flinch.isNever<string>()
+
+// @ts-expect-error - string is not unknown
+flinch.isUnknown<string>()
+
+// @ts-expect-error - string is not a function
+flinch.isFunction<string>()
+
+// @ts-expect-error - string is not an array
+flinch.isArray<string>()
+
+// @ts-expect-error - string is not an object
+flinch.isObject<string>()
+
+// @ts-expect-error - arrays are not objects in our definition
+flinch.isObject<string[]>()
+
+// @ts-expect-error - functions are not objects in our definition
+flinch.isObject<() => void>()
+
+// @ts-expect-error - property doesn't exist
+flinch.hasProperty<TestInterface, "nonExistentProp">()
+
+// @ts-expect-error - existingProp is required, not optional
+flinch.isOptional<TestInterface, "existingProp">()
+
+// @ts-expect-error - existingProp is not readonly
+flinch.isReadonly<TestInterface, "existingProp">()
+
+// Flinch API Validation Tests
 // Test that Flinch can validate its own API
-describe("Flinch API Validation", () => {
-  it("should validate flinch API structure", () => {
-    flinch.isObject<typeof flinch>()
-    flinch.hasProperty<typeof flinch, "equal">()
-    flinch.hasProperty<typeof flinch, "notEqual">()
-    flinch.hasProperty<typeof flinch, "extends">()
-    flinch.hasProperty<typeof flinch, "notExtends">()
-    flinch.hasProperty<typeof flinch, "isAny">()
-    flinch.hasProperty<typeof flinch, "isNever">()
-    flinch.hasProperty<typeof flinch, "isUnknown">()
-    flinch.hasProperty<typeof flinch, "isFunction">()
-    flinch.hasProperty<typeof flinch, "isArray">()
-    flinch.hasProperty<typeof flinch, "isObject">()
-    flinch.hasProperty<typeof flinch, "hasProperty">()
-    flinch.hasProperty<typeof flinch, "isOptional">()
-    flinch.hasProperty<typeof flinch, "isReadonly">()
 
-    // All methods should be functions
-    flinch.isFunction<typeof flinch.equal>()
-    flinch.isFunction<typeof flinch.notEqual>()
-    flinch.isFunction<typeof flinch.extends>()
-    flinch.isFunction<typeof flinch.notExtends>()
-  })
+// Validate flinch API structure
+flinch.isObject<typeof flinch>()
+flinch.hasProperty<typeof flinch, "equal">()
+flinch.hasProperty<typeof flinch, "notEqual">()
+flinch.hasProperty<typeof flinch, "extends">()
+flinch.hasProperty<typeof flinch, "notExtends">()
+flinch.hasProperty<typeof flinch, "isAny">()
+flinch.hasProperty<typeof flinch, "isNever">()
+flinch.hasProperty<typeof flinch, "isUnknown">()
+flinch.hasProperty<typeof flinch, "isFunction">()
+flinch.hasProperty<typeof flinch, "isArray">()
+flinch.hasProperty<typeof flinch, "isObject">()
+flinch.hasProperty<typeof flinch, "hasProperty">()
+flinch.hasProperty<typeof flinch, "isOptional">()
+flinch.hasProperty<typeof flinch, "isReadonly">()
 
-  it("should validate advanced type assertions", () => {
-    // All methods should be functions
-    flinch.isFunction<typeof isUnion>()
-    flinch.isFunction<typeof isTuple>()
-    flinch.isFunction<typeof tupleLength>()
-    flinch.isFunction<typeof isStringLiteral>()
-  })
-})
+// All methods should be functions
+flinch.isFunction<typeof flinch.equal>()
+flinch.isFunction<typeof flinch.notEqual>()
+flinch.isFunction<typeof flinch.extends>()
+flinch.isFunction<typeof flinch.notExtends>()
+
+// Validate advanced type assertions
+flinch.isFunction<typeof isUnion>()
+flinch.isFunction<typeof isTuple>()
+flinch.isFunction<typeof tupleLength>()
+flinch.isFunction<typeof isStringLiteral>()

--- a/packages/flinch/src/test.ts
+++ b/packages/flinch/src/test.ts
@@ -1,0 +1,502 @@
+import { describe, it } from "node:test"
+import flinch, {
+  expectTrue,
+  expectFalse,
+  type Equal,
+  type NotEqual,
+  type Extends,
+  type NotExtends,
+  type IsAny,
+  type IsNever,
+  type IsUnknown,
+  type IsFunction,
+  type IsArray,
+  type IsObject,
+  type HasProperty,
+  type IsOptional,
+  type IsReadonly,
+  type IsUnion,
+  type IsTuple,
+  type TupleLength,
+  type Head,
+  type Tail,
+  type IsStringLiteral,
+  type IsNumberLiteral,
+  type GetParameters,
+  type GetReturnType,
+  isStringLiteral,
+  isTuple,
+  tupleLength,
+  isUnion,
+} from "./index"
+
+describe("Flinch Self-Test Suite", () => {
+  describe("Core Type Utilities", () => {
+    it("should validate Equal type utility", () => {
+      // Test Equal with identical types
+      expectTrue<Equal<string, string>>()
+      expectTrue<Equal<number, number>>()
+      expectTrue<Equal<{ a: string }, { a: string }>>()
+
+      // Test Equal with different types
+      expectFalse<Equal<string, number>>()
+      expectFalse<Equal<{ a: string }, { a: number }>>()
+      expectFalse<Equal<string[], number[]>>()
+
+      // Test Equal with complex types
+      type ComplexType1 = { a: string; b: number; c?: boolean }
+      type ComplexType2 = { a: string; b: number; c?: boolean }
+      type ComplexType3 = { a: string; b: number; c: boolean }
+
+      expectTrue<Equal<ComplexType1, ComplexType2>>()
+      expectFalse<Equal<ComplexType1, ComplexType3>>()
+    })
+
+    it("should validate NotEqual type utility", () => {
+      expectTrue<NotEqual<string, number>>()
+      expectTrue<NotEqual<boolean, string>>()
+      expectFalse<NotEqual<string, string>>()
+      expectFalse<NotEqual<number, number>>()
+    })
+
+    it("should validate Extends type utility", () => {
+      expectTrue<Extends<string, string | number>>()
+      expectTrue<Extends<"hello", string>>()
+      expectTrue<Extends<never, string>>()
+      expectTrue<Extends<{ a: string; b: number }, { a: string }>>()
+
+      expectFalse<Extends<number, string>>()
+      expectFalse<Extends<string, "hello">>()
+      expectFalse<Extends<{ a: string }, { a: string; b: number }>>()
+    })
+
+    it("should validate NotExtends type utility", () => {
+      expectTrue<NotExtends<string | number, string>>()
+      expectTrue<NotExtends<string, "hello">>()
+      expectFalse<NotExtends<string, string | number>>()
+      expectFalse<NotExtends<"hello", string>>()
+    })
+  })
+
+  describe("Special Type Detection", () => {
+    it("should validate IsAny type utility", () => {
+      expectTrue<IsAny<any>>()
+      expectFalse<IsAny<string>>()
+      expectFalse<IsAny<unknown>>()
+      expectFalse<IsAny<never>>()
+      expectFalse<IsAny<{}>>()
+    })
+
+    it("should validate IsNever type utility", () => {
+      expectTrue<IsNever<never>>()
+      expectFalse<IsNever<string>>()
+      expectFalse<IsNever<any>>()
+      expectFalse<IsNever<unknown>>()
+      expectFalse<IsNever<void>>()
+
+      // Test with conditional types that resolve to never
+      type NeverType = string & number
+      expectTrue<IsNever<NeverType>>()
+    })
+
+    it("should validate IsUnknown type utility", () => {
+      expectTrue<IsUnknown<unknown>>()
+      expectFalse<IsUnknown<string>>()
+      expectFalse<IsUnknown<any>>()
+      expectFalse<IsUnknown<never>>()
+      expectFalse<IsUnknown<{}>>()
+    })
+  })
+
+  describe("Structural Type Detection", () => {
+    it("should validate IsFunction type utility", () => {
+      expectTrue<IsFunction<() => void>>()
+      expectTrue<IsFunction<(x: string) => number>>()
+      expectTrue<IsFunction<(...args: any[]) => any>>()
+      expectTrue<IsFunction<Function>>()
+
+      expectFalse<IsFunction<string>>()
+      expectFalse<IsFunction<number>>()
+      expectFalse<IsFunction<{}>>()
+      expectFalse<IsFunction<string[]>>()
+    })
+
+    it("should validate IsArray type utility", () => {
+      expectTrue<IsArray<string[]>>()
+      expectTrue<IsArray<number[]>>()
+      expectTrue<IsArray<readonly string[]>>()
+      expectTrue<IsArray<[string, number]>>()
+      expectTrue<IsArray<Array<any>>>()
+
+      expectFalse<IsArray<string>>()
+      expectFalse<IsArray<number>>()
+      expectFalse<IsArray<{}>>()
+      expectFalse<IsArray<{ length: number }>>()
+    })
+
+    it("should validate IsObject type utility", () => {
+      expectTrue<IsObject<{ a: string }>>()
+      expectTrue<IsObject<Record<string, any>>>()
+      expectTrue<IsObject<{}>>()
+      expectTrue<IsObject<object>>()
+
+      expectFalse<IsObject<string>>()
+      expectFalse<IsObject<number>>()
+      expectFalse<IsObject<string[]>>()
+      expectFalse<IsObject<Function>>()
+      expectFalse<IsObject<null>>()
+      expectFalse<IsObject<undefined>>()
+    })
+  })
+
+  describe("Property Analysis", () => {
+    interface TestInterface {
+      required: string
+      optional?: number
+      readonly readonlyProp: boolean
+      normalProp: string
+    }
+
+    it("should validate HasProperty type utility", () => {
+      expectTrue<HasProperty<TestInterface, "required">>()
+      expectTrue<HasProperty<TestInterface, "optional">>()
+      expectTrue<HasProperty<TestInterface, "readonlyProp">>()
+      expectTrue<HasProperty<TestInterface, "normalProp">>()
+
+      expectFalse<HasProperty<TestInterface, "nonexistent">>()
+      expectFalse<HasProperty<TestInterface, "missing">>()
+    })
+
+    it("should validate IsOptional type utility", () => {
+      expectTrue<IsOptional<TestInterface, "optional">>()
+      expectFalse<IsOptional<TestInterface, "required">>()
+      expectFalse<IsOptional<TestInterface, "readonlyProp">>()
+      expectFalse<IsOptional<TestInterface, "normalProp">>()
+    })
+
+    it("should validate IsReadonly type utility", () => {
+      expectTrue<IsReadonly<TestInterface, "readonlyProp">>()
+      expectFalse<IsReadonly<TestInterface, "required">>()
+      expectFalse<IsReadonly<TestInterface, "optional">>()
+      expectFalse<IsReadonly<TestInterface, "normalProp">>()
+    })
+  })
+
+  describe("Function Type Utilities", () => {
+    type TestFunction = (a: string, b: number, c?: boolean) => Promise<string>
+    type GenericFunction = <T>(x: T) => T
+    type VoidFunction = () => void
+
+    it("should validate GetParameters type utility", () => {
+      expectTrue<
+        Equal<GetParameters<TestFunction>, [string, number, boolean?]>
+      >()
+      expectTrue<Equal<GetParameters<VoidFunction>, []>>()
+
+      // Test with built-in function types
+      expectTrue<Equal<GetParameters<typeof parseInt>, [string, number?]>>()
+    })
+
+    it("should validate GetReturnType type utility", () => {
+      expectTrue<Equal<GetReturnType<TestFunction>, Promise<string>>>()
+      expectTrue<Equal<GetReturnType<VoidFunction>, void>>()
+      expectTrue<Equal<GetReturnType<() => number>, number>>()
+    })
+  })
+
+  describe("Advanced Type Utilities", () => {
+    it("should validate IsUnion type utility", () => {
+      expectTrue<IsUnion<string | number>>()
+      expectTrue<IsUnion<"a" | "b" | "c">>()
+      expectTrue<IsUnion<boolean>>() // boolean is true | false
+
+      expectFalse<IsUnion<string>>()
+      expectFalse<IsUnion<number>>()
+      expectFalse<IsUnion<{}>>()
+    })
+
+    it("should validate IsTuple type utility", () => {
+      expectTrue<IsTuple<[string, number]>>()
+      expectTrue<IsTuple<[string, number, boolean]>>()
+      expectTrue<IsTuple<[]>>()
+      expectTrue<IsTuple<readonly [string, number]>>()
+
+      expectFalse<IsTuple<string[]>>()
+      expectFalse<IsTuple<number[]>>()
+      expectFalse<IsTuple<Array<string>>>()
+    })
+
+    it("should validate TupleLength type utility", () => {
+      expectTrue<Equal<TupleLength<[string, number]>, 2>>()
+      expectTrue<Equal<TupleLength<[string, number, boolean]>, 3>>()
+      expectTrue<Equal<TupleLength<[]>, 0>>()
+      expectTrue<Equal<TupleLength<[string]>, 1>>()
+    })
+
+    it("should validate Head and Tail type utilities", () => {
+      type TestTuple = [string, number, boolean]
+
+      expectTrue<Equal<Head<TestTuple>, string>>()
+      expectTrue<Equal<Tail<TestTuple>, [number, boolean]>>()
+      expectTrue<Equal<Head<[number]>, number>>()
+      expectTrue<Equal<Tail<[number]>, []>>()
+    })
+
+    it("should validate literal type utilities", () => {
+      expectTrue<IsStringLiteral<"hello">>()
+      expectTrue<IsStringLiteral<"world">>()
+      expectFalse<IsStringLiteral<string>>()
+
+      expectTrue<IsNumberLiteral<42>>()
+      expectTrue<IsNumberLiteral<0>>()
+      expectTrue<IsNumberLiteral<-1>>()
+      expectFalse<IsNumberLiteral<number>>()
+    })
+  })
+
+  describe("Type Assertion Functions", () => {
+    it("should validate flinch functions work correctly", () => {
+      // These should compile without errors if the type assertions are correct
+      flinch.equal<string, string>()
+      flinch.notEqual<string, number>()
+      flinch.extends<string, string | number>()
+      flinch.notExtends<string | number, string>()
+
+      flinch.isFunction<() => void>()
+      flinch.isArray<string[]>()
+      flinch.isObject<{ a: string }>()
+
+      interface TestType {
+        prop: string
+        optional?: number
+        readonly readonlyProp: boolean
+      }
+
+      flinch.hasProperty<TestType, "prop">()
+      flinch.isOptional<TestType, "optional">()
+      flinch.isReadonly<TestType, "readonlyProp">()
+    })
+  })
+
+  describe("Complex Type Scenarios", () => {
+    it("should handle deeply nested generic types", () => {
+      interface ApiResponse<T> {
+        data: T
+        meta: {
+          status: number
+          message?: string
+        }
+      }
+
+      interface User {
+        id: number
+        profile: {
+          name: string
+          settings: {
+            theme: "light" | "dark"
+            notifications: boolean
+          }
+        }
+      }
+
+      type UserApiResponse = ApiResponse<User>
+
+      // Test nested property access
+      flinch.hasProperty<UserApiResponse, "data">()
+      flinch.hasProperty<UserApiResponse, "meta">()
+      flinch.hasProperty<UserApiResponse["data"], "id">()
+      flinch.hasProperty<UserApiResponse["data"], "profile">()
+      flinch.hasProperty<UserApiResponse["data"]["profile"], "name">()
+      flinch.hasProperty<UserApiResponse["data"]["profile"], "settings">()
+
+      // Test deep type equality
+      flinch.equal<
+        UserApiResponse["data"]["profile"]["settings"]["theme"],
+        "light" | "dark"
+      >()
+      flinch.equal<UserApiResponse["meta"]["status"], number>()
+
+      // Test optional properties at different levels
+      flinch.isOptional<UserApiResponse["meta"], "message">()
+    })
+
+    it("should handle conditional and mapped types", () => {
+      // Conditional type
+      type NonNullable<T> = T extends null | undefined ? never : T
+
+      flinch.equal<NonNullable<string>, string>()
+      flinch.equal<NonNullable<string | null>, string>()
+      flinch.isNever<NonNullable<null>>()
+
+      // Mapped type
+      type Partial<T> = {
+        [P in keyof T]?: T[P]
+      }
+
+      interface Original {
+        a: string
+        b: number
+      }
+
+      type PartialOriginal = Partial<Original>
+
+      flinch.isOptional<PartialOriginal, "a">()
+      flinch.isOptional<PartialOriginal, "b">()
+      flinch.equal<PartialOriginal["a"], string | undefined>()
+    })
+
+    it("should handle template literal types", () => {
+      type EventName<T extends string> = `on${Capitalize<T>}`
+      type ClickEvent = EventName<"click">
+      type HoverEvent = EventName<"hover">
+
+      flinch.equal<ClickEvent, "onClick">()
+      flinch.equal<HoverEvent, "onHover">()
+
+      // Test that these are string literals
+      isStringLiteral<ClickEvent>()
+      isStringLiteral<HoverEvent>()
+    })
+  })
+
+  describe("Edge Cases and Error Conditions", () => {
+    it("should handle empty types correctly", () => {
+      type EmptyObject = {}
+      type EmptyTuple = []
+      type EmptyUnion = never
+
+      flinch.isObject<EmptyObject>()
+      isTuple<EmptyTuple>()
+      tupleLength<EmptyTuple, 0>()
+      flinch.isNever<EmptyUnion>()
+    })
+
+    it("should handle recursive types", () => {
+      interface TreeNode {
+        value: string
+        children?: TreeNode[]
+      }
+
+      flinch.hasProperty<TreeNode, "value">()
+      flinch.hasProperty<TreeNode, "children">()
+      flinch.isOptional<TreeNode, "children">()
+
+      // Test that children is an array of TreeNode
+      type ChildrenType = NonNullable<TreeNode["children"]>
+      flinch.isArray<ChildrenType>()
+    })
+
+    it("should handle intersection types", () => {
+      interface A {
+        a: string
+      }
+
+      interface B {
+        b: number
+      }
+
+      type AB = A & B
+
+      flinch.hasProperty<AB, "a">()
+      flinch.hasProperty<AB, "b">()
+      flinch.equal<AB["a"], string>()
+      flinch.equal<AB["b"], number>()
+
+      // Test that AB extends both A and B
+      flinch.extends<AB, A>()
+      flinch.extends<AB, B>()
+    })
+  })
+})
+
+// Test that flinch methods properly fail with invalid types
+describe("Flinch Method Failure Tests", () => {
+  interface TestInterface {
+    existingProp: string
+    optionalProp?: number
+    readonly readonlyProp: boolean
+  }
+
+  it("should cause compilation errors for invalid type assertions", () => {
+    // These should all cause TypeScript compilation errors:
+
+    // @ts-expect-error - string does not equal number
+    flinch.equal<string, number>()
+
+    // @ts-expect-error - string equals string
+    flinch.notEqual<string, string>()
+
+    // @ts-expect-error - string does not extend number
+    flinch.extends<string, number>()
+
+    // @ts-expect-error - string extends string | number
+    flinch.notExtends<string, string | number>()
+
+    // @ts-expect-error - string is not any
+    flinch.isAny<string>()
+
+    // @ts-expect-error - string is not never
+    flinch.isNever<string>()
+
+    // @ts-expect-error - string is not unknown
+    flinch.isUnknown<string>()
+
+    // @ts-expect-error - string is not a function
+    flinch.isFunction<string>()
+
+    // @ts-expect-error - string is not an array
+    flinch.isArray<string>()
+
+    // @ts-expect-error - string is not an object
+    flinch.isObject<string>()
+
+    // @ts-expect-error - arrays are not objects in our definition
+    flinch.isObject<string[]>()
+
+    // @ts-expect-error - functions are not objects in our definition
+    flinch.isObject<() => void>()
+
+    // @ts-expect-error - property doesn't exist
+    flinch.hasProperty<TestInterface, "nonExistentProp">()
+
+    // @ts-expect-error - existingProp is required, not optional
+    flinch.isOptional<TestInterface, "existingProp">()
+
+    // @ts-expect-error - existingProp is not readonly
+    flinch.isReadonly<TestInterface, "existingProp">()
+  })
+})
+
+// Test that Flinch can validate its own API
+describe("Flinch API Validation", () => {
+  it("should validate flinch API structure", () => {
+    flinch.isObject<typeof flinch>()
+    flinch.hasProperty<typeof flinch, "equal">()
+    flinch.hasProperty<typeof flinch, "notEqual">()
+    flinch.hasProperty<typeof flinch, "extends">()
+    flinch.hasProperty<typeof flinch, "notExtends">()
+    flinch.hasProperty<typeof flinch, "isAny">()
+    flinch.hasProperty<typeof flinch, "isNever">()
+    flinch.hasProperty<typeof flinch, "isUnknown">()
+    flinch.hasProperty<typeof flinch, "isFunction">()
+    flinch.hasProperty<typeof flinch, "isArray">()
+    flinch.hasProperty<typeof flinch, "isObject">()
+    flinch.hasProperty<typeof flinch, "hasProperty">()
+    flinch.hasProperty<typeof flinch, "isOptional">()
+    flinch.hasProperty<typeof flinch, "isReadonly">()
+
+    // All methods should be functions
+    flinch.isFunction<typeof flinch.equal>()
+    flinch.isFunction<typeof flinch.notEqual>()
+    flinch.isFunction<typeof flinch.extends>()
+    flinch.isFunction<typeof flinch.notExtends>()
+  })
+
+  it("should validate advanced type assertions", () => {
+    // All methods should be functions
+    flinch.isFunction<typeof isUnion>()
+    flinch.isFunction<typeof isTuple>()
+    flinch.isFunction<typeof tupleLength>()
+    flinch.isFunction<typeof isStringLiteral>()
+  })
+})

--- a/packages/flinch/tsconfig.json
+++ b/packages/flinch/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": [
+    "src/index.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "dist-esm"
+  ]
+}

--- a/src/auth/api_key.ts
+++ b/src/auth/api_key.ts
@@ -1,10 +1,10 @@
 import type { Auth } from "../types"
 import type { Params } from "../params"
 
+export type APIKeyAuthConfig = string | (() => string) | (() => Promise<string>)
+
 export class APIKeyAuth implements Auth {
-  constructor(
-    private apiKey: string | (() => string) | (() => Promise<string>),
-  ) {
+  constructor(private apiKey: APIKeyAuthConfig) {
     if (typeof apiKey === "undefined") {
       throw new Error("apiKey must be provided")
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import type { Auth, Transport } from "./types"
-import { APIKeyAuth } from "./auth/api_key"
+import type { Auth, Transport, Parser } from "./types"
+import { APIKeyAuth, APIKeyAuthConfig } from "./auth/api_key"
 import { OAuthAuth, OAuthConfig } from "./auth/oauth"
 import { FlickrService, Flickr } from "./services/rest"
 import { OAuthService } from "./services/oauth"
@@ -93,22 +93,26 @@ export function createFlickr(
   }
 }
 
-export type { Flickr, Auth, Transport }
+export type { Flickr, Auth, Transport, Parser }
 export {
   FlickrService,
   UploadService,
   ReplaceService,
   FetchTransport,
   APIKeyAuth,
+  APIKeyAuthConfig,
   OAuthAuth,
   OAuthService,
+  OAuthConfig,
 }
 export * from "./services/rest/api"
 // exports for tests
+
 export { OAuth } from "./oauth"
 export { Params, GET, POST } from "./params"
 export { XMLParser } from "./parser/xml"
 export { JSONParser } from "./parser/json"
 export { FormParser } from "./parser/form"
 export { NullAuth } from "./auth/null"
+export { API } from "./services/rest"
 export { MockTransport } from "./transport/mock"

--- a/src/services/rest/index.ts
+++ b/src/services/rest/index.ts
@@ -3,6 +3,8 @@ import { POST_REGEXP, API } from "./api"
 import { GET, POST } from "../../params"
 import { JSONParser } from "../../parser/json"
 
+export type { API }
+
 export interface Flickr {
   <T extends keyof API>(method: T, params: API[T][0]): Promise<API[T][1]>
 }

--- a/src/transport/mock.ts
+++ b/src/transport/mock.ts
@@ -1,9 +1,9 @@
 import { Transport } from "../types"
 
 export class MockTransport implements Transport {
-  private responses: string[] = []
+  private responses: any[] = []
 
-  constructor(response?: string) {
+  constructor(response?: any) {
     if (response) {
       this.addMock(response)
     }
@@ -13,7 +13,7 @@ export class MockTransport implements Transport {
     this.responses = []
   }
 
-  addMock(response: string): void {
+  addMock(response: any): void {
     const stringResponse =
       typeof response === "string" ? response : JSON.stringify(response)
     this.responses.push(stringResponse)

--- a/test/oauth.ts
+++ b/test/oauth.ts
@@ -3,7 +3,7 @@ import * as assert from "node:assert"
 import { OAuth } from "flickr-sdk"
 
 describe("OAuth", function () {
-  let oauth
+  let oauth: OAuth
 
   beforeEach(function () {
     oauth = new OAuth("consumer key", "consumer secret")

--- a/test/transport.fetch.ts
+++ b/test/transport.fetch.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, it, mock } from "node:test"
 import * as assert from "node:assert"
 import { FetchTransport, GET, POST } from "flickr-sdk"
-import { createServer } from "node:http"
+import { createServer, type Server, type IncomingMessage } from "node:http"
 import { once } from "node:events"
 
 describe("transport/fetch", function () {
@@ -21,7 +21,9 @@ describe("transport/fetch", function () {
 
       const [url, init] = fn.mock.calls[0].arguments
 
+      assert.ok(url)
       assert.strictEqual(url, "http://example.com/foo?foo=bar")
+      assert.ok(init)
       assert.strictEqual(init.method, "GET")
     })
 
@@ -40,6 +42,8 @@ describe("transport/fetch", function () {
 
       const [url, init] = fn.mock.calls[0].arguments
 
+      assert.ok(url)
+      assert.ok(init)
       // @ts-ignore
       assert.strictEqual(init.headers.cookie, "foo")
     })
@@ -61,7 +65,9 @@ describe("transport/fetch", function () {
 
       const [url, init] = fn.mock.calls[0].arguments
 
+      assert.ok(url)
       assert.strictEqual(url, "http://example.com/foo")
+      assert.ok(init)
       assert.strictEqual(init.method, "POST")
       assert.ok(init.body instanceof FormData)
       assert.strictEqual(init.body.get("foo"), "bar")
@@ -94,8 +100,7 @@ describe("transport/fetch", function () {
         res.end(JSON.stringify(body))
       })
 
-    /** @type {import("http").Server | null} */
-    let server
+    let server: Server | null
 
     afterEach(function () {
       server?.close()
@@ -106,8 +111,7 @@ describe("transport/fetch", function () {
       server = createTestServer(200)
       server.listen(3000)
 
-      /** @type {Promise<[import('http').IncomingMessage]>} */
-      const promise = once(server, "request")
+      const promise: Promise<any> = once(server, "request")
 
       const transport = new FetchTransport()
 

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,62 +1,73 @@
 import { describe, it } from "node:test"
-import flinch from "flinch"
-import type { Auth, Transport, Parser } from "../src/types"
-import type { GET, POST, Params } from "../src/params"
+import assert, { Equal, Extends, IsTuple, expectTrue } from "@flickr/flinch"
+import type {
+  API,
+  Auth,
+  Transport,
+  Parser,
+  GET,
+  POST,
+  Params,
+  OAuthConfig,
+  FlickrPeopleGetInfoParams,
+  APIKeyAuthConfig,
+  FlickrTestEchoParams,
+} from "flickr-sdk"
 
 describe("flickr-sdk type tests", () => {
   describe("Auth Interface", () => {
     it("should have correct method signature", () => {
       // Verify Auth interface structure
-      flinch.hasProperty<Auth, "sign">()
-      flinch.isFunction<Auth["sign"]>()
+      assert.hasProperty<Auth, "sign">()
+      assert.isFunction<Auth["sign"]>()
 
       // Test the sign method parameters and return type
       type SignMethod = Auth["sign"]
-      flinch.isFunction<SignMethod>()
+      assert.isFunction<SignMethod>()
 
       // The sign method should return a Promise<void>
       type SignReturnType = ReturnType<SignMethod>
-      flinch.extends<SignReturnType, Promise<void>>()
+      assert.extends<SignReturnType, Promise<void>>()
     })
   })
 
   describe("Transport Interface", () => {
     it("should have get and post methods", () => {
-      flinch.hasProperty<Transport, "get">()
-      flinch.hasProperty<Transport, "post">()
+      assert.hasProperty<Transport, "get">()
+      assert.hasProperty<Transport, "post">()
 
-      flinch.isFunction<Transport["get"]>()
-      flinch.isFunction<Transport["post"]>()
+      assert.isFunction<Transport["get"]>()
+      assert.isFunction<Transport["post"]>()
     })
 
     it("should have correct method signatures", () => {
       // Test get method
       type GetMethod = Transport["get"]
       type GetReturnType = ReturnType<GetMethod>
-      flinch.extends<GetReturnType, Promise<Response>>()
+      assert.extends<GetReturnType, Promise<Response>>()
 
       // Test post method
       type PostMethod = Transport["post"]
       type PostReturnType = ReturnType<PostMethod>
-      flinch.extends<PostReturnType, Promise<Response>>()
+      assert.extends<PostReturnType, Promise<Response>>()
     })
   })
 
   describe("Parser Interface", () => {
     it("should have parse method with correct signature", () => {
-      flinch.hasProperty<Parser, "parse">()
-      flinch.isFunction<Parser["parse"]>()
+      assert.hasProperty<Parser, "parse">()
+      assert.isFunction<Parser["parse"]>()
 
       type ParseMethod = Parser["parse"]
       type ParseReturnType = ReturnType<ParseMethod>
-      flinch.extends<ParseReturnType, Promise<any>>()
+      assert.extends<ParseReturnType, Promise<any>>()
     })
   })
 
   describe("Parameter Types", () => {
     it("should verify GET and POST extend Params", () => {
-      flinch.extends<GET, Params>()
-      flinch.extends<POST, Params>()
+      assert.extends<GET, Params>()
+      assert.extends<POST, Params>()
     })
   })
 
@@ -67,9 +78,64 @@ describe("flickr-sdk type tests", () => {
       interface MockTransport extends Transport {}
       interface MockParser extends Parser {}
 
-      flinch.extends<MockAuth, Auth>()
-      flinch.extends<MockTransport, Transport>()
-      flinch.extends<MockParser, Parser>()
+      assert.extends<MockAuth, Auth>()
+      assert.extends<MockTransport, Transport>()
+      assert.extends<MockParser, Parser>()
+    })
+  })
+
+  describe("API", function () {
+    it("has flickr.people.getInfo", () => {
+      assert.hasProperty<API, "flickr.people.getInfo">()
+
+      expectTrue<IsTuple<API["flickr.people.getInfo"]>>()
+      expectTrue<
+        Equal<API["flickr.people.getInfo"][0], FlickrPeopleGetInfoParams>
+      >()
+    })
+
+    it("has flickr.test.echo", () => {
+      assert.hasProperty<API, "flickr.test.echo">()
+
+      expectTrue<IsTuple<API["flickr.test.echo"]>>()
+      expectTrue<Equal<API["flickr.test.echo"][0], FlickrTestEchoParams>>()
+    })
+  })
+
+  describe("APIKeyConfig", () => {
+    it("accepts a string", () => {
+      expectTrue<Extends<string, APIKeyAuthConfig>>()
+      expectTrue<Extends<() => string, APIKeyAuthConfig>>()
+      expectTrue<Extends<() => Promise<string>, APIKeyAuthConfig>>()
+    })
+  })
+
+  describe("OAuthConfig", () => {
+    it("accepts consumer key/secret and oauth token/secret", () => {
+      expectTrue<
+        Extends<
+          {
+            consumerKey: string
+            consumerSecret: string
+            oauthToken: string
+            oauthTokenSecret: string
+          },
+          OAuthConfig
+        >
+      >()
+    })
+    it("can specify false for oauth token/secret", () => {
+      expectTrue<
+        Extends<
+          {
+            consumerKey: string
+            consumerSecret: string
+            oauthToken: false
+            oauthTokenSecret: false
+          },
+          OAuthConfig
+        >
+      >()
     })
   })
 })

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,4 +1,10 @@
-import { describe, it } from "node:test"
+/**
+ * Flickr SDK Type Tests
+ *
+ * This file contains compile-time type assertions to verify the correctness
+ * of the Flickr SDK type definitions using the Flinch type testing framework.
+ */
+
 import assert, { Equal, Extends, IsTuple, expectTrue } from "@flickr/flinch"
 import type {
   API,
@@ -14,128 +20,104 @@ import type {
   FlickrTestEchoParams,
 } from "flickr-sdk"
 
-describe("flickr-sdk type tests", () => {
-  describe("Auth Interface", () => {
-    it("should have correct method signature", () => {
-      // Verify Auth interface structure
-      assert.hasProperty<Auth, "sign">()
-      assert.isFunction<Auth["sign"]>()
+// Auth Interface Tests
+// Verify Auth interface structure
+assert.hasProperty<Auth, "sign">()
+assert.isFunction<Auth["sign"]>()
 
-      // Test the sign method parameters and return type
-      type SignMethod = Auth["sign"]
-      assert.isFunction<SignMethod>()
+// Test the sign method parameters and return type
+type SignMethod = Auth["sign"]
+assert.isFunction<SignMethod>()
 
-      // The sign method should return a Promise<void>
-      type SignReturnType = ReturnType<SignMethod>
-      assert.extends<SignReturnType, Promise<void>>()
-    })
-  })
+// The sign method should return a Promise<void>
+type SignReturnType = ReturnType<SignMethod>
+assert.extends<SignReturnType, Promise<void>>()
 
-  describe("Transport Interface", () => {
-    it("should have get and post methods", () => {
-      assert.hasProperty<Transport, "get">()
-      assert.hasProperty<Transport, "post">()
+// Transport Interface Tests
+// Should have get and post methods
+assert.hasProperty<Transport, "get">()
+assert.hasProperty<Transport, "post">()
 
-      assert.isFunction<Transport["get"]>()
-      assert.isFunction<Transport["post"]>()
-    })
+assert.isFunction<Transport["get"]>()
+assert.isFunction<Transport["post"]>()
 
-    it("should have correct method signatures", () => {
-      // Test get method
-      type GetMethod = Transport["get"]
-      type GetReturnType = ReturnType<GetMethod>
-      assert.extends<GetReturnType, Promise<Response>>()
+// Should have correct method signatures
+// Test get method
+type GetMethod = Transport["get"]
+type GetReturnType = ReturnType<GetMethod>
+assert.extends<GetReturnType, Promise<Response>>()
 
-      // Test post method
-      type PostMethod = Transport["post"]
-      type PostReturnType = ReturnType<PostMethod>
-      assert.extends<PostReturnType, Promise<Response>>()
-    })
-  })
+// Test post method
+type PostMethod = Transport["post"]
+type PostReturnType = ReturnType<PostMethod>
+assert.extends<PostReturnType, Promise<Response>>()
 
-  describe("Parser Interface", () => {
-    it("should have parse method with correct signature", () => {
-      assert.hasProperty<Parser, "parse">()
-      assert.isFunction<Parser["parse"]>()
+// Parser Interface Tests
+// Should have parse method with correct signature
+assert.hasProperty<Parser, "parse">()
+assert.isFunction<Parser["parse"]>()
 
-      type ParseMethod = Parser["parse"]
-      type ParseReturnType = ReturnType<ParseMethod>
-      assert.extends<ParseReturnType, Promise<any>>()
-    })
-  })
+type ParseMethod = Parser["parse"]
+type ParseReturnType = ReturnType<ParseMethod>
+assert.extends<ParseReturnType, Promise<any>>()
 
-  describe("Parameter Types", () => {
-    it("should verify GET and POST extend Params", () => {
-      assert.extends<GET, Params>()
-      assert.extends<POST, Params>()
-    })
-  })
+// Parameter Types Tests
+// Should verify GET and POST extend Params
+assert.extends<GET, Params>()
+assert.extends<POST, Params>()
 
-  describe("Integration Type Tests", () => {
-    it("should verify interface compatibility", () => {
-      // Test that implementations would satisfy the interfaces
-      interface MockAuth extends Auth {}
-      interface MockTransport extends Transport {}
-      interface MockParser extends Parser {}
+// Integration Type Tests
+// Test that implementations would satisfy the interfaces
+interface MockAuth extends Auth {}
+interface MockTransport extends Transport {}
+interface MockParser extends Parser {}
 
-      assert.extends<MockAuth, Auth>()
-      assert.extends<MockTransport, Transport>()
-      assert.extends<MockParser, Parser>()
-    })
-  })
+assert.extends<MockAuth, Auth>()
+assert.extends<MockTransport, Transport>()
+assert.extends<MockParser, Parser>()
 
-  describe("API", function () {
-    it("has flickr.people.getInfo", () => {
-      assert.hasProperty<API, "flickr.people.getInfo">()
+// API Tests
+// Should have flickr.people.getInfo
+assert.hasProperty<API, "flickr.people.getInfo">()
 
-      expectTrue<IsTuple<API["flickr.people.getInfo"]>>()
-      expectTrue<
-        Equal<API["flickr.people.getInfo"][0], FlickrPeopleGetInfoParams>
-      >()
-    })
+expectTrue<IsTuple<API["flickr.people.getInfo"]>>()
+expectTrue<Equal<API["flickr.people.getInfo"][0], FlickrPeopleGetInfoParams>>()
 
-    it("has flickr.test.echo", () => {
-      assert.hasProperty<API, "flickr.test.echo">()
+// Should have flickr.test.echo
+assert.hasProperty<API, "flickr.test.echo">()
 
-      expectTrue<IsTuple<API["flickr.test.echo"]>>()
-      expectTrue<Equal<API["flickr.test.echo"][0], FlickrTestEchoParams>>()
-    })
-  })
+expectTrue<IsTuple<API["flickr.test.echo"]>>()
+expectTrue<Equal<API["flickr.test.echo"][0], FlickrTestEchoParams>>()
 
-  describe("APIKeyConfig", () => {
-    it("accepts a string", () => {
-      expectTrue<Extends<string, APIKeyAuthConfig>>()
-      expectTrue<Extends<() => string, APIKeyAuthConfig>>()
-      expectTrue<Extends<() => Promise<string>, APIKeyAuthConfig>>()
-    })
-  })
+// APIKeyConfig Tests
+// Should accept a string
+expectTrue<Extends<string, APIKeyAuthConfig>>()
+expectTrue<Extends<() => string, APIKeyAuthConfig>>()
+expectTrue<Extends<() => Promise<string>, APIKeyAuthConfig>>()
 
-  describe("OAuthConfig", () => {
-    it("accepts consumer key/secret and oauth token/secret", () => {
-      expectTrue<
-        Extends<
-          {
-            consumerKey: string
-            consumerSecret: string
-            oauthToken: string
-            oauthTokenSecret: string
-          },
-          OAuthConfig
-        >
-      >()
-    })
-    it("can specify false for oauth token/secret", () => {
-      expectTrue<
-        Extends<
-          {
-            consumerKey: string
-            consumerSecret: string
-            oauthToken: false
-            oauthTokenSecret: false
-          },
-          OAuthConfig
-        >
-      >()
-    })
-  })
-})
+// OAuthConfig Tests
+// Should accept consumer key/secret and oauth token/secret
+expectTrue<
+  Extends<
+    {
+      consumerKey: string
+      consumerSecret: string
+      oauthToken: string
+      oauthTokenSecret: string
+    },
+    OAuthConfig
+  >
+>()
+
+// Should allow false for oauth token/secret
+expectTrue<
+  Extends<
+    {
+      consumerKey: string
+      consumerSecret: string
+      oauthToken: false
+      oauthTokenSecret: false
+    },
+    OAuthConfig
+  >
+>()

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,75 @@
+import { describe, it } from "node:test"
+import flinch from "flinch"
+import type { Auth, Transport, Parser } from "../src/types"
+import type { GET, POST, Params } from "../src/params"
+
+describe("flickr-sdk type tests", () => {
+  describe("Auth Interface", () => {
+    it("should have correct method signature", () => {
+      // Verify Auth interface structure
+      flinch.hasProperty<Auth, "sign">()
+      flinch.isFunction<Auth["sign"]>()
+
+      // Test the sign method parameters and return type
+      type SignMethod = Auth["sign"]
+      flinch.isFunction<SignMethod>()
+
+      // The sign method should return a Promise<void>
+      type SignReturnType = ReturnType<SignMethod>
+      flinch.extends<SignReturnType, Promise<void>>()
+    })
+  })
+
+  describe("Transport Interface", () => {
+    it("should have get and post methods", () => {
+      flinch.hasProperty<Transport, "get">()
+      flinch.hasProperty<Transport, "post">()
+
+      flinch.isFunction<Transport["get"]>()
+      flinch.isFunction<Transport["post"]>()
+    })
+
+    it("should have correct method signatures", () => {
+      // Test get method
+      type GetMethod = Transport["get"]
+      type GetReturnType = ReturnType<GetMethod>
+      flinch.extends<GetReturnType, Promise<Response>>()
+
+      // Test post method
+      type PostMethod = Transport["post"]
+      type PostReturnType = ReturnType<PostMethod>
+      flinch.extends<PostReturnType, Promise<Response>>()
+    })
+  })
+
+  describe("Parser Interface", () => {
+    it("should have parse method with correct signature", () => {
+      flinch.hasProperty<Parser, "parse">()
+      flinch.isFunction<Parser["parse"]>()
+
+      type ParseMethod = Parser["parse"]
+      type ParseReturnType = ReturnType<ParseMethod>
+      flinch.extends<ParseReturnType, Promise<any>>()
+    })
+  })
+
+  describe("Parameter Types", () => {
+    it("should verify GET and POST extend Params", () => {
+      flinch.extends<GET, Params>()
+      flinch.extends<POST, Params>()
+    })
+  })
+
+  describe("Integration Type Tests", () => {
+    it("should verify interface compatibility", () => {
+      // Test that implementations would satisfy the interfaces
+      interface MockAuth extends Auth {}
+      interface MockTransport extends Transport {}
+      interface MockParser extends Parser {}
+
+      flinch.extends<MockAuth, Auth>()
+      flinch.extends<MockTransport, Transport>()
+      flinch.extends<MockParser, Parser>()
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,11 @@
       "node"
     ]
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
Unsatisfied with other solutions out there, I worked with AI to come up with a super comprehensive testing library for typescript. Check the [README](packages/flinch/README.md) for usage details.

This also introduces type tests for many of the interfaces exported from `flickr-sdk`.

This also also makes it so `MockTransport` can accept `any` type of thing to return, not just `string`.